### PR TITLE
hex grid

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -8,6 +8,16 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    env:
+      PUBLISH_PACKAGES: |
+        projective-grid
+        calib-targets-core
+        calib-targets-chessboard
+        calib-targets-aruco
+        calib-targets-charuco
+        calib-targets-marker
+        calib-targets-print
+        calib-targets
 
     # Needed for OIDC -> crates.io token exchange
     permissions:
@@ -33,20 +43,44 @@ jobs:
           TAG="${GITHUB_REF_NAME}"
           VER="${TAG#v}"
           META="$(cargo metadata --format-version 1 --no-deps)"
+          mapfile -t publish_packages <<<"$PUBLISH_PACKAGES"
 
           echo "tag version:   $VER"
 
-          for pkg in \
-            calib-targets-core \
-            calib-targets-chessboard \
-            calib-targets-aruco \
-            calib-targets-charuco \
-            calib-targets-marker \
-            calib-targets-print \
-            calib-targets; do
+          for pkg in "${publish_packages[@]}"; do
             PKG_VER="$(jq -r --arg name "$pkg" '.packages[] | select(.name==$name) | .version' <<<"$META")"
             echo "$pkg version:  $PKG_VER"
             test "$PKG_VER" = "$VER"
+          done
+
+      - name: Validate publish order
+        shell: bash
+        run: |
+          META="$(cargo metadata --format-version 1 --no-deps)"
+          mapfile -t publish_packages <<<"$PUBLISH_PACKAGES"
+          declare -A publish_index=()
+
+          for idx in "${!publish_packages[@]}"; do
+            pkg="${publish_packages[$idx]}"
+            publish_index["$pkg"]="$idx"
+          done
+
+          for pkg in "${publish_packages[@]}"; do
+            while IFS= read -r dep; do
+              [[ -z "$dep" ]] && continue
+              if [[ -v "publish_index[$dep]" ]] && (( publish_index["$dep"] >= publish_index["$pkg"] )); then
+                echo "Publish order is invalid: $pkg depends on $dep, but $dep is not published earlier."
+                exit 1
+              fi
+            done < <(
+              jq -r --arg name "$pkg" '
+                .packages[]
+                | select(.name == $name)
+                | .dependencies[]
+                | select(.path != null and .kind != "dev")
+                | .name
+              ' <<<"$META"
+            )
           done
 
       - name: Test workspace
@@ -61,6 +95,8 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ steps.cratesio.outputs.token }}
         shell: bash
         run: |
+          mapfile -t publish_packages <<<"$PUBLISH_PACKAGES"
+
           publish_with_retry() {
             local pkg="$1"
             for attempt in 1 2 3 4 5 6 7 8 9 10; do
@@ -75,10 +111,6 @@ jobs:
             return 1
           }
 
-          publish_with_retry calib-targets-core
-          publish_with_retry calib-targets-chessboard
-          publish_with_retry calib-targets-aruco
-          publish_with_retry calib-targets-charuco
-          publish_with_retry calib-targets-marker
-          publish_with_retry calib-targets-print
-          publish_with_retry calib-targets
+          for pkg in "${publish_packages[@]}"; do
+            publish_with_retry "$pkg"
+          done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,63 @@ This project follows [Semantic Versioning](https://semver.org/).
 
 ## [0.4.0]
 
-### Native C API
+### Standalone `projective-grid` crate
+
+- Add the new publishable [`projective-grid`](https://crates.io/crates/projective-grid)
+  crate for pattern-agnostic 2D grid tooling: pluggable `NeighborValidator`
+  traits, grid graph construction, connected-component traversal, BFS grid
+  coordinate assignment, homography estimation, global rectification, per-cell
+  mesh rectification, and grid smoothness prediction.
+- Extract the generic square-grid geometry and homography machinery from
+  `calib-targets-core` into `projective-grid`. `calib-targets-core` keeps the
+  image-space pieces (`GrayImage*`, sampling, `warp_perspective_gray`) and
+  re-exports `Homography`, `GridCoords` (`GridIndex` alias), `GridAlignment`,
+  `GridTransform`, and homography-estimation helpers for downstream
+  compatibility.
+- Refactor `calib-targets-chessboard` to delegate grid-graph construction and
+  traversal to `projective-grid`, while keeping chessboard-specific neighbor
+  validation in-crate. Switch ChArUco grid smoothness to the shared
+  `projective_grid::predict_grid_position` helper instead of maintaining a
+  separate midpoint-prediction implementation.
+
+### Hex grids and built-in validators
+
+- Add `projective_grid::hex` with pointy-top axial-coordinate support for
+  6-connected graph construction, BFS coordinate assignment, grid smoothness
+  prediction, `D6` alignment transforms, `HexGridHomography`, and
+  `HexGridHomographyMesh` for per-triangle affine/projective rectification.
+- Add ready-to-use validator implementations in
+  `projective_grid::validators`:
+  `XJunctionValidator` for ChESS-like oriented square-grid corners,
+  `SpatialSquareValidator` for unoriented square lattices, and
+  `SpatialHexValidator` for unoriented hex lattices such as ringgrids.
+
+### Native C API and bindings
 
 - Expose `ScanDecodeConfig::multi_threshold` in the FFI as
   `ct_scan_decode_config_t::multi_threshold` so native callers can control the
   multi-threshold marker decode path instead of being forced to the Rust
   default.
+- Add native test coverage that verifies `ct_scan_decode_config_t` preserves
+  the `multi_threshold` flag when converting into the Rust
+  `ScanDecodeConfig`.
+- Make the Python typing-artifact generator robust to multiline
+  `#[pyclass(...)]` attributes so generated `_core.pyi` stubs stay in sync
+  after adding `skip_from_py_object` to config-heavy binding classes.
+
+### Workspace and release engineering
+
+- Centralize shared crate metadata and dependency versions in the workspace
+  root via `[workspace.package]` and `[workspace.dependencies]` so the Rust
+  crates inherit coordinated `0.4` versioning and one dependency set.
+- Raise the documented MSRV to Rust `1.88` and surface it in the workspace
+  metadata and top-level README badge.
+- Update docs and packaging references from `0.3` to `0.4`, including the
+  getting-started dependency snippets and the coordinated Rust/Python/native
+  release metadata.
+- Include `projective-grid` in the coordinated crates.io release flow and add
+  CI validation that the publish order matches inter-crate dependencies before
+  attempting the tagged publish job.
 
 ## [0.3.2]
 

--- a/crates/projective-grid/README.md
+++ b/crates/projective-grid/README.md
@@ -1,14 +1,18 @@
 # projective-grid
 
-Generic 2D projective grid graph construction, traversal, and homography tools.
+Generic 2D projective grid graph construction, traversal, and homography tools
+for **square** and **hexagonal** grids.
 
-This crate provides reusable algorithms for building 4-connected grid graphs
-from detected 2D corners, assigning grid coordinates via BFS traversal,
-and computing projective mappings (homographies) for grid rectification.
-It is pattern-agnostic and has no dependency on image types or calibration-specific
-logic.
+This crate provides reusable algorithms for building grid graphs from detected
+2D corners, assigning grid coordinates via BFS traversal, and computing
+projective mappings (homographies) for grid rectification. It supports both
+4-connected square grids and 6-connected hexagonal grids (pointy-top, axial
+coordinates). It is pattern-agnostic and has no dependency on image types or
+calibration-specific logic.
 
 ## Quickstart
+
+### Square grid
 
 ```rust
 use projective_grid::{
@@ -60,27 +64,125 @@ fn main() {
 }
 ```
 
+### Hex grid
+
+```rust
+use projective_grid::hex::{
+    HexDirection, HexGridGraph, HexNeighborValidator, HexNodeNeighbor,
+    hex_connected_components, hex_assign_grid_coordinates,
+};
+use projective_grid::{GridGraphParams, NeighborCandidate};
+use nalgebra::Point2;
+
+/// Classify neighbors into hex sextants by angle.
+struct SextantValidator;
+
+impl HexNeighborValidator for SextantValidator {
+    type PointData = ();
+
+    fn validate(
+        &self,
+        _source_index: usize,
+        _source_data: &(),
+        candidate: &NeighborCandidate,
+        _candidate_data: &(),
+    ) -> Option<(HexDirection, f32)> {
+        let deg = candidate.offset.y.atan2(candidate.offset.x).to_degrees();
+        let dir = if (-30.0..30.0).contains(&deg) { HexDirection::East }
+            else if (30.0..90.0).contains(&deg) { HexDirection::SouthEast }
+            else if (90.0..150.0).contains(&deg) { HexDirection::SouthWest }
+            else if !(-150.0..150.0).contains(&deg) { HexDirection::West }
+            else if (-150.0..-90.0).contains(&deg) { HexDirection::NorthWest }
+            else { HexDirection::NorthEast };
+        Some((dir, candidate.distance))
+    }
+}
+
+fn main() {
+    // Build a small hex lattice (pointy-top, axial coordinates)
+    let spacing = 10.0f32;
+    let sqrt3 = 3.0f32.sqrt();
+    let mut positions = Vec::new();
+    for q in -1..=1i32 {
+        for r in -1..=1i32 {
+            if (q + r).abs() > 1 { continue; }
+            let x = spacing * (q as f32 + r as f32 * 0.5);
+            let y = spacing * (r as f32 * sqrt3 / 2.0);
+            positions.push(Point2::new(x, y));
+        }
+    }
+    let data = vec![(); positions.len()];
+
+    let graph = HexGridGraph::build(
+        &positions, &data, &SextantValidator, &GridGraphParams::default(),
+    );
+
+    let components = hex_connected_components(&graph);
+    let coords = hex_assign_grid_coordinates(&graph, &components[0]);
+    println!("assigned {} hex grid coordinates", coords.len());
+}
+```
+
 ## Modules
+
+### Square grid (4-connected)
 
 | Module | Description |
 |---|---|
 | `graph` | `GridGraph::build()` with pluggable `NeighborValidator` trait |
 | `traverse` | `connected_components()`, `assign_grid_coordinates()` |
-| `homography` | `Homography` struct, DLT estimation, 4-point solver with Hartley normalization |
-| `grid_mesh` | `GridHomographyMesh` -- per-cell homographies for distortion-robust rectification |
+| `grid_smoothness` | Neighbor-based position prediction (2 axis pairs) and outlier detection |
+| `grid_alignment` | `GridTransform`, `GridAlignment`, dihedral group D4 (8 transforms) |
 | `grid_rectify` | `GridHomography` -- single global homography from grid corners |
-| `grid_smoothness` | Neighbor-based position prediction and outlier detection |
-| `grid_alignment` | `GridTransform`, `GridAlignment`, dihedral group D4 transforms |
-| `direction` | `NeighborDirection`, `NodeNeighbor` |
-| `grid_index` | `GridIndex { i, j }` |
+| `grid_mesh` | `GridHomographyMesh` -- per-cell homographies for distortion-robust rectification |
+| `direction` | `NeighborDirection` (Right/Left/Up/Down), `NodeNeighbor` |
+
+### Hexagonal grid (6-connected)
+
+| Module | Description |
+|---|---|
+| `hex::graph` | `HexGridGraph::build()` with pluggable `HexNeighborValidator` trait |
+| `hex::traverse` | `hex_connected_components()`, `hex_assign_grid_coordinates()` |
+| `hex::smoothness` | Neighbor-based position prediction (3 axis pairs) and outlier detection |
+| `hex::alignment` | Dihedral group D6 (12 transforms) via `GridTransform` |
+| `hex::rectify` | `HexGridHomography` -- global homography with axial-to-rectified mapping |
+| `hex::mesh` | `HexGridHomographyMesh` -- per-triangle affine/homography mesh |
+| `hex::direction` | `HexDirection` (E/W/NE/SW/NW/SE), `HexNodeNeighbor` |
+
+### Shared
+
+| Module | Description |
+|---|---|
+| `homography` | `Homography` struct, DLT estimation, 4-point solver with Hartley normalization |
+| `grid_index` | `GridIndex { i, j }` -- used as `(col, row)` for square and `(q, r)` for hex |
+| `grid_alignment` | `GridTransform`, `GridAlignment` -- generic 2x2 integer matrix transforms |
 
 ## Design
 
-The `NeighborValidator` trait is the main extension point. Implementors decide
-which spatially close points qualify as grid neighbors and assign them a cardinal
-direction and quality score. This lets the same graph construction algorithm work
-for chessboards (orientation-based validation), ChArUco grids (marker-anchored
-validation), or any other 2D grid pattern.
+The validator traits (`NeighborValidator` for square, `HexNeighborValidator` for
+hex) are the main extension points. Implementors decide which spatially close
+points qualify as grid neighbors and assign them a direction and quality score.
+This lets the same graph construction algorithm work for chessboards
+(orientation-based validation), ChArUco grids (marker-anchored validation),
+ring calibration targets on hex lattices, or any other 2D grid pattern.
+
+### Hex coordinate convention
+
+Hex grids use **pointy-top** orientation with **axial coordinates** `(q, r)`,
+stored in `GridIndex` as `i = q`, `j = r`:
+
+- `q` increases eastward
+- `r` increases south-eastward
+- Six directions: E `(+1, 0)`, W `(-1, 0)`, NE `(+1, -1)`, SW `(-1, +1)`, NW `(0, -1)`, SE `(0, +1)`
+- Rectified mapping: `x = s * (q + r/2)`, `y = s * (r * sqrt(3)/2)` where `s` = pixels per cell
+
+### Hex mesh triangulation
+
+The hex mesh (`HexGridHomographyMesh`) decomposes the axial grid into
+parallelogram cells, each split into two triangles. Each triangle stores both
+an `AffineTransform2D` (exact 3-point mapping) and a `Homography` (4-point,
+using the centroid), giving callers the choice between speed and projective
+accuracy.
 
 The crate is standalone: it depends only on `nalgebra`, `kiddo`, `serde`, and
 `thiserror`. No image types, no calibration-specific logic.

--- a/crates/projective-grid/src/hex/alignment.rs
+++ b/crates/projective-grid/src/hex/alignment.rs
@@ -210,11 +210,7 @@ mod tests {
         let identity = &GRID_TRANSFORMS_D6[0];
         let mut acc = *identity;
         for (k, expected) in GRID_TRANSFORMS_D6.iter().enumerate().take(6) {
-            assert_eq!(
-                as_tuple(&acc),
-                as_tuple(expected),
-                "rot60^{k} mismatch"
-            );
+            assert_eq!(as_tuple(&acc), as_tuple(expected), "rot60^{k} mismatch");
             acc = compose(&acc, rot60);
         }
     }

--- a/crates/projective-grid/src/hex/alignment.rs
+++ b/crates/projective-grid/src/hex/alignment.rs
@@ -1,0 +1,221 @@
+//! Dihedral group D6 transforms for hexagonal grids in axial coordinates.
+//!
+//! The 12 symmetries of a regular hexagon: 6 rotations and 6 reflections.
+//! All transforms are expressed as 2x2 integer matrices acting on axial `(q, r)`.
+//!
+//! Reuses [`GridTransform`] — same struct, different values.
+
+use crate::grid_alignment::GridTransform;
+
+/// The 12 dihedral transforms D6 on the hexagonal integer grid (axial coordinates).
+///
+/// Rotation generator (60° CW): `(q, r) → (-r, q + r)` = `[[0, -1], [1, 1]]`.
+/// Reflection generator: `(q, r) → (q + r, -r)` = `[[1, 1], [0, -1]]`.
+///
+/// # Order
+///
+/// Indices 0..6 are rotations (0°, 60°, 120°, 180°, 240°, 300°).
+/// Indices 6..12 are reflections (reflection composed with each rotation).
+pub const GRID_TRANSFORMS_D6: [GridTransform; 12] = [
+    // --- Rotations ---
+    // 0°: identity
+    GridTransform {
+        a: 1,
+        b: 0,
+        c: 0,
+        d: 1,
+    },
+    // 60°: (q, r) → (-r, q+r)
+    GridTransform {
+        a: 0,
+        b: -1,
+        c: 1,
+        d: 1,
+    },
+    // 120°: (q, r) → (-q-r, q)
+    GridTransform {
+        a: -1,
+        b: -1,
+        c: 1,
+        d: 0,
+    },
+    // 180°: (q, r) → (-q, -r)
+    GridTransform {
+        a: -1,
+        b: 0,
+        c: 0,
+        d: -1,
+    },
+    // 240°: (q, r) → (r, -q-r)
+    GridTransform {
+        a: 0,
+        b: 1,
+        c: -1,
+        d: -1,
+    },
+    // 300°: (q, r) → (q+r, -q)
+    GridTransform {
+        a: 1,
+        b: 1,
+        c: -1,
+        d: 0,
+    },
+    // --- Reflections (reflection generator composed with rotations) ---
+    // ref ∘ rot(0°): (q, r) → (q+r, -r)
+    GridTransform {
+        a: 1,
+        b: 1,
+        c: 0,
+        d: -1,
+    },
+    // ref ∘ rot(60°): (q, r) → (-r, -q) ... apply ref to (-r, q+r) = (-r + q+r, -(q+r)) = (q, -q-r)
+    GridTransform {
+        a: 1,
+        b: 0,
+        c: -1,
+        d: -1,
+    },
+    // ref ∘ rot(120°): apply ref to (-q-r, q) = (-q-r+q, -q) = (-r, -q)
+    GridTransform {
+        a: 0,
+        b: -1,
+        c: -1,
+        d: 0,
+    },
+    // ref ∘ rot(180°): apply ref to (-q, -r) = (-q-r, r)
+    GridTransform {
+        a: -1,
+        b: -1,
+        c: 0,
+        d: 1,
+    },
+    // ref ∘ rot(240°): apply ref to (r, -q-r) = (r-q-r, q+r) = (-q, q+r)
+    GridTransform {
+        a: -1,
+        b: 0,
+        c: 1,
+        d: 1,
+    },
+    // ref ∘ rot(300°): apply ref to (q+r, -q) = (q+r-q, q) = (r, q)
+    GridTransform {
+        a: 0,
+        b: 1,
+        c: 1,
+        d: 0,
+    },
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    fn compose(a: &GridTransform, b: &GridTransform) -> GridTransform {
+        GridTransform {
+            a: a.a * b.a + a.b * b.c,
+            b: a.a * b.b + a.b * b.d,
+            c: a.c * b.a + a.d * b.c,
+            d: a.c * b.b + a.d * b.d,
+        }
+    }
+
+    fn det(t: &GridTransform) -> i32 {
+        t.a * t.d - t.b * t.c
+    }
+
+    fn as_tuple(t: &GridTransform) -> (i32, i32, i32, i32) {
+        (t.a, t.b, t.c, t.d)
+    }
+
+    #[test]
+    fn all_twelve_distinct() {
+        let set: HashSet<_> = GRID_TRANSFORMS_D6.iter().map(as_tuple).collect();
+        assert_eq!(set.len(), 12);
+    }
+
+    #[test]
+    fn all_unimodular() {
+        for t in &GRID_TRANSFORMS_D6 {
+            let d = det(t);
+            assert!(d == 1 || d == -1, "det = {d} for {t:?}");
+        }
+    }
+
+    #[test]
+    fn rotations_det_plus_one() {
+        for t in &GRID_TRANSFORMS_D6[0..6] {
+            assert_eq!(det(t), 1, "rotation {t:?} should have det +1");
+        }
+    }
+
+    #[test]
+    fn reflections_det_minus_one() {
+        for t in &GRID_TRANSFORMS_D6[6..12] {
+            assert_eq!(det(t), -1, "reflection {t:?} should have det -1");
+        }
+    }
+
+    #[test]
+    fn rotation_order_six() {
+        let rot60 = &GRID_TRANSFORMS_D6[1];
+        let identity = &GRID_TRANSFORMS_D6[0];
+
+        let mut acc = *identity;
+        for k in 1..=6 {
+            acc = compose(&acc, rot60);
+            if k < 6 {
+                assert_ne!(
+                    as_tuple(&acc),
+                    as_tuple(identity),
+                    "rot60^{k} should not be identity"
+                );
+            }
+        }
+        assert_eq!(
+            as_tuple(&acc),
+            as_tuple(identity),
+            "rot60^6 must be identity"
+        );
+    }
+
+    #[test]
+    fn reflections_are_involutions() {
+        for (i, t) in GRID_TRANSFORMS_D6[6..12].iter().enumerate() {
+            let t_sq = compose(t, t);
+            assert_eq!(
+                as_tuple(&t_sq),
+                as_tuple(&GRID_TRANSFORMS_D6[0]),
+                "reflection[{i}]^2 must be identity"
+            );
+        }
+    }
+
+    #[test]
+    fn closure_under_composition() {
+        let set: HashSet<_> = GRID_TRANSFORMS_D6.iter().map(as_tuple).collect();
+        for a in &GRID_TRANSFORMS_D6 {
+            for b in &GRID_TRANSFORMS_D6 {
+                let c = compose(a, b);
+                assert!(
+                    set.contains(&as_tuple(&c)),
+                    "product of {a:?} and {b:?} = {c:?} not in D6"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn rotations_match_successive_composition() {
+        let rot60 = &GRID_TRANSFORMS_D6[1];
+        let identity = &GRID_TRANSFORMS_D6[0];
+        let mut acc = *identity;
+        for (k, expected) in GRID_TRANSFORMS_D6.iter().enumerate().take(6) {
+            assert_eq!(
+                as_tuple(&acc),
+                as_tuple(expected),
+                "rot60^{k} mismatch"
+            );
+            acc = compose(&acc, rot60);
+        }
+    }
+}

--- a/crates/projective-grid/src/hex/direction.rs
+++ b/crates/projective-grid/src/hex/direction.rs
@@ -1,0 +1,157 @@
+//! Hex grid directions and neighbor metadata for pointy-top axial coordinates.
+
+use serde::{Deserialize, Serialize};
+
+/// Direction along a 6-connected hexagonal grid (pointy-top, axial coordinates).
+///
+/// Axial coordinate convention: `q` increases eastward, `r` increases south-eastward.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum HexDirection {
+    East,
+    West,
+    NorthEast,
+    SouthWest,
+    NorthWest,
+    SouthEast,
+}
+
+impl HexDirection {
+    /// All six directions in clockwise order starting from East.
+    pub const ALL: [HexDirection; 6] = [
+        Self::East,
+        Self::SouthEast,
+        Self::SouthWest,
+        Self::West,
+        Self::NorthWest,
+        Self::NorthEast,
+    ];
+
+    /// The opposite direction.
+    pub fn opposite(self) -> Self {
+        match self {
+            Self::East => Self::West,
+            Self::West => Self::East,
+            Self::NorthEast => Self::SouthWest,
+            Self::SouthWest => Self::NorthEast,
+            Self::NorthWest => Self::SouthEast,
+            Self::SouthEast => Self::NorthWest,
+        }
+    }
+
+    /// Axial coordinate delta `(dq, dr)` for this direction.
+    ///
+    /// Convention (pointy-top): `q` increases eastward, `r` increases south-eastward.
+    pub fn delta(self) -> (i32, i32) {
+        match self {
+            Self::East => (1, 0),
+            Self::West => (-1, 0),
+            Self::NorthEast => (1, -1),
+            Self::SouthWest => (-1, 1),
+            Self::NorthWest => (0, -1),
+            Self::SouthEast => (0, 1),
+        }
+    }
+
+    /// Rotate 60 degrees clockwise.
+    pub fn rotate_cw_60(self) -> Self {
+        match self {
+            Self::East => Self::SouthEast,
+            Self::SouthEast => Self::SouthWest,
+            Self::SouthWest => Self::West,
+            Self::West => Self::NorthWest,
+            Self::NorthWest => Self::NorthEast,
+            Self::NorthEast => Self::East,
+        }
+    }
+
+    /// Axis index grouping opposite pairs: 0 = E/W, 1 = NE/SW, 2 = NW/SE.
+    pub fn axis_index(self) -> usize {
+        match self {
+            Self::East | Self::West => 0,
+            Self::NorthEast | Self::SouthWest => 1,
+            Self::NorthWest | Self::SouthEast => 2,
+        }
+    }
+
+    /// Slot index for `select_hex_neighbors` (one unique slot per direction).
+    pub(crate) fn slot_index(self) -> usize {
+        match self {
+            Self::East => 0,
+            Self::West => 1,
+            Self::NorthEast => 2,
+            Self::SouthWest => 3,
+            Self::NorthWest => 4,
+            Self::SouthEast => 5,
+        }
+    }
+}
+
+/// A validated hex grid neighbor with direction, distance, and quality score.
+#[derive(Debug)]
+pub struct HexNodeNeighbor {
+    /// Direction from the source node to this neighbor.
+    pub direction: HexDirection,
+    /// Index of the neighbor in the original point array.
+    pub index: usize,
+    /// Euclidean distance in pixels.
+    pub distance: f32,
+    /// Quality score (lower is better).
+    pub score: f32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn opposite_round_trips() {
+        for &d in &HexDirection::ALL {
+            assert_eq!(d.opposite().opposite(), d);
+        }
+    }
+
+    #[test]
+    fn opposite_deltas_sum_to_zero() {
+        for &d in &HexDirection::ALL {
+            let (dq1, dr1) = d.delta();
+            let (dq2, dr2) = d.opposite().delta();
+            assert_eq!(dq1 + dq2, 0);
+            assert_eq!(dr1 + dr2, 0);
+        }
+    }
+
+    #[test]
+    fn rotate_cw_60_cycles_all_six() {
+        let mut d = HexDirection::East;
+        let mut visited = Vec::new();
+        for _ in 0..6 {
+            visited.push(d);
+            d = d.rotate_cw_60();
+        }
+        assert_eq!(d, HexDirection::East);
+        // All 6 are distinct
+        for i in 0..6 {
+            for j in (i + 1)..6 {
+                assert_ne!(visited[i], visited[j]);
+            }
+        }
+    }
+
+    #[test]
+    fn axis_index_groups_opposites() {
+        for &d in &HexDirection::ALL {
+            assert_eq!(d.axis_index(), d.opposite().axis_index());
+        }
+        // Three distinct axes
+        let axes: std::collections::HashSet<usize> =
+            HexDirection::ALL.iter().map(|d| d.axis_index()).collect();
+        assert_eq!(axes.len(), 3);
+    }
+
+    #[test]
+    fn slot_indices_are_unique() {
+        let slots: Vec<usize> = HexDirection::ALL.iter().map(|d| d.slot_index()).collect();
+        let set: std::collections::HashSet<usize> = slots.iter().copied().collect();
+        assert_eq!(set.len(), 6);
+    }
+}

--- a/crates/projective-grid/src/hex/graph.rs
+++ b/crates/projective-grid/src/hex/graph.rs
@@ -1,0 +1,272 @@
+//! 6-connected hex grid graph construction via KD-tree spatial search.
+
+use crate::graph::{GridGraphParams, NeighborCandidate};
+use crate::hex::direction::{HexDirection, HexNodeNeighbor};
+use kiddo::{KdTree, SquaredEuclidean};
+use nalgebra::{Point2, Vector2};
+
+/// Extension point for hex-pattern-specific neighbor validation.
+///
+/// Implementors decide whether a spatially close point is a valid hex grid
+/// neighbor, and if so, assign it a direction and quality score.
+pub trait HexNeighborValidator {
+    /// Per-point data beyond position (e.g., orientation angle).
+    /// Use `()` if no extra data is needed.
+    type PointData;
+
+    /// Validate whether `candidate` is a valid hex grid neighbor of the point
+    /// at `source_index`. Returns `(direction, score)` where lower score
+    /// is better, or `None` to reject.
+    fn validate(
+        &self,
+        source_index: usize,
+        source_data: &Self::PointData,
+        candidate: &NeighborCandidate,
+        candidate_data: &Self::PointData,
+    ) -> Option<(HexDirection, f32)>;
+}
+
+/// A 6-connected hex grid graph over 2D points.
+///
+/// Each node has at most one neighbor per hex direction,
+/// selected as the best-scoring candidate from spatial proximity search.
+pub struct HexGridGraph {
+    /// Per-node adjacency list. `neighbors[i]` contains up to 6 validated neighbors.
+    pub neighbors: Vec<Vec<HexNodeNeighbor>>,
+}
+
+impl HexGridGraph {
+    /// Build a hex grid graph from 2D points using a caller-supplied validator.
+    ///
+    /// - `positions`: 2D point positions for spatial search.
+    /// - `point_data`: per-point data passed to the validator (same length as `positions`).
+    /// - `validator`: determines which spatial neighbors are valid hex grid neighbors.
+    /// - `params`: controls KD-tree search parameters.
+    pub fn build<V: HexNeighborValidator>(
+        positions: &[Point2<f32>],
+        point_data: &[V::PointData],
+        validator: &V,
+        params: &GridGraphParams,
+    ) -> Self {
+        assert_eq!(
+            positions.len(),
+            point_data.len(),
+            "positions and point_data must have the same length"
+        );
+
+        let coords: Vec<[f32; 2]> = positions.iter().map(|p| [p.x, p.y]).collect();
+        let tree: KdTree<f32, 2> = (&coords).into();
+        let max_dist_sq = params.max_distance * params.max_distance;
+
+        let mut neighbors = Vec::with_capacity(positions.len());
+
+        for (i, pos) in positions.iter().enumerate() {
+            let query = [pos.x, pos.y];
+            let results = tree.nearest_n::<SquaredEuclidean>(&query, params.k_neighbors);
+
+            let mut candidates = Vec::new();
+
+            for nn in results {
+                let j = nn.item as usize;
+                if j == i {
+                    continue;
+                }
+
+                let dist_sq = nn.distance;
+                if dist_sq > max_dist_sq {
+                    continue;
+                }
+
+                let neighbor_pos = positions[j];
+                let offset = Vector2::new(neighbor_pos.x - pos.x, neighbor_pos.y - pos.y);
+                let distance = dist_sq.sqrt();
+
+                let candidate = NeighborCandidate {
+                    index: j,
+                    offset,
+                    distance,
+                };
+
+                if let Some((direction, score)) =
+                    validator.validate(i, &point_data[i], &candidate, &point_data[j])
+                {
+                    candidates.push(HexNodeNeighbor {
+                        direction,
+                        index: j,
+                        distance,
+                        score,
+                    });
+                }
+            }
+
+            neighbors.push(select_hex_neighbors(candidates));
+        }
+
+        Self { neighbors }
+    }
+}
+
+/// Keep at most one neighbor per direction, choosing the lowest-score candidate.
+fn select_hex_neighbors(candidates: Vec<HexNodeNeighbor>) -> Vec<HexNodeNeighbor> {
+    let mut best: [Option<HexNodeNeighbor>; 6] = [None, None, None, None, None, None];
+
+    for candidate in candidates {
+        let slot = &mut best[candidate.direction.slot_index()];
+
+        let replace = match slot {
+            None => true,
+            Some(current) => {
+                candidate.score < current.score
+                    || (candidate.score == current.score && candidate.distance < current.distance)
+            }
+        };
+
+        if replace {
+            *slot = Some(candidate);
+        }
+    }
+
+    best.into_iter().flatten().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Trivial validator that assigns direction by sextant angle.
+    struct AngleValidator;
+
+    impl HexNeighborValidator for AngleValidator {
+        type PointData = ();
+
+        fn validate(
+            &self,
+            _source_index: usize,
+            _source_data: &(),
+            candidate: &NeighborCandidate,
+            _candidate_data: &(),
+        ) -> Option<(HexDirection, f32)> {
+            let angle = candidate.offset.y.atan2(candidate.offset.x);
+            let deg = angle.to_degrees();
+
+            // Map angle to nearest hex direction (pointy-top, 60° sectors)
+            let dir = if (-30.0..30.0).contains(&deg) {
+                HexDirection::East
+            } else if (30.0..90.0).contains(&deg) {
+                HexDirection::SouthEast
+            } else if (90.0..150.0).contains(&deg) {
+                HexDirection::SouthWest
+            } else if !(-150.0..150.0).contains(&deg) {
+                HexDirection::West
+            } else if (-150.0..-90.0).contains(&deg) {
+                HexDirection::NorthWest
+            } else {
+                HexDirection::NorthEast
+            };
+
+            Some((dir, candidate.distance))
+        }
+    }
+
+    /// Generate a regular hex lattice (pointy-top) with given radius.
+    fn hex_lattice(radius: i32, spacing: f32) -> Vec<Point2<f32>> {
+        let mut points = Vec::new();
+        let sqrt3 = 3.0f32.sqrt();
+        for q in -radius..=radius {
+            for r in -radius..=radius {
+                if (q + r).abs() > radius {
+                    continue;
+                }
+                let x = spacing * (q as f32 + r as f32 * 0.5);
+                let y = spacing * (r as f32 * sqrt3 / 2.0);
+                points.push(Point2::new(x, y));
+            }
+        }
+        points
+    }
+
+    #[test]
+    fn center_node_has_six_neighbors() {
+        let spacing = 50.0;
+        let points = hex_lattice(2, spacing);
+        let data = vec![(); points.len()];
+
+        let params = GridGraphParams {
+            k_neighbors: 12,
+            max_distance: spacing * 1.5,
+        };
+
+        let graph = HexGridGraph::build(&points, &data, &AngleValidator, &params);
+
+        // Find the center node (0, 0) -> (x=0, y=0)
+        let center = points
+            .iter()
+            .position(|p| p.x.abs() < 0.01 && p.y.abs() < 0.01)
+            .unwrap();
+
+        assert_eq!(graph.neighbors[center].len(), 6);
+    }
+
+    #[test]
+    fn edge_nodes_have_fewer_neighbors() {
+        let spacing = 50.0;
+        let points = hex_lattice(1, spacing);
+        let data = vec![(); points.len()];
+
+        let params = GridGraphParams {
+            k_neighbors: 12,
+            max_distance: spacing * 1.5,
+        };
+
+        let graph = HexGridGraph::build(&points, &data, &AngleValidator, &params);
+
+        // All non-center nodes in radius-1 hex have exactly 3 neighbors
+        for (i, p) in points.iter().enumerate() {
+            if p.x.abs() < 0.01 && p.y.abs() < 0.01 {
+                assert_eq!(graph.neighbors[i].len(), 6);
+            } else {
+                assert_eq!(
+                    graph.neighbors[i].len(),
+                    3,
+                    "edge node {i} at ({}, {}) has {} neighbors",
+                    p.x,
+                    p.y,
+                    graph.neighbors[i].len()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn select_keeps_best_per_direction() {
+        let candidates = vec![
+            HexNodeNeighbor {
+                direction: HexDirection::East,
+                index: 1,
+                distance: 50.0,
+                score: 0.9,
+            },
+            HexNodeNeighbor {
+                direction: HexDirection::East,
+                index: 2,
+                distance: 55.0,
+                score: 0.5,
+            },
+            HexNodeNeighbor {
+                direction: HexDirection::West,
+                index: 3,
+                distance: 50.0,
+                score: 0.3,
+            },
+        ];
+
+        let selected = select_hex_neighbors(candidates);
+        assert_eq!(selected.len(), 2);
+
+        let east = selected
+            .iter()
+            .find(|n| n.direction == HexDirection::East)
+            .unwrap();
+        assert_eq!(east.index, 2); // lower score wins
+    }
+}

--- a/crates/projective-grid/src/hex/mesh.rs
+++ b/crates/projective-grid/src/hex/mesh.rs
@@ -1,0 +1,517 @@
+//! Per-triangle homography mesh for hex grid rectification.
+//!
+//! Given a map of hex grid corners (axial coordinates) to image positions,
+//! builds one affine transform and one homography per triangle cell.
+//! The hex lattice is decomposed into parallelogram cells, each split into
+//! two triangles.
+
+use crate::grid_index::GridIndex;
+use crate::homography::{estimate_homography, Homography};
+use nalgebra::{Matrix2, Point2, Vector2};
+use std::collections::HashMap;
+
+/// Sqrt(3) / 2, the vertical spacing factor for pointy-top hex grids.
+const SQRT3_HALF: f64 = 0.866_025_403_784_438_6;
+
+#[derive(thiserror::Error, Debug)]
+pub enum HexMeshError {
+    #[error("not enough grid corners (need at least 3)")]
+    NotEnoughCorners,
+    #[error("no valid triangles found")]
+    NoValidTriangles,
+}
+
+/// A 2D affine transform: `dst = M * [src_x, src_y]^T + t`.
+#[derive(Clone, Copy, Debug)]
+pub struct AffineTransform2D {
+    /// 2x2 linear part.
+    pub linear: Matrix2<f64>,
+    /// Translation part.
+    pub translation: Vector2<f64>,
+}
+
+impl AffineTransform2D {
+    /// Compute the affine transform mapping `src` triangle to `dst` triangle.
+    ///
+    /// Returns `None` if the source triangle is degenerate (collinear points).
+    pub fn from_triangle_correspondence(
+        src: [Point2<f64>; 3],
+        dst: [Point2<f64>; 3],
+    ) -> Option<Self> {
+        // Solve: dst_i = M * src_i + t for i = 0, 1, 2
+        // Using src[0] as origin: M * (src_i - src_0) = (dst_i - dst_0) for i = 1, 2
+        let ds1 = src[1] - src[0];
+        let ds2 = src[2] - src[0];
+        let dd1 = dst[1] - dst[0];
+        let dd2 = dst[2] - dst[0];
+
+        // [ds1 | ds2] as column matrix, invert to get M
+        let src_mat = Matrix2::new(ds1.x, ds2.x, ds1.y, ds2.y);
+
+        let src_inv = src_mat.try_inverse()?;
+
+        // M = [dd1 | dd2] * src_inv
+        let dst_mat = Matrix2::new(dd1.x, dd2.x, dd1.y, dd2.y);
+        let linear = dst_mat * src_inv;
+
+        let t = dst[0] - linear * Vector2::new(src[0].x, src[0].y);
+        let translation = Vector2::new(t.x, t.y);
+
+        Some(Self {
+            linear,
+            translation,
+        })
+    }
+
+    /// Apply the transform to a 2D point.
+    pub fn apply(&self, p: Point2<f64>) -> Point2<f64> {
+        let v = self.linear * Vector2::new(p.x, p.y) + self.translation;
+        Point2::new(v.x, v.y)
+    }
+}
+
+#[derive(Clone, Debug)]
+struct TriangleCell {
+    /// Affine transform from rectified triangle to image triangle.
+    affine: AffineTransform2D,
+    /// Homography from rectified triangle to image triangle (4-point, with centroid).
+    homography: Homography,
+}
+
+/// Per-triangle homography mesh over a hex grid.
+///
+/// Each parallelogram cell in axial space `(q, r) → (q+1, r+1)` is split
+/// into two triangles:
+/// - **Lower**: `(q,r)`, `(q+1,r)`, `(q,r+1)` — when `frac_q + frac_r ≤ 1`
+/// - **Upper**: `(q+1,r)`, `(q,r+1)`, `(q+1,r+1)` — when `frac_q + frac_r > 1`
+#[derive(Clone, Debug)]
+pub struct HexGridHomographyMesh {
+    pub min_q: i32,
+    pub min_r: i32,
+    /// Number of parallelogram cells along q.
+    pub cells_q: usize,
+    /// Number of parallelogram cells along r.
+    pub cells_r: usize,
+    /// Rectified pixels per grid cell edge.
+    pub px_per_cell: f32,
+    /// Number of valid triangle cells.
+    pub valid_triangles: usize,
+    /// Rectified image dimensions.
+    pub rect_width: usize,
+    pub rect_height: usize,
+
+    // 2 triangles per parallelogram cell: [lower, upper] interleaved.
+    // Length = cells_q * cells_r * 2
+    cells: Vec<Option<TriangleCell>>,
+
+    // Rectified coordinate offset (subtracted from raw axial→rect mapping).
+    x_offset: f64,
+    y_offset: f64,
+}
+
+impl HexGridHomographyMesh {
+    /// Build per-triangle transforms from a hex grid corner map.
+    ///
+    /// - `corners`: map from axial grid index `(q=i, r=j)` to image position.
+    /// - `px_per_cell`: rectified pixels per grid cell edge.
+    pub fn from_corners(
+        corners: &HashMap<GridIndex, Point2<f32>>,
+        px_per_cell: f32,
+    ) -> Result<Self, HexMeshError> {
+        if corners.len() < 3 {
+            return Err(HexMeshError::NotEnoughCorners);
+        }
+
+        let (mut min_q, mut min_r) = (i32::MAX, i32::MAX);
+        let (mut max_q, mut max_r) = (i32::MIN, i32::MIN);
+        for g in corners.keys() {
+            min_q = min_q.min(g.i);
+            min_r = min_r.min(g.j);
+            max_q = max_q.max(g.i);
+            max_r = max_r.max(g.j);
+        }
+
+        if max_q - min_q < 1 || max_r - min_r < 1 {
+            return Err(HexMeshError::NoValidTriangles);
+        }
+
+        let cells_q = (max_q - min_q) as usize;
+        let cells_r = (max_r - min_r) as usize;
+        let s = px_per_cell as f64;
+
+        // Compute rectified bounding box
+        let mut x_min = f64::MAX;
+        let mut x_max = f64::MIN;
+        let mut y_min = f64::MAX;
+        let mut y_max = f64::MIN;
+
+        // Check all corner positions of the bounding parallelogram
+        for &q in &[min_q, max_q] {
+            for &r in &[min_r, max_r] {
+                let x = s * (q as f64 + r as f64 * 0.5);
+                let y = s * (r as f64 * SQRT3_HALF);
+                x_min = x_min.min(x);
+                x_max = x_max.max(x);
+                y_min = y_min.min(y);
+                y_max = y_max.max(y);
+            }
+        }
+
+        let rect_width = ((x_max - x_min).round().max(1.0)) as usize;
+        let rect_height = ((y_max - y_min).round().max(1.0)) as usize;
+
+        let axial_to_rect = |q: i32, r: i32| -> Point2<f64> {
+            Point2::new(
+                s * (q as f64 + r as f64 * 0.5) - x_min,
+                s * (r as f64 * SQRT3_HALF) - y_min,
+            )
+        };
+
+        let mut cells = vec![None; cells_q * cells_r * 2];
+        let mut valid_triangles = 0usize;
+
+        for cr in 0..cells_r {
+            for cq in 0..cells_q {
+                let q0 = min_q + cq as i32;
+                let r0 = min_r + cr as i32;
+
+                let g00 = GridIndex { i: q0, j: r0 };
+                let g10 = GridIndex { i: q0 + 1, j: r0 };
+                let g01 = GridIndex { i: q0, j: r0 + 1 };
+                let g11 = GridIndex {
+                    i: q0 + 1,
+                    j: r0 + 1,
+                };
+
+                let p00 = corners.get(&g00).copied();
+                let p10 = corners.get(&g10).copied();
+                let p01 = corners.get(&g01).copied();
+                let p11 = corners.get(&g11).copied();
+
+                let idx_base = (cr * cells_q + cq) * 2;
+
+                // Lower triangle: g00, g10, g01
+                if let (Some(ip00), Some(ip10), Some(ip01)) = (p00, p10, p01) {
+                    let rect_tri = [
+                        axial_to_rect(q0, r0),
+                        axial_to_rect(q0 + 1, r0),
+                        axial_to_rect(q0, r0 + 1),
+                    ];
+                    let img_tri = [
+                        Point2::new(ip00.x as f64, ip00.y as f64),
+                        Point2::new(ip10.x as f64, ip10.y as f64),
+                        Point2::new(ip01.x as f64, ip01.y as f64),
+                    ];
+
+                    if let Some(affine) =
+                        AffineTransform2D::from_triangle_correspondence(rect_tri, img_tri)
+                    {
+                        // 4-point homography: add centroid as 4th point
+                        let rect_c = centroid(&rect_tri);
+                        let img_c = affine.apply(rect_c);
+                        let rect_4: Vec<Point2<f32>> = rect_tri
+                            .iter()
+                            .chain(std::iter::once(&rect_c))
+                            .map(|p| Point2::new(p.x as f32, p.y as f32))
+                            .collect();
+                        let img_4: Vec<Point2<f32>> = img_tri
+                            .iter()
+                            .chain(std::iter::once(&img_c))
+                            .map(|p| Point2::new(p.x as f32, p.y as f32))
+                            .collect();
+
+                        if let Some(homography) = estimate_homography(&rect_4, &img_4) {
+                            cells[idx_base] = Some(TriangleCell { affine, homography });
+                            valid_triangles += 1;
+                        }
+                    }
+                }
+
+                // Upper triangle: g10, g01, g11
+                if let (Some(ip10), Some(ip01), Some(ip11)) = (p10, p01, p11) {
+                    let rect_tri = [
+                        axial_to_rect(q0 + 1, r0),
+                        axial_to_rect(q0, r0 + 1),
+                        axial_to_rect(q0 + 1, r0 + 1),
+                    ];
+                    let img_tri = [
+                        Point2::new(ip10.x as f64, ip10.y as f64),
+                        Point2::new(ip01.x as f64, ip01.y as f64),
+                        Point2::new(ip11.x as f64, ip11.y as f64),
+                    ];
+
+                    if let Some(affine) =
+                        AffineTransform2D::from_triangle_correspondence(rect_tri, img_tri)
+                    {
+                        let rect_c = centroid(&rect_tri);
+                        let img_c = affine.apply(rect_c);
+                        let rect_4: Vec<Point2<f32>> = rect_tri
+                            .iter()
+                            .chain(std::iter::once(&rect_c))
+                            .map(|p| Point2::new(p.x as f32, p.y as f32))
+                            .collect();
+                        let img_4: Vec<Point2<f32>> = img_tri
+                            .iter()
+                            .chain(std::iter::once(&img_c))
+                            .map(|p| Point2::new(p.x as f32, p.y as f32))
+                            .collect();
+
+                        if let Some(homography) = estimate_homography(&rect_4, &img_4) {
+                            cells[idx_base + 1] = Some(TriangleCell { affine, homography });
+                            valid_triangles += 1;
+                        }
+                    }
+                }
+            }
+        }
+
+        if valid_triangles == 0 {
+            return Err(HexMeshError::NoValidTriangles);
+        }
+
+        Ok(Self {
+            min_q,
+            min_r,
+            cells_q,
+            cells_r,
+            px_per_cell,
+            valid_triangles,
+            rect_width,
+            rect_height,
+            cells,
+            x_offset: x_min,
+            y_offset: y_min,
+        })
+    }
+
+    /// Map a point in **global rectified pixel coordinates** to image coordinates
+    /// using the per-triangle affine transform.
+    ///
+    /// Returns `None` if the point lies outside the mesh or the cell is invalid.
+    pub fn rect_to_img_affine(&self, p_rect: Point2<f32>) -> Option<Point2<f32>> {
+        let (cell, p64) = self.lookup_cell(p_rect)?;
+        let result = cell.affine.apply(p64);
+        Some(Point2::new(result.x as f32, result.y as f32))
+    }
+
+    /// Map a point in **global rectified pixel coordinates** to image coordinates
+    /// using the per-triangle homography.
+    ///
+    /// Returns `None` if the point lies outside the mesh or the cell is invalid.
+    pub fn rect_to_img(&self, p_rect: Point2<f32>) -> Option<Point2<f32>> {
+        let (cell, _) = self.lookup_cell(p_rect)?;
+        Some(cell.homography.apply(p_rect))
+    }
+
+    /// Look up the triangle cell for a rectified point.
+    fn lookup_cell(&self, p_rect: Point2<f32>) -> Option<(&TriangleCell, Point2<f64>)> {
+        let s = self.px_per_cell as f64;
+        if s <= 0.0 {
+            return None;
+        }
+
+        let p64 = Point2::new(p_rect.x as f64, p_rect.y as f64);
+
+        // Convert rectified pixel coords back to fractional axial coords
+        let r_frac = (p64.y + self.y_offset) / (s * SQRT3_HALF);
+        let q_frac = (p64.x + self.x_offset) / s - r_frac * 0.5;
+
+        // Determine parallelogram cell
+        let cq_f = q_frac - self.min_q as f64;
+        let cr_f = r_frac - self.min_r as f64;
+
+        let cq = cq_f.floor() as i32;
+        let cr = cr_f.floor() as i32;
+
+        if cq < 0 || cr < 0 || cq >= self.cells_q as i32 || cr >= self.cells_r as i32 {
+            return None;
+        }
+
+        // Determine lower vs upper triangle
+        let frac_q = cq_f - cq as f64;
+        let frac_r = cr_f - cr as f64;
+        let is_upper = frac_q + frac_r > 1.0;
+
+        let idx = (cr as usize * self.cells_q + cq as usize) * 2 + is_upper as usize;
+        let cell = self.cells.get(idx)?.as_ref()?;
+
+        Some((cell, p64))
+    }
+}
+
+fn centroid(tri: &[Point2<f64>; 3]) -> Point2<f64> {
+    Point2::new(
+        (tri[0].x + tri[1].x + tri[2].x) / 3.0,
+        (tri[0].y + tri[1].y + tri[2].y) / 3.0,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_hex_corners(radius: i32, spacing: f32) -> HashMap<GridIndex, Point2<f32>> {
+        let sqrt3 = 3.0f32.sqrt();
+        let mut map = HashMap::new();
+        for q in -radius..=radius {
+            for r in -radius..=radius {
+                if (q + r).abs() > radius {
+                    continue;
+                }
+                let x = spacing * (q as f32 + r as f32 * 0.5);
+                let y = spacing * (r as f32 * sqrt3 / 2.0);
+                map.insert(GridIndex { i: q, j: r }, Point2::new(x, y));
+            }
+        }
+        map
+    }
+
+    #[test]
+    fn affine_from_triangle_identity() {
+        let tri = [
+            Point2::new(0.0, 0.0),
+            Point2::new(1.0, 0.0),
+            Point2::new(0.0, 1.0),
+        ];
+        let aff = AffineTransform2D::from_triangle_correspondence(tri, tri).unwrap();
+        let p = Point2::new(0.3, 0.4);
+        let result = aff.apply(p);
+        assert!((result.x - p.x).abs() < 1e-10);
+        assert!((result.y - p.y).abs() < 1e-10);
+    }
+
+    #[test]
+    fn affine_maps_vertices_correctly() {
+        let src = [
+            Point2::new(0.0, 0.0),
+            Point2::new(1.0, 0.0),
+            Point2::new(0.0, 1.0),
+        ];
+        let dst = [
+            Point2::new(10.0, 20.0),
+            Point2::new(30.0, 20.0),
+            Point2::new(10.0, 50.0),
+        ];
+        let aff = AffineTransform2D::from_triangle_correspondence(src, dst).unwrap();
+        for (s, d) in src.iter().zip(dst.iter()) {
+            let result = aff.apply(*s);
+            assert!((result.x - d.x).abs() < 1e-10);
+            assert!((result.y - d.y).abs() < 1e-10);
+        }
+    }
+
+    #[test]
+    fn degenerate_triangle_returns_none() {
+        let src = [
+            Point2::new(0.0, 0.0),
+            Point2::new(1.0, 0.0),
+            Point2::new(2.0, 0.0), // collinear
+        ];
+        let dst = src;
+        assert!(AffineTransform2D::from_triangle_correspondence(src, dst).is_none());
+    }
+
+    #[test]
+    fn mesh_from_regular_hex_grid() {
+        let corners = make_hex_corners(3, 60.0);
+        let mesh = HexGridHomographyMesh::from_corners(&corners, 60.0).unwrap();
+        assert!(mesh.valid_triangles > 0);
+        assert!(mesh.rect_width > 0);
+        assert!(mesh.rect_height > 0);
+    }
+
+    #[test]
+    fn round_trip_through_affine_mesh() {
+        let spacing = 60.0;
+        let corners = make_hex_corners(3, spacing);
+        let mesh = HexGridHomographyMesh::from_corners(&corners, spacing).unwrap();
+
+        // Test that known corner positions round-trip through the mesh
+        let s = spacing as f64;
+
+        // Verify that corners at known positions map back reasonably
+        for (g, &img_pos) in &corners {
+            let rx = (s * (g.i as f64 + g.j as f64 * 0.5) - mesh.x_offset) as f32;
+            let ry = (s * (g.j as f64 * SQRT3_HALF) - mesh.y_offset) as f32;
+            let rect_pt = Point2::new(rx, ry);
+
+            if let Some(recovered) = mesh.rect_to_img_affine(rect_pt) {
+                assert!(
+                    (recovered.x - img_pos.x).abs() < 1.0,
+                    "x mismatch at ({},{}): {} vs {}",
+                    g.i,
+                    g.j,
+                    recovered.x,
+                    img_pos.x,
+                );
+                assert!(
+                    (recovered.y - img_pos.y).abs() < 1.0,
+                    "y mismatch at ({},{}): {} vs {}",
+                    g.i,
+                    g.j,
+                    recovered.y,
+                    img_pos.y,
+                );
+            }
+            // Some boundary corners may not have a valid triangle cell — that's OK
+        }
+    }
+
+    #[test]
+    fn round_trip_through_homography_mesh() {
+        let spacing = 60.0;
+        let corners = make_hex_corners(3, spacing);
+        let mesh = HexGridHomographyMesh::from_corners(&corners, spacing).unwrap();
+
+        let s = spacing as f64;
+
+        for (g, &img_pos) in &corners {
+            let rx = (s * (g.i as f64 + g.j as f64 * 0.5) - mesh.x_offset) as f32;
+            let ry = (s * (g.j as f64 * SQRT3_HALF) - mesh.y_offset) as f32;
+            let rect_pt = Point2::new(rx, ry);
+
+            if let Some(recovered) = mesh.rect_to_img(rect_pt) {
+                assert!(
+                    (recovered.x - img_pos.x).abs() < 1.0,
+                    "homography x mismatch at ({},{}): {} vs {}",
+                    g.i,
+                    g.j,
+                    recovered.x,
+                    img_pos.x,
+                );
+                assert!(
+                    (recovered.y - img_pos.y).abs() < 1.0,
+                    "homography y mismatch at ({},{}): {} vs {}",
+                    g.i,
+                    g.j,
+                    recovered.y,
+                    img_pos.y,
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn too_few_corners_errors() {
+        let mut corners = HashMap::new();
+        corners.insert(GridIndex { i: 0, j: 0 }, Point2::new(0.0, 0.0));
+        corners.insert(GridIndex { i: 1, j: 0 }, Point2::new(50.0, 0.0));
+
+        let result = HexGridHomographyMesh::from_corners(&corners, 50.0);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn missing_corners_handled_gracefully() {
+        let mut corners = make_hex_corners(3, 60.0);
+        // Remove some corners
+        corners.remove(&GridIndex { i: 0, j: 0 });
+        corners.remove(&GridIndex { i: 1, j: 1 });
+
+        let mesh = HexGridHomographyMesh::from_corners(&corners, 60.0);
+        // Should still succeed (just with fewer valid triangles)
+        assert!(mesh.is_ok());
+        let mesh = mesh.unwrap();
+        assert!(mesh.valid_triangles > 0);
+    }
+}

--- a/crates/projective-grid/src/hex/mod.rs
+++ b/crates/projective-grid/src/hex/mod.rs
@@ -1,0 +1,27 @@
+//! Hexagonal grid support for pointy-top axial coordinates.
+//!
+//! This module provides hex-grid counterparts of the square-grid types
+//! in the parent crate: 6-connected graph construction, BFS traversal,
+//! smoothness analysis, D6 alignment transforms, and rectification.
+//!
+//! # Coordinate Convention
+//!
+//! Axial coordinates `(q, r)` are stored in [`GridIndex`](crate::GridIndex)
+//! where `i = q` and `j = r`. Pointy-top orientation: `q` increases eastward,
+//! `r` increases south-eastward.
+
+pub mod alignment;
+pub mod direction;
+pub mod graph;
+pub mod mesh;
+pub mod rectify;
+pub mod smoothness;
+pub mod traverse;
+
+pub use alignment::GRID_TRANSFORMS_D6;
+pub use direction::{HexDirection, HexNodeNeighbor};
+pub use graph::{HexGridGraph, HexNeighborValidator};
+pub use mesh::{AffineTransform2D, HexGridHomographyMesh, HexMeshError};
+pub use rectify::{HexGridHomography, HexRectifyError};
+pub use smoothness::{hex_find_inconsistent_corners, hex_predict_grid_position};
+pub use traverse::{hex_assign_grid_coordinates, hex_connected_components};

--- a/crates/projective-grid/src/hex/rectify.rs
+++ b/crates/projective-grid/src/hex/rectify.rs
@@ -1,0 +1,238 @@
+//! Single global homography from hex grid corners.
+//!
+//! Computes a global projective mapping between a rectified coordinate system
+//! (uniform hex lattice spacing) and the original image. Suitable when lens
+//! distortion is negligible.
+
+use crate::grid_index::GridIndex;
+use crate::homography::{estimate_homography, Homography};
+use nalgebra::Point2;
+use std::collections::HashMap;
+
+/// Sqrt(3) / 2, the vertical spacing factor for pointy-top hex grids.
+const SQRT3_HALF: f64 = 0.866_025_403_784_438_6;
+
+#[derive(thiserror::Error, Debug)]
+pub enum HexRectifyError {
+    #[error("not enough grid corners with positions (need >= 4, got {got})")]
+    NotEnoughPoints { got: usize },
+    #[error("homography estimation failed")]
+    HomographyFailed,
+    #[error("homography not invertible")]
+    NonInvertible,
+}
+
+/// A global homography mapping between rectified hex grid space and image space.
+///
+/// Rectified coordinates map axial `(q, r)` to 2D using:
+/// ```text
+/// x = px_per_cell * (q + r * 0.5)
+/// y = px_per_cell * (r * sqrt(3) / 2)
+/// ```
+#[derive(Clone, Debug)]
+pub struct HexGridHomography {
+    /// Maps rectified coordinates to image coordinates.
+    pub h_img_from_rect: Homography,
+    /// Maps image coordinates to rectified coordinates.
+    pub h_rect_from_img: Homography,
+    /// Axial bounding box (with margin).
+    pub min_q: i32,
+    pub min_r: i32,
+    pub max_q: i32,
+    pub max_r: i32,
+    /// Rectified pixels per grid cell edge.
+    pub px_per_cell: f32,
+    /// Rectified image dimensions.
+    pub rect_width: usize,
+    pub rect_height: usize,
+}
+
+impl HexGridHomography {
+    /// Compute a global homography from hex grid corners to a rectified coordinate system.
+    ///
+    /// - `corners`: map from axial grid index `(q=i, r=j)` to image position.
+    /// - `px_per_cell`: rectified pixels per grid cell edge.
+    /// - `margin_cells`: extra margin around the grid bounding box (in cell units).
+    pub fn from_corners(
+        corners: &HashMap<GridIndex, Point2<f32>>,
+        px_per_cell: f32,
+        margin_cells: f32,
+    ) -> Result<Self, HexRectifyError> {
+        if corners.len() < 4 {
+            return Err(HexRectifyError::NotEnoughPoints { got: corners.len() });
+        }
+
+        // Find axial bounding box
+        let (mut min_q, mut min_r) = (i32::MAX, i32::MAX);
+        let (mut max_q, mut max_r) = (i32::MIN, i32::MIN);
+        for g in corners.keys() {
+            min_q = min_q.min(g.i);
+            min_r = min_r.min(g.j);
+            max_q = max_q.max(g.i);
+            max_r = max_r.max(g.j);
+        }
+
+        // Compute rectified bounding box with margin
+        // x = px_per_cell * (q + r * 0.5), y = px_per_cell * (r * sqrt3/2)
+        // We need to find min/max x and y over all possible (q, r) in bounds
+        let s = px_per_cell as f64;
+        let sqrt3_half = SQRT3_HALF;
+
+        // Compute x-range: x depends on both q and r
+        let mut x_min = f64::MAX;
+        let mut x_max = f64::MIN;
+        let mut y_min = f64::MAX;
+        let mut y_max = f64::MIN;
+
+        for g in corners.keys() {
+            let x = s * (g.i as f64 + g.j as f64 * 0.5);
+            let y = s * (g.j as f64 * sqrt3_half);
+            x_min = x_min.min(x);
+            x_max = x_max.max(x);
+            y_min = y_min.min(y);
+            y_max = y_max.max(y);
+        }
+
+        let margin_px = margin_cells as f64 * s;
+        x_min -= margin_px;
+        y_min -= margin_px;
+        x_max += margin_px;
+        y_max += margin_px;
+
+        let rect_width = ((x_max - x_min).round().max(1.0)) as usize;
+        let rect_height = ((y_max - y_min).round().max(1.0)) as usize;
+
+        // Build correspondences: rectified positions vs image positions
+        let mut rect_pts = Vec::with_capacity(corners.len());
+        let mut img_pts = Vec::with_capacity(corners.len());
+        for (g, &pos) in corners {
+            let rx = s * (g.i as f64 + g.j as f64 * 0.5) - x_min;
+            let ry = s * (g.j as f64 * sqrt3_half) - y_min;
+            rect_pts.push(Point2::new(rx as f32, ry as f32));
+            img_pts.push(pos);
+        }
+
+        let h_img_from_rect =
+            estimate_homography(&rect_pts, &img_pts).ok_or(HexRectifyError::HomographyFailed)?;
+
+        let h_rect_from_img = h_img_from_rect
+            .inverse()
+            .ok_or(HexRectifyError::NonInvertible)?;
+
+        // Apply margin to axial bounds
+        let mq = min_q - margin_cells.ceil() as i32;
+        let mr = min_r - margin_cells.ceil() as i32;
+        let aq = max_q + margin_cells.ceil() as i32;
+        let ar = max_r + margin_cells.ceil() as i32;
+
+        Ok(Self {
+            h_img_from_rect,
+            h_rect_from_img,
+            min_q: mq,
+            min_r: mr,
+            max_q: aq,
+            max_r: ar,
+            px_per_cell,
+            rect_width,
+            rect_height,
+        })
+    }
+
+    /// Map a point from rectified space to image space.
+    pub fn rect_to_img(&self, p_rect: Point2<f32>) -> Point2<f32> {
+        self.h_img_from_rect.apply(p_rect)
+    }
+
+    /// Map a point from image space to rectified space.
+    pub fn img_to_rect(&self, p_img: Point2<f32>) -> Point2<f32> {
+        self.h_rect_from_img.apply(p_img)
+    }
+
+    /// Convert axial coordinates `(q, r)` to rectified pixel coordinates.
+    ///
+    /// This does **not** apply the homography — it maps grid indices to the
+    /// rectified coordinate system directly.
+    pub fn axial_to_rect(&self, q: f64, r: f64) -> Point2<f64> {
+        let s = self.px_per_cell as f64;
+        // We need the same x_min, y_min used during construction.
+        // Reconstruct from stored bounds (approximate — for exact use, store offsets).
+        // For now, use the stored min_q/min_r with margin to reconstruct.
+        let x = s * (q + r * 0.5);
+        let y = s * (r * SQRT3_HALF);
+        Point2::new(x, y)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_hex_corners(radius: i32, spacing: f32) -> HashMap<GridIndex, Point2<f32>> {
+        let sqrt3 = 3.0f32.sqrt();
+        let mut map = HashMap::new();
+        for q in -radius..=radius {
+            for r in -radius..=radius {
+                if (q + r).abs() > radius {
+                    continue;
+                }
+                let x = spacing * (q as f32 + r as f32 * 0.5);
+                let y = spacing * (r as f32 * sqrt3 / 2.0);
+                map.insert(GridIndex { i: q, j: r }, Point2::new(x, y));
+            }
+        }
+        map
+    }
+
+    #[test]
+    fn round_trip_rect_to_img() {
+        let corners = make_hex_corners(3, 60.0);
+        let h = HexGridHomography::from_corners(&corners, 60.0, 1.0).unwrap();
+
+        for &pos in corners.values() {
+            let rect = h.img_to_rect(pos);
+            let recovered = h.rect_to_img(rect);
+            assert!(
+                (recovered.x - pos.x).abs() < 0.5,
+                "x: {} vs {}",
+                recovered.x,
+                pos.x
+            );
+            assert!(
+                (recovered.y - pos.y).abs() < 0.5,
+                "y: {} vs {}",
+                recovered.y,
+                pos.y
+            );
+        }
+    }
+
+    #[test]
+    fn identity_case_with_ideal_positions() {
+        // When corners are at ideal hex positions, the homography should be
+        // close to a translation (the offset to make coordinates non-negative).
+        let corners = make_hex_corners(2, 50.0);
+        let h = HexGridHomography::from_corners(&corners, 50.0, 0.0).unwrap();
+
+        assert!(h.rect_width > 0);
+        assert!(h.rect_height > 0);
+
+        // The homography should map rectified positions close to image positions
+        for &img_pos in corners.values() {
+            // Verify round-trip: the rectified offset makes direct comparison tricky.
+            let rect_pos = h.img_to_rect(img_pos);
+            let recovered = h.rect_to_img(rect_pos);
+            assert!((recovered.x - img_pos.x).abs() < 0.1);
+            assert!((recovered.y - img_pos.y).abs() < 0.1);
+        }
+    }
+
+    #[test]
+    fn too_few_corners_errors() {
+        let mut corners = HashMap::new();
+        corners.insert(GridIndex { i: 0, j: 0 }, Point2::new(0.0, 0.0));
+        corners.insert(GridIndex { i: 1, j: 0 }, Point2::new(50.0, 0.0));
+
+        let result = HexGridHomography::from_corners(&corners, 50.0, 0.0);
+        assert!(result.is_err());
+    }
+}

--- a/crates/projective-grid/src/hex/rectify.rs
+++ b/crates/projective-grid/src/hex/rectify.rs
@@ -45,6 +45,12 @@ pub struct HexGridHomography {
     /// Rectified image dimensions.
     pub rect_width: usize,
     pub rect_height: usize,
+
+    /// Pixel-space origin offset subtracted during construction.
+    /// Needed by [`axial_to_rect`](Self::axial_to_rect) to produce coordinates
+    /// in the same frame as the stored homography.
+    x_offset: f64,
+    y_offset: f64,
 }
 
 impl HexGridHomography {
@@ -135,6 +141,8 @@ impl HexGridHomography {
             px_per_cell,
             rect_width,
             rect_height,
+            x_offset: x_min,
+            y_offset: y_min,
         })
     }
 
@@ -151,14 +159,13 @@ impl HexGridHomography {
     /// Convert axial coordinates `(q, r)` to rectified pixel coordinates.
     ///
     /// This does **not** apply the homography — it maps grid indices to the
-    /// rectified coordinate system directly.
+    /// rectified coordinate system directly. The result is in the same shifted
+    /// frame used by the stored homography, so it can be passed to
+    /// [`rect_to_img`](Self::rect_to_img).
     pub fn axial_to_rect(&self, q: f64, r: f64) -> Point2<f64> {
         let s = self.px_per_cell as f64;
-        // We need the same x_min, y_min used during construction.
-        // Reconstruct from stored bounds (approximate — for exact use, store offsets).
-        // For now, use the stored min_q/min_r with margin to reconstruct.
-        let x = s * (q + r * 0.5);
-        let y = s * (r * SQRT3_HALF);
+        let x = s * (q + r * 0.5) - self.x_offset;
+        let y = s * (r * SQRT3_HALF) - self.y_offset;
         Point2::new(x, y)
     }
 }
@@ -223,6 +230,33 @@ mod tests {
             let recovered = h.rect_to_img(rect_pos);
             assert!((recovered.x - img_pos.x).abs() < 0.1);
             assert!((recovered.y - img_pos.y).abs() < 0.1);
+        }
+    }
+
+    #[test]
+    fn axial_to_rect_then_rect_to_img_matches_corners() {
+        let corners = make_hex_corners(3, 60.0);
+        let h = HexGridHomography::from_corners(&corners, 60.0, 1.0).unwrap();
+
+        for (g, &img_pos) in &corners {
+            let rect_pt = h.axial_to_rect(g.i as f64, g.j as f64);
+            let recovered = h.rect_to_img(Point2::new(rect_pt.x as f32, rect_pt.y as f32));
+            assert!(
+                (recovered.x - img_pos.x).abs() < 0.5,
+                "x mismatch at ({},{}): {} vs {}",
+                g.i,
+                g.j,
+                recovered.x,
+                img_pos.x,
+            );
+            assert!(
+                (recovered.y - img_pos.y).abs() < 0.5,
+                "y mismatch at ({},{}): {} vs {}",
+                g.i,
+                g.j,
+                recovered.y,
+                img_pos.y,
+            );
         }
     }
 

--- a/crates/projective-grid/src/hex/smoothness.rs
+++ b/crates/projective-grid/src/hex/smoothness.rs
@@ -1,0 +1,196 @@
+//! Hex grid smoothness analysis: predict corner positions from neighbors.
+//!
+//! For each hex grid corner, the expected position can be predicted from its
+//! immediate neighbors along three axial directions via midpoint averaging.
+//! Corners that deviate significantly from the prediction are likely false detections.
+
+use crate::grid_index::GridIndex;
+use nalgebra::Point2;
+use std::collections::HashMap;
+
+/// Opposite-pair deltas for the three hex axes (axial coordinates).
+///
+/// Each entry is `((dq_neg, dr_neg), (dq_pos, dr_pos))`.
+const HEX_AXIS_PAIRS: [((i32, i32), (i32, i32)); 3] = [
+    // E/W axis
+    ((-1, 0), (1, 0)),
+    // NE/SW axis
+    ((1, -1), (-1, 1)),
+    // NW/SE axis
+    ((0, -1), (0, 1)),
+];
+
+/// Predict a hex grid corner's position from its neighbors along three axes.
+///
+/// Uses midpoint averaging on up to three opposite-direction pairs:
+/// - E/W: midpoint of `(q-1, r)` and `(q+1, r)`
+/// - NE/SW: midpoint of `(q+1, r-1)` and `(q-1, r+1)`
+/// - NW/SE: midpoint of `(q, r-1)` and `(q, r+1)`
+///
+/// Returns the average of available predictions, or `None` if no complete
+/// neighbor pair exists.
+pub fn hex_predict_grid_position(
+    grid: &HashMap<GridIndex, Point2<f32>>,
+    idx: GridIndex,
+) -> Option<Point2<f32>> {
+    let mut pred_sum = Point2::new(0.0f32, 0.0f32);
+    let mut pred_count = 0u32;
+
+    for &((dq_a, dr_a), (dq_b, dr_b)) in &HEX_AXIS_PAIRS {
+        let a = GridIndex {
+            i: idx.i + dq_a,
+            j: idx.j + dr_a,
+        };
+        let b = GridIndex {
+            i: idx.i + dq_b,
+            j: idx.j + dr_b,
+        };
+        if let (Some(&pa), Some(&pb)) = (grid.get(&a), grid.get(&b)) {
+            pred_sum.x += 0.5 * (pa.x + pb.x);
+            pred_sum.y += 0.5 * (pa.y + pb.y);
+            pred_count += 1;
+        }
+    }
+
+    if pred_count == 0 {
+        return None;
+    }
+
+    Some(Point2::new(
+        pred_sum.x / pred_count as f32,
+        pred_sum.y / pred_count as f32,
+    ))
+}
+
+/// Find hex grid corners whose position deviates from the neighbor-predicted
+/// position by more than `threshold` pixels.
+///
+/// Returns `(grid_index, predicted_position)` for each inconsistent corner.
+pub fn hex_find_inconsistent_corners(
+    grid: &HashMap<GridIndex, Point2<f32>>,
+    threshold: f32,
+) -> Vec<(GridIndex, Point2<f32>)> {
+    let threshold_sq = threshold * threshold;
+    let mut flagged = Vec::new();
+
+    for (&idx, &pos) in grid {
+        if let Some(predicted) = hex_predict_grid_position(grid, idx) {
+            let dx = pos.x - predicted.x;
+            let dy = pos.y - predicted.y;
+            if dx * dx + dy * dy > threshold_sq {
+                flagged.push((idx, predicted));
+            }
+        }
+    }
+
+    flagged
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_hex_grid(radius: i32, spacing: f32) -> HashMap<GridIndex, Point2<f32>> {
+        let sqrt3 = 3.0f32.sqrt();
+        let mut map = HashMap::new();
+        for q in -radius..=radius {
+            for r in -radius..=radius {
+                if (q + r).abs() > radius {
+                    continue;
+                }
+                let x = spacing * (q as f32 + r as f32 * 0.5);
+                let y = spacing * (r as f32 * sqrt3 / 2.0);
+                map.insert(GridIndex { i: q, j: r }, Point2::new(x, y));
+            }
+        }
+        map
+    }
+
+    #[test]
+    fn clean_hex_grid_has_no_inconsistencies() {
+        let grid = make_hex_grid(3, 60.0);
+        let flagged = hex_find_inconsistent_corners(&grid, 3.0);
+        assert!(flagged.is_empty());
+    }
+
+    #[test]
+    fn displaced_corner_is_flagged() {
+        let mut grid = make_hex_grid(2, 60.0);
+        let center = GridIndex { i: 0, j: 0 };
+        // Displace center by (9, 9) pixels
+        grid.insert(center, Point2::new(9.0, 9.0));
+
+        let flagged = hex_find_inconsistent_corners(&grid, 3.0);
+        assert_eq!(1, flagged.len());
+        assert_eq!(center, flagged[0].0);
+
+        // Predicted should be near (0, 0) — the ideal center
+        let pred = flagged[0].1;
+        assert!(pred.x.abs() < 0.01, "pred.x = {}", pred.x);
+        assert!(pred.y.abs() < 0.01, "pred.y = {}", pred.y);
+    }
+
+    #[test]
+    fn isolated_nodes_are_skipped() {
+        let mut grid = HashMap::new();
+        grid.insert(GridIndex { i: 0, j: 0 }, Point2::new(0.0, 0.0));
+        grid.insert(GridIndex { i: 10, j: 10 }, Point2::new(500.0, 500.0));
+
+        let flagged = hex_find_inconsistent_corners(&grid, 3.0);
+        assert!(flagged.is_empty());
+    }
+
+    #[test]
+    fn prediction_from_single_axis_pair() {
+        let spacing = 60.0;
+        let sqrt3 = 3.0f32.sqrt();
+        let mut grid = HashMap::new();
+        // Just three points along the E/W axis: q = -1, 0, 1 at r = 0
+        grid.insert(GridIndex { i: -1, j: 0 }, Point2::new(-spacing, 0.0));
+        grid.insert(GridIndex { i: 0, j: 0 }, Point2::new(0.0, 0.0));
+        grid.insert(GridIndex { i: 1, j: 0 }, Point2::new(spacing, 0.0));
+
+        let pred = hex_predict_grid_position(&grid, GridIndex { i: 0, j: 0 }).unwrap();
+        assert!((pred.x - 0.0).abs() < 0.01);
+        assert!((pred.y - 0.0).abs() < 0.01);
+
+        // Three points along the NW/SE axis: (0,-1), (0,0), (0,1)
+        let mut grid2 = HashMap::new();
+        grid2.insert(
+            GridIndex { i: 0, j: -1 },
+            Point2::new(-0.5 * spacing, -sqrt3 / 2.0 * spacing),
+        );
+        grid2.insert(GridIndex { i: 0, j: 0 }, Point2::new(0.0, 0.0));
+        grid2.insert(
+            GridIndex { i: 0, j: 1 },
+            Point2::new(0.5 * spacing, sqrt3 / 2.0 * spacing),
+        );
+
+        let pred2 = hex_predict_grid_position(&grid2, GridIndex { i: 0, j: 0 }).unwrap();
+        assert!((pred2.x - 0.0).abs() < 0.01);
+        assert!((pred2.y - 0.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn perspective_distorted_hex_grid_passes() {
+        let spacing = 60.0;
+        let sqrt3 = 3.0f32.sqrt();
+        let mut grid = HashMap::new();
+        let radius: i32 = 3;
+        for q in -radius..=radius {
+            for r in -radius..=radius {
+                if (q + r).abs() > radius {
+                    continue;
+                }
+                let x = spacing * (q as f32 + r as f32 * 0.5);
+                let y = spacing * (r as f32 * sqrt3 / 2.0);
+                // Mild perspective: scale increases with y
+                let scale = 1.0 + 0.01 * y / spacing;
+                grid.insert(GridIndex { i: q, j: r }, Point2::new(x * scale, y * scale));
+            }
+        }
+
+        let flagged = hex_find_inconsistent_corners(&grid, 3.0);
+        assert!(flagged.is_empty());
+    }
+}

--- a/crates/projective-grid/src/hex/traverse.rs
+++ b/crates/projective-grid/src/hex/traverse.rs
@@ -1,0 +1,203 @@
+//! Connected components and BFS coordinate assignment for hex grid graphs.
+
+use crate::grid_index::GridIndex;
+use crate::hex::graph::HexGridGraph;
+
+/// Find connected components in the hex grid graph.
+///
+/// Returns a list of components, each being a list of node indices.
+/// Components are found via iterative DFS.
+pub fn hex_connected_components(graph: &HexGridGraph) -> Vec<Vec<usize>> {
+    let mut visited = vec![false; graph.neighbors.len()];
+    let mut components = Vec::new();
+
+    for start in 0..graph.neighbors.len() {
+        if visited[start] {
+            continue;
+        }
+
+        let mut component = Vec::new();
+        let mut stack = vec![start];
+
+        while let Some(node) = stack.pop() {
+            if visited[node] {
+                continue;
+            }
+            visited[node] = true;
+            component.push(node);
+
+            for neighbor in &graph.neighbors[node] {
+                if !visited[neighbor.index] {
+                    stack.push(neighbor.index);
+                }
+            }
+        }
+
+        components.push(component);
+    }
+
+    components
+}
+
+/// Assign axial grid coordinates `(q, r)` to nodes in a connected component via BFS.
+///
+/// Starts from the first node in `component` at `(0, 0)` and propagates
+/// coordinates using hex direction deltas.
+///
+/// Returns `(node_index, GridIndex)` for each reachable node, where
+/// `GridIndex.i` is `q` and `GridIndex.j` is `r`.
+pub fn hex_assign_grid_coordinates(
+    graph: &HexGridGraph,
+    component: &[usize],
+) -> Vec<(usize, GridIndex)> {
+    let mut coords = Vec::new();
+    let mut visited = vec![false; graph.neighbors.len()];
+    let mut queue = std::collections::VecDeque::new();
+
+    let start = component[0];
+    queue.push_back((start, 0i32, 0i32));
+
+    while let Some((node_idx, q, r)) = queue.pop_front() {
+        if visited[node_idx] {
+            continue;
+        }
+        visited[node_idx] = true;
+        coords.push((node_idx, GridIndex { i: q, j: r }));
+
+        for neighbor in &graph.neighbors[node_idx] {
+            let (dq, dr) = neighbor.direction.delta();
+            queue.push_back((neighbor.index, q + dq, r + dr));
+        }
+    }
+
+    coords
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph::{GridGraphParams, NeighborCandidate};
+    use crate::hex::direction::HexDirection;
+    use crate::hex::graph::{HexGridGraph, HexNeighborValidator};
+    use nalgebra::Point2;
+    use std::collections::HashMap;
+
+    struct AngleValidator;
+
+    impl HexNeighborValidator for AngleValidator {
+        type PointData = ();
+        fn validate(
+            &self,
+            _si: usize,
+            _sd: &(),
+            c: &NeighborCandidate,
+            _cd: &(),
+        ) -> Option<(HexDirection, f32)> {
+            let deg = c.offset.y.atan2(c.offset.x).to_degrees();
+            let dir = if (-30.0..30.0).contains(&deg) {
+                HexDirection::East
+            } else if (30.0..90.0).contains(&deg) {
+                HexDirection::SouthEast
+            } else if (90.0..150.0).contains(&deg) {
+                HexDirection::SouthWest
+            } else if !(-150.0..150.0).contains(&deg) {
+                HexDirection::West
+            } else if (-150.0..-90.0).contains(&deg) {
+                HexDirection::NorthWest
+            } else {
+                HexDirection::NorthEast
+            };
+            Some((dir, c.distance))
+        }
+    }
+
+    type HexLattice = (Vec<Point2<f32>>, HashMap<(i32, i32), usize>);
+
+    fn hex_lattice(radius: i32, spacing: f32) -> HexLattice {
+        let sqrt3 = 3.0f32.sqrt();
+        let mut points = Vec::new();
+        let mut idx_map = HashMap::new();
+        for q in -radius..=radius {
+            for r in -radius..=radius {
+                if (q + r).abs() > radius {
+                    continue;
+                }
+                let x = spacing * (q as f32 + r as f32 * 0.5);
+                let y = spacing * (r as f32 * sqrt3 / 2.0);
+                idx_map.insert((q, r), points.len());
+                points.push(Point2::new(x, y));
+            }
+        }
+        (points, idx_map)
+    }
+
+    #[test]
+    fn single_component_for_connected_hex() {
+        let (points, _) = hex_lattice(2, 50.0);
+        let data = vec![(); points.len()];
+        let params = GridGraphParams {
+            k_neighbors: 12,
+            max_distance: 75.0,
+        };
+        let graph = HexGridGraph::build(&points, &data, &AngleValidator, &params);
+        let components = hex_connected_components(&graph);
+        assert_eq!(components.len(), 1);
+        assert_eq!(components[0].len(), points.len());
+    }
+
+    #[test]
+    fn bfs_assigns_correct_axial_coordinates() {
+        let spacing = 50.0;
+        let (points, expected) = hex_lattice(2, spacing);
+        let data = vec![(); points.len()];
+        let params = GridGraphParams {
+            k_neighbors: 12,
+            max_distance: spacing * 1.5,
+        };
+        let graph = HexGridGraph::build(&points, &data, &AngleValidator, &params);
+        let components = hex_connected_components(&graph);
+        let coords = hex_assign_grid_coordinates(&graph, &components[0]);
+
+        assert_eq!(coords.len(), points.len());
+
+        // Find the BFS origin to determine the offset
+        let (origin_idx, _) = coords[0];
+        let origin_qr = expected
+            .iter()
+            .find(|(_, &idx)| idx == origin_idx)
+            .map(|(&qr, _)| qr)
+            .unwrap();
+
+        // All assigned coordinates should differ from expected by the same offset
+        let mut coord_map: HashMap<usize, (i32, i32)> = HashMap::new();
+        for &(node_idx, ref gi) in &coords {
+            coord_map.insert(node_idx, (gi.i, gi.j));
+        }
+
+        let offset_q = 0 - origin_qr.0;
+        let offset_r = 0 - origin_qr.1;
+
+        for (&(exp_q, exp_r), &node_idx) in &expected {
+            let (got_q, got_r) = coord_map[&node_idx];
+            assert_eq!(
+                (got_q, got_r),
+                (exp_q + offset_q, exp_r + offset_r),
+                "coordinate mismatch for node {node_idx}"
+            );
+        }
+    }
+
+    #[test]
+    fn disconnected_components_found() {
+        // Two isolated points
+        let points = vec![Point2::new(0.0, 0.0), Point2::new(1000.0, 1000.0)];
+        let data = vec![(); 2];
+        let params = GridGraphParams {
+            k_neighbors: 4,
+            max_distance: 100.0,
+        };
+        let graph = HexGridGraph::build(&points, &data, &AngleValidator, &params);
+        let components = hex_connected_components(&graph);
+        assert_eq!(components.len(), 2);
+    }
+}

--- a/crates/projective-grid/src/lib.rs
+++ b/crates/projective-grid/src/lib.rs
@@ -12,6 +12,11 @@
 //!
 //! The [`hex`] module provides 6-connected hexagonal grid counterparts for
 //! pointy-top axial coordinates `(q, r)`.
+//!
+//! # Built-in Validators
+//!
+//! The [`validators`] module provides ready-to-use implementations of
+//! [`NeighborValidator`] and [`hex::HexNeighborValidator`] for common scenarios.
 
 pub mod direction;
 pub mod graph;
@@ -23,6 +28,7 @@ pub mod grid_smoothness;
 pub mod hex;
 pub mod homography;
 pub mod traverse;
+pub mod validators;
 
 pub use direction::{NeighborDirection, NodeNeighbor};
 pub use graph::{GridGraph, GridGraphParams, NeighborCandidate, NeighborValidator};

--- a/crates/projective-grid/src/lib.rs
+++ b/crates/projective-grid/src/lib.rs
@@ -7,6 +7,11 @@
 //! It is pattern-agnostic: the [`NeighborValidator`] trait lets callers plug in
 //! pattern-specific logic (chessboard orientation checks, marker constraints, etc.)
 //! while the graph construction, traversal, and geometry remain generic.
+//!
+//! # Hex Grid Support
+//!
+//! The [`hex`] module provides 6-connected hexagonal grid counterparts for
+//! pointy-top axial coordinates `(q, r)`.
 
 pub mod direction;
 pub mod graph;
@@ -15,6 +20,7 @@ pub mod grid_index;
 pub mod grid_mesh;
 pub mod grid_rectify;
 pub mod grid_smoothness;
+pub mod hex;
 pub mod homography;
 pub mod traverse;
 

--- a/crates/projective-grid/src/validators.rs
+++ b/crates/projective-grid/src/validators.rs
@@ -1,0 +1,662 @@
+//! Ready-to-use [`NeighborValidator`] and [`HexNeighborValidator`] implementations
+//! for common grid detection scenarios.
+//!
+//! | Validator | Grid | PointData | Use case |
+//! |-----------|------|-----------|----------|
+//! | [`XJunctionValidator`] | Square | `f32` (orientation mod π) | ChESS corners, chessboard X-junctions |
+//! | [`SpatialSquareValidator`] | Square | `()` | Unoriented features on a square lattice |
+//! | [`SpatialHexValidator`] | Hex | `()` | Unoriented features on a hex lattice (ringgrid, etc.) |
+
+use crate::direction::NeighborDirection;
+use crate::graph::{NeighborCandidate, NeighborValidator};
+use crate::hex::direction::HexDirection;
+use crate::hex::graph::HexNeighborValidator;
+use nalgebra::Vector2;
+
+// ---------------------------------------------------------------------------
+// Geometry helpers
+// ---------------------------------------------------------------------------
+
+/// Absolute angle difference in `[0, π]`.
+fn angle_diff_abs(a: f32, b: f32) -> f32 {
+    let two_pi = 2.0 * std::f32::consts::PI;
+    let mut diff = (b - a).rem_euclid(two_pi);
+    if diff >= std::f32::consts::PI {
+        diff -= two_pi;
+    }
+    diff.abs()
+}
+
+/// Check whether two undirected axes (angles mod π) are approximately orthogonal.
+fn is_orthogonal(a: f32, b: f32, tolerance: f32) -> bool {
+    let diff = angle_diff_abs(a, b);
+    (std::f32::consts::FRAC_PI_2 - diff).abs() <= tolerance.abs()
+}
+
+/// Angle between an undirected axis `axis_angle` (mod π) and a directed vector
+/// `vec_angle`. Returns a value in `[0, π/2]`.
+fn axis_vec_diff(axis_angle: f32, vec_angle: f32) -> f32 {
+    let two_pi = 2.0 * std::f32::consts::PI;
+    let mut diff = (vec_angle - axis_angle).rem_euclid(two_pi);
+    if diff >= std::f32::consts::PI {
+        diff -= two_pi;
+    }
+    let diff_abs = diff.abs();
+    diff_abs.min(std::f32::consts::PI - diff_abs)
+}
+
+/// Classify an offset vector into one of 4 cardinal directions by quadrant.
+fn direction_quadrant(offset: &Vector2<f32>) -> NeighborDirection {
+    if offset.x.abs() > offset.y.abs() {
+        if offset.x >= 0.0 {
+            NeighborDirection::Right
+        } else {
+            NeighborDirection::Left
+        }
+    } else if offset.y >= 0.0 {
+        NeighborDirection::Down
+    } else {
+        NeighborDirection::Up
+    }
+}
+
+/// Classify an offset vector into one of 6 hex directions by sextant (60° sectors).
+fn direction_sextant(offset: &Vector2<f32>) -> HexDirection {
+    let deg = offset.y.atan2(offset.x).to_degrees();
+    if (-30.0..30.0).contains(&deg) {
+        HexDirection::East
+    } else if (30.0..90.0).contains(&deg) {
+        HexDirection::SouthEast
+    } else if (90.0..150.0).contains(&deg) {
+        HexDirection::SouthWest
+    } else if !(-150.0..150.0).contains(&deg) {
+        HexDirection::West
+    } else if (-150.0..-90.0).contains(&deg) {
+        HexDirection::NorthWest
+    } else {
+        HexDirection::NorthEast
+    }
+}
+
+// ---------------------------------------------------------------------------
+// XJunctionValidator
+// ---------------------------------------------------------------------------
+
+/// Validator for **square grids** of X-junction corners with known orientation.
+///
+/// Designed for ChESS-like features where each corner has an orientation angle
+/// (mod π) and adjacent corners on a chessboard pattern have orthogonal
+/// orientations. The edge between two neighbors is at ~45° to both orientations.
+///
+/// # PointData
+///
+/// `f32` — the corner's orientation angle in radians (mod π, undirected axis).
+///
+/// # Example
+///
+/// ```
+/// use projective_grid::{GridGraph, GridGraphParams, NeighborCandidate};
+/// use projective_grid::validators::XJunctionValidator;
+/// use nalgebra::Point2;
+/// use std::f32::consts::FRAC_PI_4;
+///
+/// let positions = vec![
+///     Point2::new(0.0f32, 0.0), Point2::new(10.0, 0.0),
+///     Point2::new(0.0, 10.0),   Point2::new(10.0, 10.0),
+/// ];
+/// // Alternating orientations (π/4 and 3π/4) like a chessboard
+/// let orientations = vec![FRAC_PI_4, 3.0 * FRAC_PI_4, 3.0 * FRAC_PI_4, FRAC_PI_4];
+///
+/// let validator = XJunctionValidator {
+///     min_spacing: 5.0,
+///     max_spacing: 15.0,
+///     tolerance_rad: 15.0f32.to_radians(),
+/// };
+/// let graph = GridGraph::build(
+///     &positions, &orientations, &validator, &GridGraphParams::default(),
+/// );
+/// ```
+pub struct XJunctionValidator {
+    /// Minimum acceptable neighbor distance (pixels).
+    pub min_spacing: f32,
+    /// Maximum acceptable neighbor distance (pixels).
+    pub max_spacing: f32,
+    /// Angular tolerance (radians) for orthogonality and 45° edge alignment checks.
+    pub tolerance_rad: f32,
+}
+
+impl NeighborValidator for XJunctionValidator {
+    type PointData = f32;
+
+    fn validate(
+        &self,
+        _source_index: usize,
+        source_data: &f32,
+        candidate: &NeighborCandidate,
+        candidate_data: &f32,
+    ) -> Option<(NeighborDirection, f32)> {
+        // 1. Orientations must be approximately orthogonal.
+        if !is_orthogonal(*source_data, *candidate_data, self.tolerance_rad) {
+            return None;
+        }
+
+        // 2. Distance within range.
+        if candidate.distance < self.min_spacing || candidate.distance > self.max_spacing {
+            return None;
+        }
+
+        // 3. Edge direction should be at ~45° to both corner orientations.
+        let edge_angle = candidate.offset.y.atan2(candidate.offset.x);
+        let expected = std::f32::consts::FRAC_PI_4;
+
+        let score_src = (axis_vec_diff(*source_data, edge_angle) - expected).abs();
+        let score_cand = (axis_vec_diff(*candidate_data, edge_angle) - expected).abs();
+
+        if score_src > self.tolerance_rad || score_cand > self.tolerance_rad {
+            return None;
+        }
+
+        // 4. Direction by image-space quadrant.
+        let direction = direction_quadrant(&candidate.offset);
+
+        // 5. Score: angular deviations + orientation orthogonality residual.
+        let score_ortho =
+            (std::f32::consts::FRAC_PI_2 - angle_diff_abs(*source_data, *candidate_data)).abs();
+        let score = score_src + score_cand + score_ortho;
+
+        Some((direction, score))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SpatialSquareValidator
+// ---------------------------------------------------------------------------
+
+/// Validator for **square grids** with no orientation information.
+///
+/// Classifies neighbors by image-space quadrant and filters by distance.
+/// Suitable for any approximately regular square lattice of detected features.
+///
+/// # PointData
+///
+/// `()` — no per-point data needed.
+pub struct SpatialSquareValidator {
+    /// Minimum acceptable neighbor distance (pixels).
+    pub min_spacing: f32,
+    /// Maximum acceptable neighbor distance (pixels).
+    pub max_spacing: f32,
+}
+
+impl NeighborValidator for SpatialSquareValidator {
+    type PointData = ();
+
+    fn validate(
+        &self,
+        _source_index: usize,
+        _source_data: &(),
+        candidate: &NeighborCandidate,
+        _candidate_data: &(),
+    ) -> Option<(NeighborDirection, f32)> {
+        if candidate.distance < self.min_spacing || candidate.distance > self.max_spacing {
+            return None;
+        }
+
+        let direction = direction_quadrant(&candidate.offset);
+        Some((direction, candidate.distance))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SpatialHexValidator
+// ---------------------------------------------------------------------------
+
+/// Validator for **hex grids** with no orientation information.
+///
+/// Classifies neighbors into 6 sextant directions and filters by distance.
+/// Suitable for hex lattices of circular markers (ringgrid), blob detections,
+/// or any approximately regular hex arrangement.
+///
+/// # PointData
+///
+/// `()` — no per-point data needed.
+pub struct SpatialHexValidator {
+    /// Minimum acceptable neighbor distance (pixels).
+    pub min_spacing: f32,
+    /// Maximum acceptable neighbor distance (pixels).
+    pub max_spacing: f32,
+}
+
+impl HexNeighborValidator for SpatialHexValidator {
+    type PointData = ();
+
+    fn validate(
+        &self,
+        _source_index: usize,
+        _source_data: &(),
+        candidate: &NeighborCandidate,
+        _candidate_data: &(),
+    ) -> Option<(HexDirection, f32)> {
+        if candidate.distance < self.min_spacing || candidate.distance > self.max_spacing {
+            return None;
+        }
+
+        let direction = direction_sextant(&candidate.offset);
+        Some((direction, candidate.distance))
+    }
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph::GridGraphParams;
+    use crate::hex::graph::HexGridGraph;
+    use crate::hex::traverse::{hex_assign_grid_coordinates, hex_connected_components};
+    use crate::traverse::{assign_grid_coordinates, connected_components};
+    use crate::{GridGraph, NodeNeighbor};
+    use nalgebra::Point2;
+    use std::collections::HashMap;
+    use std::f32::consts::FRAC_PI_4;
+
+    fn neighbor_map(neighbors: &[NodeNeighbor]) -> HashMap<NeighborDirection, &NodeNeighbor> {
+        neighbors.iter().map(|n| (n.direction, n)).collect()
+    }
+
+    // -----------------------------------------------------------------------
+    // XJunctionValidator tests
+    // -----------------------------------------------------------------------
+
+    fn make_chess_grid(rows: usize, cols: usize, spacing: f32) -> (Vec<Point2<f32>>, Vec<f32>) {
+        let mut positions = Vec::new();
+        let mut orientations = Vec::new();
+        for j in 0..rows {
+            for i in 0..cols {
+                positions.push(Point2::new(i as f32 * spacing, j as f32 * spacing));
+                orientations.push(if (i + j) % 2 == 0 {
+                    FRAC_PI_4
+                } else {
+                    3.0 * FRAC_PI_4
+                });
+            }
+        }
+        (positions, orientations)
+    }
+
+    #[test]
+    fn xjunction_regular_grid_center_has_four_neighbors() {
+        let spacing = 10.0;
+        let (positions, orientations) = make_chess_grid(3, 3, spacing);
+
+        let validator = XJunctionValidator {
+            min_spacing: 5.0,
+            max_spacing: 15.0,
+            tolerance_rad: 15.0f32.to_radians(),
+        };
+        let graph = GridGraph::build(
+            &positions,
+            &orientations,
+            &validator,
+            &GridGraphParams::default(),
+        );
+
+        let idx = |i: usize, j: usize| j * 3 + i;
+        let center = neighbor_map(&graph.neighbors[idx(1, 1)]);
+        assert_eq!(4, center.len());
+        assert_eq!(idx(0, 1), center[&NeighborDirection::Left].index);
+        assert_eq!(idx(2, 1), center[&NeighborDirection::Right].index);
+        assert_eq!(idx(1, 0), center[&NeighborDirection::Up].index);
+        assert_eq!(idx(1, 2), center[&NeighborDirection::Down].index);
+    }
+
+    #[test]
+    fn xjunction_rejects_parallel_orientations() {
+        let spacing = 10.0;
+        let positions = vec![Point2::new(0.0, 0.0), Point2::new(spacing, 0.0)];
+        // Same orientation — should be rejected
+        let orientations = vec![FRAC_PI_4, FRAC_PI_4];
+
+        let validator = XJunctionValidator {
+            min_spacing: 5.0,
+            max_spacing: 15.0,
+            tolerance_rad: 15.0f32.to_radians(),
+        };
+        let graph = GridGraph::build(
+            &positions,
+            &orientations,
+            &validator,
+            &GridGraphParams {
+                k_neighbors: 2,
+                ..Default::default()
+            },
+        );
+
+        assert!(graph.neighbors[0].is_empty());
+        assert!(graph.neighbors[1].is_empty());
+    }
+
+    #[test]
+    fn xjunction_rejects_out_of_range_distance() {
+        let spacing = 30.0;
+        let positions = vec![Point2::new(0.0, 0.0), Point2::new(spacing, 0.0)];
+        let orientations = vec![FRAC_PI_4, 3.0 * FRAC_PI_4];
+
+        let validator = XJunctionValidator {
+            min_spacing: 5.0,
+            max_spacing: 15.0, // 30 > 15, rejected
+            tolerance_rad: 15.0f32.to_radians(),
+        };
+        let graph = GridGraph::build(
+            &positions,
+            &orientations,
+            &validator,
+            &GridGraphParams::default(),
+        );
+
+        assert!(graph.neighbors[0].is_empty());
+        assert!(graph.neighbors[1].is_empty());
+    }
+
+    #[test]
+    fn xjunction_rotated_grid_forms_single_component() {
+        let spacing = 20.0;
+        let angle = 40.0f32.to_radians();
+        let ax = Vector2::new(angle.cos(), angle.sin());
+        let ay = Vector2::new(-angle.sin(), angle.cos());
+        let cols = 4usize;
+        let rows = 4usize;
+
+        let diag0 = angle + FRAC_PI_4;
+        let diag1 = angle + 3.0 * FRAC_PI_4;
+
+        let mut positions = Vec::new();
+        let mut orientations = Vec::new();
+        for j in 0..rows {
+            for i in 0..cols {
+                let pos = ax * (i as f32 * spacing) + ay * (j as f32 * spacing);
+                positions.push(Point2::new(pos.x + 100.0, pos.y + 100.0));
+                orientations.push(if (i + j) % 2 == 0 { diag0 } else { diag1 });
+            }
+        }
+
+        let validator = XJunctionValidator {
+            min_spacing: spacing * 0.5,
+            max_spacing: spacing * 1.5,
+            tolerance_rad: 20.0f32.to_radians(),
+        };
+        let graph = GridGraph::build(
+            &positions,
+            &orientations,
+            &validator,
+            &GridGraphParams {
+                k_neighbors: 8,
+                ..Default::default()
+            },
+        );
+
+        let components = connected_components(&graph);
+        assert_eq!(1, components.len());
+        assert_eq!(cols * rows, components[0].len());
+
+        let coords = assign_grid_coordinates(&graph, &components[0]);
+        let coord_set: std::collections::HashSet<(i32, i32)> =
+            coords.iter().map(|&(_, g)| (g.i, g.j)).collect();
+        assert_eq!(cols * rows, coord_set.len());
+    }
+
+    #[test]
+    fn xjunction_direction_symmetry() {
+        let spacing = 20.0;
+        let (positions, orientations) = make_chess_grid(3, 3, spacing);
+
+        let validator = XJunctionValidator {
+            min_spacing: spacing * 0.5,
+            max_spacing: spacing * 1.5,
+            tolerance_rad: 15.0f32.to_radians(),
+        };
+        let graph = GridGraph::build(
+            &positions,
+            &orientations,
+            &validator,
+            &GridGraphParams::default(),
+        );
+
+        for (a, neighbors) in graph.neighbors.iter().enumerate() {
+            for n in neighbors {
+                let b = n.index;
+                let back = graph.neighbors[b].iter().find(|nn| nn.index == a);
+                assert!(
+                    back.is_some(),
+                    "Edge {a}->{b} exists but reverse {b}->{a} does not"
+                );
+                assert_eq!(n.direction.opposite(), back.unwrap().direction,);
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // SpatialSquareValidator tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn spatial_square_regular_grid_center_has_four() {
+        let spacing = 10.0;
+        let mut positions = Vec::new();
+        for j in 0..3 {
+            for i in 0..3 {
+                positions.push(Point2::new(i as f32 * spacing, j as f32 * spacing));
+            }
+        }
+        let data = vec![(); positions.len()];
+
+        let validator = SpatialSquareValidator {
+            min_spacing: 5.0,
+            max_spacing: 15.0,
+        };
+        let graph = GridGraph::build(&positions, &data, &validator, &GridGraphParams::default());
+
+        let idx = |i: usize, j: usize| j * 3 + i;
+        let center = neighbor_map(&graph.neighbors[idx(1, 1)]);
+        assert_eq!(4, center.len());
+        assert_eq!(idx(0, 1), center[&NeighborDirection::Left].index);
+        assert_eq!(idx(2, 1), center[&NeighborDirection::Right].index);
+        assert_eq!(idx(1, 0), center[&NeighborDirection::Up].index);
+        assert_eq!(idx(1, 2), center[&NeighborDirection::Down].index);
+    }
+
+    #[test]
+    fn spatial_square_rejects_out_of_range() {
+        let positions = vec![
+            Point2::new(0.0f32, 0.0),
+            Point2::new(3.0, 0.0),  // too close
+            Point2::new(50.0, 0.0), // too far
+        ];
+        let data = vec![(); 3];
+
+        let validator = SpatialSquareValidator {
+            min_spacing: 5.0,
+            max_spacing: 15.0,
+        };
+        let graph = GridGraph::build(&positions, &data, &validator, &GridGraphParams::default());
+
+        assert!(graph.neighbors[0].is_empty());
+    }
+
+    #[test]
+    fn spatial_square_score_prefers_closest() {
+        let positions = vec![
+            Point2::new(0.0f32, 0.0),
+            Point2::new(8.0, 0.0),  // closer
+            Point2::new(12.0, 0.0), // farther, same quadrant
+        ];
+        let data = vec![(); 3];
+
+        let validator = SpatialSquareValidator {
+            min_spacing: 5.0,
+            max_spacing: 15.0,
+        };
+        let graph = GridGraph::build(&positions, &data, &validator, &GridGraphParams::default());
+
+        let right = graph.neighbors[0]
+            .iter()
+            .find(|n| n.direction == NeighborDirection::Right)
+            .unwrap();
+        assert_eq!(1, right.index); // closer one wins
+    }
+
+    #[test]
+    fn spatial_square_diagonal_grid_works() {
+        // Grid rotated 45° — quadrant classification still assigns consistent directions
+        let spacing = 10.0;
+        let angle = 45.0f32.to_radians();
+        let ax = Vector2::new(angle.cos(), angle.sin());
+        let ay = Vector2::new(-angle.sin(), angle.cos());
+
+        let mut positions = Vec::new();
+        for j in 0..3 {
+            for i in 0..3 {
+                let pos = ax * (i as f32 * spacing) + ay * (j as f32 * spacing);
+                positions.push(Point2::new(pos.x + 50.0, pos.y + 50.0));
+            }
+        }
+        let data = vec![(); positions.len()];
+
+        let validator = SpatialSquareValidator {
+            min_spacing: spacing * 0.5,
+            max_spacing: spacing * 1.5,
+        };
+        let graph = GridGraph::build(&positions, &data, &validator, &GridGraphParams::default());
+
+        let components = connected_components(&graph);
+        assert_eq!(1, components.len());
+        assert_eq!(9, components[0].len());
+    }
+
+    // -----------------------------------------------------------------------
+    // SpatialHexValidator tests
+    // -----------------------------------------------------------------------
+
+    fn hex_lattice(radius: i32, spacing: f32) -> Vec<Point2<f32>> {
+        let sqrt3 = 3.0f32.sqrt();
+        let mut points = Vec::new();
+        for q in -radius..=radius {
+            for r in -radius..=radius {
+                if (q + r).abs() > radius {
+                    continue;
+                }
+                let x = spacing * (q as f32 + r as f32 * 0.5);
+                let y = spacing * (r as f32 * sqrt3 / 2.0);
+                points.push(Point2::new(x, y));
+            }
+        }
+        points
+    }
+
+    #[test]
+    fn spatial_hex_center_has_six_neighbors() {
+        let spacing = 50.0;
+        let points = hex_lattice(2, spacing);
+        let data = vec![(); points.len()];
+
+        let validator = SpatialHexValidator {
+            min_spacing: spacing * 0.5,
+            max_spacing: spacing * 1.5,
+        };
+        let graph = HexGridGraph::build(
+            &points,
+            &data,
+            &validator,
+            &GridGraphParams {
+                k_neighbors: 12,
+                ..Default::default()
+            },
+        );
+
+        let center = points
+            .iter()
+            .position(|p| p.x.abs() < 0.01 && p.y.abs() < 0.01)
+            .unwrap();
+        assert_eq!(6, graph.neighbors[center].len());
+    }
+
+    #[test]
+    fn spatial_hex_edge_nodes_have_three() {
+        let spacing = 50.0;
+        let points = hex_lattice(1, spacing);
+        let data = vec![(); points.len()];
+
+        let validator = SpatialHexValidator {
+            min_spacing: spacing * 0.5,
+            max_spacing: spacing * 1.5,
+        };
+        let graph = HexGridGraph::build(
+            &points,
+            &data,
+            &validator,
+            &GridGraphParams {
+                k_neighbors: 12,
+                ..Default::default()
+            },
+        );
+
+        for (i, p) in points.iter().enumerate() {
+            if p.x.abs() < 0.01 && p.y.abs() < 0.01 {
+                assert_eq!(6, graph.neighbors[i].len());
+            } else {
+                assert_eq!(3, graph.neighbors[i].len());
+            }
+        }
+    }
+
+    #[test]
+    fn spatial_hex_rejects_out_of_range() {
+        let points = vec![
+            Point2::new(0.0f32, 0.0),
+            Point2::new(3.0, 0.0), // too close
+        ];
+        let data = vec![(); 2];
+
+        let validator = SpatialHexValidator {
+            min_spacing: 10.0,
+            max_spacing: 50.0,
+        };
+        let graph = HexGridGraph::build(&points, &data, &validator, &GridGraphParams::default());
+
+        assert!(graph.neighbors[0].is_empty());
+    }
+
+    #[test]
+    fn spatial_hex_single_component_and_correct_coordinates() {
+        let spacing = 50.0;
+        let points = hex_lattice(2, spacing);
+        let data = vec![(); points.len()];
+
+        let validator = SpatialHexValidator {
+            min_spacing: spacing * 0.5,
+            max_spacing: spacing * 1.5,
+        };
+        let graph = HexGridGraph::build(
+            &points,
+            &data,
+            &validator,
+            &GridGraphParams {
+                k_neighbors: 12,
+                ..Default::default()
+            },
+        );
+
+        let components = hex_connected_components(&graph);
+        assert_eq!(1, components.len());
+        assert_eq!(points.len(), components[0].len());
+
+        let coords = hex_assign_grid_coordinates(&graph, &components[0]);
+        assert_eq!(points.len(), coords.len());
+
+        // All coordinates should be unique
+        let coord_set: std::collections::HashSet<(i32, i32)> =
+            coords.iter().map(|&(_, g)| (g.i, g.j)).collect();
+        assert_eq!(points.len(), coord_set.len());
+    }
+}


### PR DESCRIPTION
### Standalone `projective-grid` crate

- Add the new publishable [`projective-grid`](https://crates.io/crates/projective-grid)
  crate for pattern-agnostic 2D grid tooling: pluggable `NeighborValidator`
  traits, grid graph construction, connected-component traversal, BFS grid
  coordinate assignment, homography estimation, global rectification, per-cell
  mesh rectification, and grid smoothness prediction.
- Extract the generic square-grid geometry and homography machinery from
  `calib-targets-core` into `projective-grid`. `calib-targets-core` keeps the
  image-space pieces (`GrayImage*`, sampling, `warp_perspective_gray`) and
  re-exports `Homography`, `GridCoords` (`GridIndex` alias), `GridAlignment`,
  `GridTransform`, and homography-estimation helpers for downstream
  compatibility.
- Refactor `calib-targets-chessboard` to delegate grid-graph construction and
  traversal to `projective-grid`, while keeping chessboard-specific neighbor
  validation in-crate. Switch ChArUco grid smoothness to the shared
  `projective_grid::predict_grid_position` helper instead of maintaining a
  separate midpoint-prediction implementation.

### Hex grids and built-in validators

- Add `projective_grid::hex` with pointy-top axial-coordinate support for
  6-connected graph construction, BFS coordinate assignment, grid smoothness
  prediction, `D6` alignment transforms, `HexGridHomography`, and
  `HexGridHomographyMesh` for per-triangle affine/projective rectification.
- Add ready-to-use validator implementations in
  `projective_grid::validators`:
  `XJunctionValidator` for ChESS-like oriented square-grid corners,
  `SpatialSquareValidator` for unoriented square lattices, and
  `SpatialHexValidator` for unoriented hex lattices such as ringgrids.

### Native C API and bindings

- Expose `ScanDecodeConfig::multi_threshold` in the FFI as
  `ct_scan_decode_config_t::multi_threshold` so native callers can control the
  multi-threshold marker decode path instead of being forced to the Rust
  default.
- Add native test coverage that verifies `ct_scan_decode_config_t` preserves
  the `multi_threshold` flag when converting into the Rust
  `ScanDecodeConfig`.
- Make the Python typing-artifact generator robust to multiline
  `#[pyclass(...)]` attributes so generated `_core.pyi` stubs stay in sync
  after adding `skip_from_py_object` to config-heavy binding classes.

### Workspace and release engineering

- Centralize shared crate metadata and dependency versions in the workspace
  root via `[workspace.package]` and `[workspace.dependencies]` so the Rust
  crates inherit coordinated `0.4` versioning and one dependency set.
- Raise the documented MSRV to Rust `1.88` and surface it in the workspace
  metadata and top-level README badge.
- Update docs and packaging references from `0.3` to `0.4`, including the
  getting-started dependency snippets and the coordinated Rust/Python/native
  release metadata.
- Include `projective-grid` in the coordinated crates.io release flow and add
  CI validation that the publish order matches inter-crate dependencies before
  attempting the tagged publish job.