### PR TITLE
chore(wasm): publish to npm as @vitavition/calib-targets

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -100,7 +100,7 @@ This is a Cargo workspace. All publishable crates live under `crates/`:
 | `calib-targets-print` | Printable target generation: JSON/SVG/PNG output bundles |
 | `calib-targets-ffi` | C ABI bindings with generated header and CMake package (not published) |
 | `calib-targets-py` | PyO3/maturin Python bindings (not published to crates.io) |
-| `calib-targets-wasm` | wasm-bindgen WebAssembly bindings (not published to crates.io) |
+| `calib-targets-wasm` | wasm-bindgen WebAssembly bindings (published to npm as `@vitavition/calib-targets`, not published to crates.io) |
 
 **CLI**: the `calib-targets` binary lives in the facade crate behind the default `cli` feature (`cargo install calib-targets`), and the Python package exposes the same subcommands as a console script via `[project.scripts]`.
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -100,7 +100,7 @@ This is a Cargo workspace. All publishable crates live under `crates/`:
 | `calib-targets-print` | Printable target generation: JSON/SVG/PNG output bundles |
 | `calib-targets-ffi` | C ABI bindings with generated header and CMake package (not published) |
 | `calib-targets-py` | PyO3/maturin Python bindings (not published to crates.io) |
-| `calib-targets-wasm` | wasm-bindgen WebAssembly bindings (published to npm as `@vitavition/calib-targets`, not published to crates.io) |
+| `calib-targets-wasm` | wasm-bindgen WebAssembly bindings (published to npm as `@vitavision/calib-targets`, not published to crates.io) |
 
 **CLI**: the `calib-targets` binary lives in the facade crate behind the default `cli` feature (`cargo install calib-targets`), and the Python package exposes the same subcommands as a console script via `[project.scripts]`.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,10 @@ jobs:
       - name: Build WASM package
         run: wasm-pack build crates/calib-targets-wasm --target web --release --out-dir ../../demo/pkg --out-name calib_targets_wasm
 
+      - name: Set scoped npm package name
+        working-directory: demo/pkg
+        run: npm pkg set name=@vitavition/calib-targets
+
       - name: Verify WASM output
         run: |
           test -f demo/pkg/calib_targets_wasm.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,11 @@ jobs:
       - name: Build WASM package
         run: wasm-pack build crates/calib-targets-wasm --target web --release --out-dir ../../demo/pkg --out-name calib_targets_wasm
 
+      - name: Append object-shape TypeScript declarations
+        run: |
+          cat crates/calib-targets-wasm/typescript-extras.d.ts \
+            >> demo/pkg/calib_targets_wasm.d.ts
+
       - name: Set scoped npm package name
         working-directory: demo/pkg
         run: npm pkg set name=@vitavision/calib-targets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Set scoped npm package name
         working-directory: demo/pkg
-        run: npm pkg set name=@vitavition/calib-targets
+        run: npm pkg set name=@vitavision/calib-targets
 
       - name: Verify WASM output
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,11 +32,20 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rust-docs
+          targets: wasm32-unknown-unknown
 
       - name: Install mdBook
         uses: taiki-e/install-action@v2
         with:
           tool: mdbook
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
 
       - name: Cache cargo build
         uses: Swatinem/rust-cache@v2
@@ -51,11 +60,19 @@ jobs:
           echo '<meta http-equiv="refresh" content="0; url=calib_targets_core/index.html">' > target/doc/index.html
           mdbook build book
 
+      - name: Build playground (WASM + demo)
+        run: |
+          ./scripts/build-wasm.sh
+          cd demo
+          bun install --frozen-lockfile
+          bun run build
+
       - name: Assemble Pages artifact
         run: |
-          mkdir -p public/api
+          mkdir -p public/api public/playground
           rsync -a target/doc/ public/api/
           rsync -a book/book/ public/
+          rsync -a demo/dist/ public/playground/
 
       - name: Upload artifact for Pages
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -43,6 +43,11 @@ jobs:
       - name: Copy README into pkg
         run: cp crates/calib-targets-wasm/README.md crates/calib-targets-wasm/pkg/README.md
 
+      - name: Append object-shape TypeScript declarations
+        run: |
+          cat crates/calib-targets-wasm/typescript-extras.d.ts \
+            >> crates/calib-targets-wasm/pkg/calib_targets_wasm.d.ts
+
       - name: Set scoped npm package name
         working-directory: crates/calib-targets-wasm/pkg
         run: npm pkg set name=@vitavision/calib-targets

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Set scoped npm package name
         working-directory: crates/calib-targets-wasm/pkg
-        run: npm pkg set name=@vitavition/calib-targets
+        run: npm pkg set name=@vitavision/calib-targets
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -43,6 +43,10 @@ jobs:
       - name: Copy README into pkg
         run: cp crates/calib-targets-wasm/README.md crates/calib-targets-wasm/pkg/README.md
 
+      - name: Set scoped npm package name
+        working-directory: crates/calib-targets-wasm/pkg
+        run: npm pkg set name=@vitavition/calib-targets
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ target
 .vscode
 *.pyc
 book/book
+public/
 tmpdata
 synthetic
 stereo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ This project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.7.3]
+
+WASM-and-tooling release. The npm WASM package gains feature parity with
+the Rust facade and a typed object-shape surface, the published GitHub
+Pages site picks up an interactive playground, and a new dataset-gated
+PuzzleBoard regression locks the `Full` vs `FixedBoard` agreement
+contract on a known printed-board dataset. No Rust API breakage.
+
 ### Changed
 
 - **WASM npm package renamed** from `calib-targets-wasm` to the scoped
@@ -13,6 +21,55 @@ This project follows [Semantic Versioning](https://semver.org/).
   (`calib-targets-wasm`) is unchanged. Update consumers to
   `npm install @vitavision/calib-targets` and rewrite imports from
   `"calib-targets-wasm"` to `"@vitavision/calib-targets"`.
+
+### Added
+
+- **WASM API parity with the Rust facade.** New exports in
+  `calib-targets-wasm`: `default_charuco_params`,
+  `list_aruco_dictionaries`, `chessboard_sweep_default`,
+  `charuco_sweep_for_board`, `puzzleboard_sweep_for_board`,
+  `render_chessboard_png`, `render_charuco_png`,
+  `render_marker_board_png`. PuzzleBoard PNG rendering ceases to be a
+  special case — every supported target family renders through the
+  same surface.
+- **Typed WASM object shapes for TypeScript.** A hand-written
+  `typescript-extras.d.ts` (43 result and parameter shapes — `Corner`
+  with `axes`, the flat 30-field `DetectorParams`, PuzzleBoard
+  search/scoring tagged enums, every supporting struct) is appended
+  to the auto-generated `calib_targets_wasm.d.ts` during build, so
+  npm consumers get strongly-typed object shapes alongside function
+  signatures. Wired into both `scripts/build-wasm.sh` and the npm
+  release workflow.
+- **mdBook playground.** New `book/src/playground.md` chapter
+  iframes the React/Vite demo at `./playground/` so the published
+  GitHub Pages site has an interactive playground. The docs workflow
+  builds the WASM crate, runs `vite build`, and rsyncs `demo/dist/`
+  into `public/playground/` alongside the existing `api/` and `book/`
+  trees.
+- **Demo refresh.** The interactive demo now uses the WASM default
+  helpers (`default_charuco_params`, `list_aruco_dictionaries`, the
+  three sweep presets) instead of pre-0.7-schema constants that
+  silently no-op'd on the current deserializer. Adds a
+  "use 3-config sweep" toggle wired to the `detect_*_best` family,
+  generates synthetic targets across all four target kinds, and
+  exposes a dictionary dropdown for ChArUco.
+- **Dataset-gated PuzzleBoard regression test.**
+  `crates/calib-targets-puzzleboard/tests/dataset_full_mode_bounds.rs`
+  freezes three contracts on a known printed-board dataset:
+  `FixedBoard + SoftLogLikelihood` keeps every decoded
+  `target_position` inside the declared board's bounds at low BER;
+  `Full` and `FixedBoard` pick the same `(D4, master_origin_*)` on
+  the pinned fixtures; and an on-demand `--ignored` sweep covers
+  every available snap under both scoring modes. Skips silently
+  when the dataset is missing.
+
+### Fixed
+
+- **Demo ChArUco sliders bind to the post-0.7 schema.** Sliders
+  now read and write `charucoParams.board.*` (not the stale
+  `.charuco.*`) and chessboard sliders use the flat-`DetectorParams`
+  field names (`min_corner_strength`, `min_labeled_corners`,
+  `max_components`, `cell_size_hint`).
 
 ## [0.7.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,10 @@ This project follows [Semantic Versioning](https://semver.org/).
 ### Changed
 
 - **WASM npm package renamed** from `calib-targets-wasm` to the scoped
-  public package `@vitavition/calib-targets`. The Rust crate name
+  public package `@vitavision/calib-targets`. The Rust crate name
   (`calib-targets-wasm`) is unchanged. Update consumers to
-  `npm install @vitavition/calib-targets` and rewrite imports from
-  `"calib-targets-wasm"` to `"@vitavition/calib-targets"`.
+  `npm install @vitavision/calib-targets` and rewrite imports from
+  `"calib-targets-wasm"` to `"@vitavision/calib-targets"`.
 
 ## [0.7.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ This project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **WASM npm package renamed** from `calib-targets-wasm` to the scoped
+  public package `@vitavition/calib-targets`. The Rust crate name
+  (`calib-targets-wasm`) is unchanged. Update consumers to
+  `npm install @vitavition/calib-targets` and rewrite imports from
+  `"calib-targets-wasm"` to `"@vitavition/calib-targets"`.
+
 ## [0.7.2]
 
 PuzzleBoard feature-and-fix release. This version removes the large

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -569,9 +569,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1378,9 +1378,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
 dependencies = [
  "jiff-static",
  "log",
@@ -1391,9 +1391,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1470,9 +1470,9 @@ checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -2883,7 +2883,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.1",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -3372,9 +3372,9 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,7 +341,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "calib-targets"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "assert_cmd",
  "calib-targets-aruco",
@@ -370,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-aruco"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "calib-targets-chessboard",
  "calib-targets-core",
@@ -385,7 +385,7 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-charuco"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "calib-targets",
  "calib-targets-aruco",
@@ -407,7 +407,7 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-chessboard"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "approx",
  "calib-targets",
@@ -428,7 +428,7 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-core"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "log",
  "nalgebra",
@@ -442,7 +442,7 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-ffi"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "calib-targets",
  "cbindgen",
@@ -455,7 +455,7 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-marker"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "calib-targets-chessboard",
  "calib-targets-core",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-print"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "calib-targets-aruco",
  "calib-targets-charuco",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-puzzleboard"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "calib-targets",
  "calib-targets-chessboard",
@@ -510,7 +510,7 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-py"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "calib-targets",
  "chess-corners",
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-wasm"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "calib-targets-aruco",
  "calib-targets-charuco",
@@ -2114,7 +2114,7 @@ dependencies = [
 
 [[package]]
 name = "projective-grid"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "kiddo",
  "nalgebra",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/VitalyVorobyev/calib-targets-rs"

--- a/README.md
+++ b/README.md
@@ -121,8 +121,9 @@ scripts/build-wasm.sh
 cd demo && bun install && bun run dev
 ```
 
-See [`crates/calib-targets-wasm`](crates/calib-targets-wasm) for the
-TypeScript API and per-target snippets.
+See [`@vitavition/calib-targets`](crates/calib-targets-wasm) on npm
+(source under `crates/calib-targets-wasm/`) for the TypeScript API
+and per-target snippets.
 
 ### Printable targets
 
@@ -171,7 +172,7 @@ Canonical guide: [printable-target chapter][printable-chapter].
 | [`calib-targets-marker`](crates/calib-targets-marker) | [published](https://crates.io/crates/calib-targets-marker) | Checkerboard + 3-circle marker boards. |
 | [`calib-targets-print`](crates/calib-targets-print) | [published](https://crates.io/crates/calib-targets-print) | Printable target generation (JSON / SVG / PNG). |
 | [`calib-targets-py`](crates/calib-targets-py) | PyPI | Python bindings (PyO3 / maturin). |
-| [`calib-targets-wasm`](crates/calib-targets-wasm) | npm / repo-local | WebAssembly bindings. |
+| [`@vitavition/calib-targets`](crates/calib-targets-wasm) | npm / repo-local | WebAssembly bindings. |
 | [`calib-targets-ffi`](crates/calib-targets-ffi) | repo-local | C ABI bindings ([docs](./docs/ffi/README.md)). |
 
 The printable-target CLI now ships with both the facade crate and the Python

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ scripts/build-wasm.sh
 cd demo && bun install && bun run dev
 ```
 
-See [`@vitavition/calib-targets`](crates/calib-targets-wasm) on npm
+See [`@vitavision/calib-targets`](crates/calib-targets-wasm) on npm
 (source under `crates/calib-targets-wasm/`) for the TypeScript API
 and per-target snippets.
 
@@ -172,7 +172,7 @@ Canonical guide: [printable-target chapter][printable-chapter].
 | [`calib-targets-marker`](crates/calib-targets-marker) | [published](https://crates.io/crates/calib-targets-marker) | Checkerboard + 3-circle marker boards. |
 | [`calib-targets-print`](crates/calib-targets-print) | [published](https://crates.io/crates/calib-targets-print) | Printable target generation (JSON / SVG / PNG). |
 | [`calib-targets-py`](crates/calib-targets-py) | PyPI | Python bindings (PyO3 / maturin). |
-| [`@vitavition/calib-targets`](crates/calib-targets-wasm) | npm / repo-local | WebAssembly bindings. |
+| [`@vitavision/calib-targets`](crates/calib-targets-wasm) | npm / repo-local | WebAssembly bindings. |
 | [`calib-targets-ffi`](crates/calib-targets-ffi) | repo-local | C ABI bindings ([docs](./docs/ffi/README.md)). |
 
 The printable-target CLI now ships with both the facade crate and the Python

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -1,6 +1,7 @@
 # Summary
 
 - [Introduction](intro.md)
+- [Interactive Playground](playground.md)
 - [User Guide]()
   - [Getting Started](getting-started.md)
   - [Tuning the Detector](tuning.md)

--- a/book/src/playground.md
+++ b/book/src/playground.md
@@ -1,0 +1,68 @@
+# Interactive Playground
+
+The same detectors shipped in the Rust facade — chessboard, ChArUco,
+PuzzleBoard, and marker board — also run **directly in the browser** via
+WebAssembly. The npm package is
+[`@vitavision/calib-targets`](https://www.npmjs.com/package/@vitavision/calib-targets);
+the playground below is a thin React UI on top of it. No data leaves your
+machine: detection happens in the WASM module loaded into this page.
+
+<iframe
+  id="calib-targets-playground"
+  src="./playground/"
+  title="calib-targets WebAssembly playground"
+  loading="lazy"
+  allow="clipboard-read; clipboard-write"
+  style="width: 100%; height: 900px; border: 1px solid #ddd; border-radius: 4px;">
+</iframe>
+
+<noscript>The interactive playground requires JavaScript and WebAssembly.</noscript>
+
+## What it does
+
+| Surface | Description |
+|---|---|
+| **Image input** | Drop or browse a file, or generate a synthetic chessboard / ChArUco / marker / PuzzleBoard target in WASM. |
+| **Detection mode** | Switch between corner detection and the four target detectors. |
+| **3-config sweep** | Toggle `detect_*_best` to try the built-in 3-config preset and keep the best result. |
+| **Live tuning** | ChESS threshold / NMS / pyramid plus per-detector knobs (board dims, dictionary, marker size, board size, bit confidence). |
+| **Overlays** | Detected corners colour-coded by grid position; PuzzleBoard edge bits drawn at decoded edge midpoints. |
+| **JSON dump** | Toggle the raw `serde_json` payload returned by the WASM call — the same shape the Rust facade emits. |
+
+## Running locally
+
+If the embedded iframe fails to load (older browsers without
+`WebAssembly` or `ES modules` support), build and run the demo standalone:
+
+```bash
+scripts/build-wasm.sh                       # populates demo/pkg/
+cd demo && bun install && bun run dev       # http://localhost:5173
+```
+
+To use the same WASM module from your own web app:
+
+```bash
+npm install @vitavision/calib-targets
+```
+
+```typescript
+import init, {
+  default_chess_config,
+  default_chessboard_params,
+  detect_chessboard,
+  rgba_to_gray,
+} from "@vitavision/calib-targets";
+
+await init();
+const gray = rgba_to_gray(rgba, width, height);
+const result = detect_chessboard(
+  width, height, gray,
+  default_chess_config(),
+  default_chessboard_params(),
+);
+```
+
+The full TypeScript surface — `default_*_params(...)`,
+`*_sweep_*(...)`, `render_*_png(...)`, and `list_aruco_dictionaries()` —
+is documented in the package README and ships as `.d.ts` declarations
+alongside the WASM module.

--- a/crates/calib-targets-puzzleboard/tests/dataset_full_mode_bounds.rs
+++ b/crates/calib-targets-puzzleboard/tests/dataset_full_mode_bounds.rs
@@ -1,0 +1,316 @@
+//! Dataset-gated regression for PuzzleBoard `Full` vs `FixedBoard` decode
+//! contracts on a known printed-board dataset.
+//!
+//! A handoff from a sibling calibration repo (kept locally under the
+//! gitignored `docs/datasets/` tree) reported that `Full` mode could pick a
+//! wrong master origin under partial views, putting decoded
+//! `target_position` values far outside the declared board. Re-measurement
+//! against this branch shows `Full` and `FixedBoard` agree on every
+//! decoded snap of the local `130x130_puzzle` set; this file freezes that
+//! contract so any future detector change that splits the two modes apart
+//! is caught immediately.
+//!
+//! Three tests share one fixture set:
+//!
+//! - [`fixed_board_keeps_target_positions_in_board`] — `FixedBoard +
+//!   SoftLogLikelihood` keeps every decoded `target_position` inside the
+//!   declared board's bounds and stays at low BER.
+//! - [`full_mode_origin_matches_fixed_board`] — `Full` and `FixedBoard`
+//!   pick the same `(D4, master_origin_row, master_origin_col)` on the
+//!   pinned fixtures.
+//! - [`full_vs_fixed_board_origin_match_on_all_snaps`] (`#[ignore]`) —
+//!   on-demand sweep over every `target_*.png` × 6 snaps; reports any
+//!   disagreement. Run with `cargo test ... -- --ignored`.
+//!
+//! All tests skip silently when the dataset directory is missing — this
+//! matches the bench at `benches/dataset_decode.rs` so fresh clones and CI
+//! without the private dataset stay green. Override the dataset path with
+//! `CALIB_PUZZLE_PRIVATE_DATASET=/path/to/130x130_puzzle`.
+
+use std::path::PathBuf;
+
+use calib_targets::detect::{default_chess_config, detect_corners, gray_view};
+use calib_targets_puzzleboard::{
+    PuzzleBoardDetectionResult, PuzzleBoardDetector, PuzzleBoardParams, PuzzleBoardScoringMode,
+    PuzzleBoardSearchMode, PuzzleBoardSpec,
+};
+use image::imageops::FilterType;
+use image::{GenericImageView, GrayImage};
+
+const SNAP_WIDTH: u32 = 720;
+const SNAP_HEIGHT: u32 = 540;
+
+const BOARD_ROWS: u32 = 130;
+const BOARD_COLS: u32 = 130;
+const BOARD_CELL_MM: f32 = 1.014;
+const UPSCALE: u32 = 2;
+const MAX_BIT_ERROR_RATE: f32 = 0.05;
+
+/// Same fixture set as `benches/dataset_decode.rs` so the bounds regression
+/// stays in lockstep with the bench-pinned snaps.
+const FIXTURES: &[(u32, u32, &str)] = &[
+    (0, 0, "t0s0"),
+    (5, 2, "t5s2"),
+    (11, 3, "t11s3"),
+    (19, 5, "t19s5"),
+];
+
+fn dataset_dir() -> PathBuf {
+    if let Ok(custom) = std::env::var("CALIB_PUZZLE_PRIVATE_DATASET") {
+        return PathBuf::from(custom);
+    }
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../privatedata/130x130_puzzle")
+}
+
+fn load_snap(target_idx: u32, snap_idx: u32) -> Option<GrayImage> {
+    let path = dataset_dir().join(format!("target_{target_idx}.png"));
+    if !path.exists() {
+        return None;
+    }
+    let img = image::open(&path).ok()?.to_luma8();
+    let x0 = snap_idx * SNAP_WIDTH;
+    if x0 + SNAP_WIDTH > img.width() || img.height() < SNAP_HEIGHT {
+        return None;
+    }
+    let snap = img.view(x0, 0, SNAP_WIDTH, SNAP_HEIGHT).to_image();
+    if UPSCALE == 1 {
+        return Some(snap);
+    }
+    Some(image::imageops::resize(
+        &snap,
+        SNAP_WIDTH * UPSCALE,
+        SNAP_HEIGHT * UPSCALE,
+        FilterType::Triangle,
+    ))
+}
+
+fn detect_one(
+    image: &GrayImage,
+    search_mode: PuzzleBoardSearchMode,
+    scoring_mode: PuzzleBoardScoringMode,
+) -> Option<PuzzleBoardDetectionResult> {
+    let spec =
+        PuzzleBoardSpec::with_origin(BOARD_ROWS, BOARD_COLS, BOARD_CELL_MM, 0, 0).expect("spec");
+    let mut params = PuzzleBoardParams::for_board(&spec);
+    params.decode.search_mode = search_mode;
+    params.decode.scoring_mode = scoring_mode;
+    let detector = PuzzleBoardDetector::new(params).expect("detector");
+
+    let chess_cfg = default_chess_config();
+    let corners = detect_corners(image, &chess_cfg);
+    detector.detect(&gray_view(image), &corners).ok()
+}
+
+fn dataset_present_or_skip(test_name: &str) -> bool {
+    if dataset_dir().exists() {
+        return true;
+    }
+    eprintln!(
+        "[skipped] {test_name}: dataset {:?} missing — set \
+         CALIB_PUZZLE_PRIVATE_DATASET to enable",
+        dataset_dir()
+    );
+    false
+}
+
+#[test]
+fn fixed_board_keeps_target_positions_in_board() {
+    if !dataset_present_or_skip("fixed_board_keeps_target_positions_in_board") {
+        return;
+    }
+
+    let max_x_mm = (BOARD_COLS as f32 - 1.0) * BOARD_CELL_MM;
+    let max_y_mm = (BOARD_ROWS as f32 - 1.0) * BOARD_CELL_MM;
+
+    let mut successes = 0usize;
+    for &(target_idx, snap_idx, label) in FIXTURES {
+        let Some(image) = load_snap(target_idx, snap_idx) else {
+            panic!("fixture {label} (target {target_idx} snap {snap_idx}) missing on disk");
+        };
+        let Some(result) = detect_one(
+            &image,
+            PuzzleBoardSearchMode::FixedBoard,
+            PuzzleBoardScoringMode::SoftLogLikelihood,
+        ) else {
+            eprintln!("{label}: FixedBoard+Soft decode failed — skipping bounds check");
+            continue;
+        };
+        successes += 1;
+
+        assert!(
+            result.decode.bit_error_rate <= MAX_BIT_ERROR_RATE,
+            "{label}: BER {:.3} > {MAX_BIT_ERROR_RATE} — decode below confidence floor",
+            result.decode.bit_error_rate,
+        );
+
+        for lc in &result.detection.corners {
+            let Some(tp) = lc.target_position else {
+                continue;
+            };
+            assert!(
+                (0.0..=max_x_mm).contains(&tp.x),
+                "{label}: target_position.x = {:.3} mm out of [0, {max_x_mm:.3}] \
+                 (origin r={}, c={}, transform={:?})",
+                tp.x,
+                result.decode.master_origin_row,
+                result.decode.master_origin_col,
+                result.alignment.transform,
+            );
+            assert!(
+                (0.0..=max_y_mm).contains(&tp.y),
+                "{label}: target_position.y = {:.3} mm out of [0, {max_y_mm:.3}] \
+                 (origin r={}, c={}, transform={:?})",
+                tp.y,
+                result.decode.master_origin_row,
+                result.decode.master_origin_col,
+                result.alignment.transform,
+            );
+        }
+    }
+
+    assert!(
+        successes >= 3,
+        "FixedBoard+Soft decoded only {successes}/{} fixtures — recall regression",
+        FIXTURES.len(),
+    );
+}
+
+#[test]
+fn full_mode_origin_matches_fixed_board() {
+    if !dataset_present_or_skip("full_mode_origin_matches_fixed_board") {
+        return;
+    }
+
+    let mut compared = 0usize;
+    let mut disagreements = Vec::<String>::new();
+    for &(target_idx, snap_idx, label) in FIXTURES {
+        let Some(image) = load_snap(target_idx, snap_idx) else {
+            panic!("fixture {label} (target {target_idx} snap {snap_idx}) missing on disk");
+        };
+        let full = detect_one(
+            &image,
+            PuzzleBoardSearchMode::Full,
+            PuzzleBoardScoringMode::SoftLogLikelihood,
+        );
+        let fixed = detect_one(
+            &image,
+            PuzzleBoardSearchMode::FixedBoard,
+            PuzzleBoardScoringMode::SoftLogLikelihood,
+        );
+        match (full, fixed) {
+            (Some(f), Some(x)) => {
+                compared += 1;
+                if f.alignment.transform != x.alignment.transform
+                    || f.decode.master_origin_row != x.decode.master_origin_row
+                    || f.decode.master_origin_col != x.decode.master_origin_col
+                {
+                    disagreements.push(format!(
+                        "{label}: full=({},{},{:?}) fixed=({},{},{:?})",
+                        f.decode.master_origin_row,
+                        f.decode.master_origin_col,
+                        f.alignment.transform,
+                        x.decode.master_origin_row,
+                        x.decode.master_origin_col,
+                        x.alignment.transform,
+                    ));
+                }
+            }
+            _ => {
+                eprintln!("{label}: skipping (one mode failed to decode)");
+            }
+        }
+    }
+
+    assert!(
+        compared >= 1,
+        "no fixture decoded under both modes — cannot evaluate origin match",
+    );
+    assert!(
+        disagreements.is_empty(),
+        "Full vs FixedBoard origin mismatch on {}/{compared} fixtures:\n  {}",
+        disagreements.len(),
+        disagreements.join("\n  "),
+    );
+}
+
+const SNAPS_PER_IMAGE: u32 = 6;
+const MAX_TARGET_IDX: u32 = 32;
+
+/// On-demand sweep over every available `target_*.png` × 6 snaps, comparing
+/// `Full` and `FixedBoard` master origins under both scoring modes.
+///
+/// Marked `#[ignore]` so it stays out of the default test pass — the
+/// pinned-fixture variant already locks the contract; this one is the
+/// broader spot-check used when investigating a real-world wrong-origin
+/// report. Run with:
+/// ```text
+/// cargo test -p calib-targets-puzzleboard --test dataset_full_mode_bounds \
+///     -- --ignored full_vs_fixed_board_origin_match_on_all_snaps --nocapture
+/// ```
+#[test]
+#[ignore = "broad dataset sweep (~minute); run on demand with --ignored"]
+fn full_vs_fixed_board_origin_match_on_all_snaps() {
+    if !dataset_present_or_skip("full_vs_fixed_board_origin_match_on_all_snaps") {
+        return;
+    }
+
+    let modes = [
+        ("hard", PuzzleBoardScoringMode::HardWeighted),
+        ("soft", PuzzleBoardScoringMode::SoftLogLikelihood),
+    ];
+
+    for (mode_name, scoring) in modes {
+        let mut compared = 0usize;
+        let mut full_only = 0usize;
+        let mut fixed_only = 0usize;
+        let mut both_fail = 0usize;
+        let mut disagreements = Vec::<String>::new();
+        for target_idx in 0..MAX_TARGET_IDX {
+            for snap_idx in 0..SNAPS_PER_IMAGE {
+                let Some(image) = load_snap(target_idx, snap_idx) else {
+                    break; // out of frames for this target_idx
+                };
+                let label = format!("t{target_idx}s{snap_idx}");
+                let full = detect_one(&image, PuzzleBoardSearchMode::Full, scoring);
+                let fixed = detect_one(&image, PuzzleBoardSearchMode::FixedBoard, scoring);
+                match (full, fixed) {
+                    (Some(f), Some(x)) => {
+                        compared += 1;
+                        if f.alignment.transform != x.alignment.transform
+                            || f.decode.master_origin_row != x.decode.master_origin_row
+                            || f.decode.master_origin_col != x.decode.master_origin_col
+                        {
+                            disagreements.push(format!(
+                                "{label} ({mode_name}): full=({},{},{:?}) fixed=({},{},{:?})",
+                                f.decode.master_origin_row,
+                                f.decode.master_origin_col,
+                                f.alignment.transform,
+                                x.decode.master_origin_row,
+                                x.decode.master_origin_col,
+                                x.alignment.transform,
+                            ));
+                        }
+                    }
+                    (Some(_), None) => full_only += 1,
+                    (None, Some(_)) => fixed_only += 1,
+                    (None, None) => both_fail += 1,
+                }
+            }
+        }
+        eprintln!(
+            "{mode_name}: compared={compared} full_only={full_only} \
+             fixed_only={fixed_only} both_fail={both_fail} \
+             disagreements={}",
+            disagreements.len(),
+        );
+        for d in &disagreements {
+            eprintln!("  {d}");
+        }
+        assert!(
+            disagreements.is_empty(),
+            "Full vs FixedBoard mismatch under {mode_name} scoring \
+             on {} of {compared} doubly-decoded snaps",
+            disagreements.len(),
+        );
+    }
+}

--- a/crates/calib-targets-wasm/README.md
+++ b/crates/calib-targets-wasm/README.md
@@ -1,4 +1,4 @@
-# calib-targets-wasm
+# @vitavition/calib-targets
 
 WebAssembly bindings for the [calib-targets] Rust workspace. Run
 chessboard, ChArUco, PuzzleBoard, and marker-board detection directly in
@@ -17,7 +17,7 @@ Book & per-target chapters: <https://vitalyvorobyev.github.io/calib-targets-rs/>
 ## Install
 
 ```bash
-npm install calib-targets-wasm
+npm install @vitavition/calib-targets
 # or, for the local build output:
 scripts/build-wasm.sh   # produces demo/pkg/
 ```
@@ -30,7 +30,7 @@ import init, {
   default_chessboard_params,
   detect_chessboard,
   rgba_to_gray,
-} from "calib-targets-wasm";
+} from "@vitavition/calib-targets";
 
 await init(); // initialise the WASM module once per page
 
@@ -58,7 +58,7 @@ plain JS object you can `JSON.stringify`.
 ### Chessboard
 
 ```typescript
-import { default_chess_config, default_chessboard_params, detect_chessboard_best } from "calib-targets-wasm";
+import { default_chess_config, default_chessboard_params, detect_chessboard_best } from "@vitavition/calib-targets";
 
 const base = default_chessboard_params();
 const configs = [0.20, 0.15, 0.08].map(t => ({
@@ -71,7 +71,7 @@ const best = detect_chessboard_best(width, height, gray, configs);
 ### ChArUco
 
 ```typescript
-import { detect_charuco } from "calib-targets-wasm";
+import { detect_charuco } from "@vitavition/calib-targets";
 
 const board = {
   rows: 5, cols: 7, cell_size: 1.0,
@@ -95,7 +95,7 @@ const result = detect_charuco(width, height, gray, default_chess_config(), param
 ### PuzzleBoard
 
 ```typescript
-import { default_puzzleboard_params, detect_puzzleboard, render_puzzleboard_png } from "calib-targets-wasm";
+import { default_puzzleboard_params, detect_puzzleboard, render_puzzleboard_png } from "@vitavition/calib-targets";
 
 // Generate a PuzzleBoard PNG in the browser (only PuzzleBoard is supported
 // in-browser — see Limitations below).
@@ -112,7 +112,7 @@ const result = detect_puzzleboard(width, height, gray, default_chess_config(), p
 ### Marker board
 
 ```typescript
-import { default_marker_board_params, detect_marker_board } from "calib-targets-wasm";
+import { default_marker_board_params, detect_marker_board } from "@vitavition/calib-targets";
 
 const params = default_marker_board_params();
 params.layout = {

--- a/crates/calib-targets-wasm/README.md
+++ b/crates/calib-targets-wasm/README.md
@@ -1,4 +1,4 @@
-# @vitavition/calib-targets
+# @vitavision/calib-targets
 
 WebAssembly bindings for the [calib-targets] Rust workspace. Run
 chessboard, ChArUco, PuzzleBoard, and marker-board detection directly in
@@ -17,7 +17,7 @@ Book & per-target chapters: <https://vitalyvorobyev.github.io/calib-targets-rs/>
 ## Install
 
 ```bash
-npm install @vitavition/calib-targets
+npm install @vitavision/calib-targets
 # or, for the local build output:
 scripts/build-wasm.sh   # produces demo/pkg/
 ```
@@ -30,7 +30,7 @@ import init, {
   default_chessboard_params,
   detect_chessboard,
   rgba_to_gray,
-} from "@vitavition/calib-targets";
+} from "@vitavision/calib-targets";
 
 await init(); // initialise the WASM module once per page
 
@@ -58,7 +58,7 @@ plain JS object you can `JSON.stringify`.
 ### Chessboard
 
 ```typescript
-import { default_chess_config, default_chessboard_params, detect_chessboard_best } from "@vitavition/calib-targets";
+import { default_chess_config, default_chessboard_params, detect_chessboard_best } from "@vitavision/calib-targets";
 
 const base = default_chessboard_params();
 const configs = [0.20, 0.15, 0.08].map(t => ({
@@ -71,7 +71,7 @@ const best = detect_chessboard_best(width, height, gray, configs);
 ### ChArUco
 
 ```typescript
-import { detect_charuco } from "@vitavition/calib-targets";
+import { detect_charuco } from "@vitavision/calib-targets";
 
 const board = {
   rows: 5, cols: 7, cell_size: 1.0,
@@ -95,7 +95,7 @@ const result = detect_charuco(width, height, gray, default_chess_config(), param
 ### PuzzleBoard
 
 ```typescript
-import { default_puzzleboard_params, detect_puzzleboard, render_puzzleboard_png } from "@vitavition/calib-targets";
+import { default_puzzleboard_params, detect_puzzleboard, render_puzzleboard_png } from "@vitavision/calib-targets";
 
 // Generate a PuzzleBoard PNG in the browser (only PuzzleBoard is supported
 // in-browser — see Limitations below).
@@ -112,7 +112,7 @@ const result = detect_puzzleboard(width, height, gray, default_chess_config(), p
 ### Marker board
 
 ```typescript
-import { default_marker_board_params, detect_marker_board } from "@vitavition/calib-targets";
+import { default_marker_board_params, detect_marker_board } from "@vitavision/calib-targets";
 
 const params = default_marker_board_params();
 params.layout = {

--- a/crates/calib-targets-wasm/src/lib.rs
+++ b/crates/calib-targets-wasm/src/lib.rs
@@ -6,13 +6,14 @@
 mod convert;
 mod gray;
 
-use calib_targets_charuco::{CharucoDetector, CharucoParams};
+use calib_targets_aruco::builtins::{builtin_dictionary, BUILTIN_DICTIONARY_NAMES};
+use calib_targets_charuco::{CharucoBoardSpec, CharucoDetector, CharucoParams, MarkerLayout};
 use calib_targets_chessboard::{Detector as ChessDetector, DetectorParams};
 use calib_targets_core::{ChessConfig, Corner, ThresholdMode};
 use calib_targets_marker::{MarkerBoardDetector, MarkerBoardParams};
 use calib_targets_print::{
-    render_target_bundle, PageSize, PageSpec, PrintableTargetDocument, PuzzleBoardTargetSpec,
-    RenderOptions, TargetSpec,
+    render_target_bundle, CharucoTargetSpec, ChessboardTargetSpec, MarkerBoardTargetSpec, PageSize,
+    PageSpec, PrintableTargetDocument, PuzzleBoardTargetSpec, RenderOptions, TargetSpec,
 };
 use calib_targets_puzzleboard::{PuzzleBoardDetector, PuzzleBoardParams, PuzzleBoardSpec};
 use chess_corners::find_chess_corners_u8;
@@ -118,9 +119,203 @@ pub fn default_puzzleboard_params(rows: u32, cols: u32) -> Result<JsValue, JsErr
     to_js(&PuzzleBoardParams::for_board(&spec))
 }
 
+/// Return default `CharucoParams` for the given board geometry.
+///
+/// `rows` / `cols` are **square counts** (not inner-corner counts).
+/// `marker_size_rel` ∈ (0, 1] is the marker side length relative to the
+/// square. `dictionary_name` is one of [`list_aruco_dictionaries`] (e.g.
+/// `"DICT_4X4_50"`).
+#[wasm_bindgen]
+pub fn default_charuco_params(
+    rows: u32,
+    cols: u32,
+    marker_size_rel: f64,
+    dictionary_name: &str,
+) -> Result<JsValue, JsError> {
+    let spec = charuco_board_spec(rows, cols, marker_size_rel, dictionary_name)?;
+    to_js(&CharucoParams::for_board(&spec))
+}
+
+/// List the names of every built-in ArUco / AprilTag dictionary.
+///
+/// The returned strings are valid `dictionary_name` arguments for
+/// [`default_charuco_params`] and [`render_charuco_png`].
+#[wasm_bindgen]
+pub fn list_aruco_dictionaries() -> Result<JsValue, JsError> {
+    to_js(&BUILTIN_DICTIONARY_NAMES)
+}
+
 // ---------------------------------------------------------------------------
-// Synthetic PuzzleBoard generation
+// Multi-config sweep presets
 // ---------------------------------------------------------------------------
+
+/// Return the 3-config chessboard sweep preset (`DetectorParams::sweep_default()`).
+///
+/// Pass the array directly to [`detect_chessboard_best`].
+#[wasm_bindgen]
+pub fn chessboard_sweep_default() -> Result<JsValue, JsError> {
+    to_js(&DetectorParams::sweep_default())
+}
+
+/// Return the ChArUco sweep preset for a given board (`CharucoParams::sweep_for_board(&spec)`).
+///
+/// Pass the array directly to [`detect_charuco_best`].
+#[wasm_bindgen]
+pub fn charuco_sweep_for_board(
+    rows: u32,
+    cols: u32,
+    marker_size_rel: f64,
+    dictionary_name: &str,
+) -> Result<JsValue, JsError> {
+    let spec = charuco_board_spec(rows, cols, marker_size_rel, dictionary_name)?;
+    to_js(&CharucoParams::sweep_for_board(&spec))
+}
+
+/// Return the PuzzleBoard sweep preset for a given board (`PuzzleBoardParams::sweep_for_board(&spec)`).
+///
+/// Pass the array directly to [`detect_puzzleboard_best`].
+#[wasm_bindgen]
+pub fn puzzleboard_sweep_for_board(rows: u32, cols: u32) -> Result<JsValue, JsError> {
+    let spec = PuzzleBoardSpec::new(rows, cols, 1.0).map_err(|e| JsError::new(&e.to_string()))?;
+    to_js(&PuzzleBoardParams::sweep_for_board(&spec))
+}
+
+// ---------------------------------------------------------------------------
+// Synthetic target generation
+// ---------------------------------------------------------------------------
+
+/// Build a `CharucoBoardSpec` from JS-friendly arguments.
+fn charuco_board_spec(
+    rows: u32,
+    cols: u32,
+    marker_size_rel: f64,
+    dictionary_name: &str,
+) -> Result<CharucoBoardSpec, JsError> {
+    let dictionary = builtin_dictionary(dictionary_name).ok_or_else(|| {
+        JsError::new(&format!(
+            "unknown dictionary {:?}; call list_aruco_dictionaries() for valid names",
+            dictionary_name
+        ))
+    })?;
+    Ok(CharucoBoardSpec {
+        rows,
+        cols,
+        cell_size: 1.0,
+        marker_size_rel: marker_size_rel as f32,
+        dictionary,
+        marker_layout: MarkerLayout::default(),
+    })
+}
+
+/// Wrap a target spec in a `PrintableTargetDocument` sized to fit the board
+/// exactly (board extent + 20 mm margin), at `dpi`.
+fn fitted_document(
+    target: TargetSpec,
+    width_mm: f64,
+    height_mm: f64,
+    dpi: u32,
+) -> PrintableTargetDocument {
+    let mut doc = PrintableTargetDocument::new(target);
+    doc.page = PageSpec {
+        size: PageSize::Custom {
+            width_mm: width_mm + 20.0,
+            height_mm: height_mm + 20.0,
+        },
+        margin_mm: 5.0,
+        ..PageSpec::default()
+    };
+    doc.render = RenderOptions {
+        debug_annotations: false,
+        png_dpi: dpi,
+    };
+    doc
+}
+
+/// Synthesise a chessboard target PNG in memory.
+///
+/// `inner_rows` / `inner_cols` are the **inner-corner** counts (each ≥ 2). The
+/// printed board has `(inner_cols + 1) × (inner_rows + 1)` squares of side
+/// `square_size_mm`. Returns raw PNG bytes for a tightly-cropped page.
+#[wasm_bindgen]
+pub fn render_chessboard_png(
+    inner_rows: u32,
+    inner_cols: u32,
+    square_size_mm: f64,
+    dpi: u32,
+) -> Result<Vec<u8>, JsError> {
+    let target = TargetSpec::Chessboard(ChessboardTargetSpec {
+        inner_rows,
+        inner_cols,
+        square_size_mm,
+    });
+    let w = f64::from(inner_cols + 1) * square_size_mm;
+    let h = f64::from(inner_rows + 1) * square_size_mm;
+    let bundle = render_target_bundle(&fitted_document(target, w, h, dpi))
+        .map_err(|e| JsError::new(&e.to_string()))?;
+    Ok(bundle.png_bytes)
+}
+
+/// Synthesise a ChArUco target PNG in memory.
+///
+/// `rows` / `cols` are **square counts** (≥ 2 each). `marker_size_rel` ∈ (0, 1]
+/// sets the marker side length relative to the square; `dictionary_name` is
+/// one of [`list_aruco_dictionaries`] (e.g. `"DICT_4X4_50"`).
+#[wasm_bindgen]
+pub fn render_charuco_png(
+    rows: u32,
+    cols: u32,
+    square_size_mm: f64,
+    marker_size_rel: f64,
+    dictionary_name: &str,
+    dpi: u32,
+) -> Result<Vec<u8>, JsError> {
+    let dictionary = builtin_dictionary(dictionary_name).ok_or_else(|| {
+        JsError::new(&format!(
+            "unknown dictionary {:?}; call list_aruco_dictionaries() for valid names",
+            dictionary_name
+        ))
+    })?;
+    let target = TargetSpec::Charuco(CharucoTargetSpec {
+        rows,
+        cols,
+        square_size_mm,
+        marker_size_rel,
+        dictionary,
+        marker_layout: MarkerLayout::default(),
+        border_bits: 1,
+    });
+    let w = f64::from(cols) * square_size_mm;
+    let h = f64::from(rows) * square_size_mm;
+    let bundle = render_target_bundle(&fitted_document(target, w, h, dpi))
+        .map_err(|e| JsError::new(&e.to_string()))?;
+    Ok(bundle.png_bytes)
+}
+
+/// Synthesise a marker-board target PNG in memory.
+///
+/// `inner_rows` / `inner_cols` are the **inner-corner** counts. The default
+/// 3-circle layout from `MarkerBoardTargetSpec::default_circles` is used; for
+/// custom circle placement, call the Rust facade directly.
+#[wasm_bindgen]
+pub fn render_marker_board_png(
+    inner_rows: u32,
+    inner_cols: u32,
+    square_size_mm: f64,
+    dpi: u32,
+) -> Result<Vec<u8>, JsError> {
+    let target = TargetSpec::MarkerBoard(MarkerBoardTargetSpec {
+        inner_rows,
+        inner_cols,
+        square_size_mm,
+        circles: MarkerBoardTargetSpec::default_circles(inner_rows, inner_cols),
+        circle_diameter_rel: 0.5,
+    });
+    let w = f64::from(inner_cols + 1) * square_size_mm;
+    let h = f64::from(inner_rows + 1) * square_size_mm;
+    let bundle = render_target_bundle(&fitted_document(target, w, h, dpi))
+        .map_err(|e| JsError::new(&e.to_string()))?;
+    Ok(bundle.png_bytes)
+}
 
 /// Synthesise a PuzzleBoard target PNG in memory.
 ///
@@ -135,28 +330,18 @@ pub fn render_puzzleboard_png(
     square_size_mm: f64,
     dpi: u32,
 ) -> Result<Vec<u8>, JsError> {
-    let target = PuzzleBoardTargetSpec {
+    let target = TargetSpec::PuzzleBoard(PuzzleBoardTargetSpec {
         rows,
         cols,
         square_size_mm,
         origin_row: 0,
         origin_col: 0,
         dot_diameter_rel: 1.0 / 3.0,
-    };
-    let mut doc = PrintableTargetDocument::new(TargetSpec::PuzzleBoard(target));
-    doc.page = PageSpec {
-        size: PageSize::Custom {
-            width_mm: f64::from(cols) * square_size_mm + 20.0,
-            height_mm: f64::from(rows) * square_size_mm + 20.0,
-        },
-        margin_mm: 5.0,
-        ..PageSpec::default()
-    };
-    doc.render = RenderOptions {
-        debug_annotations: false,
-        png_dpi: dpi,
-    };
-    let bundle = render_target_bundle(&doc).map_err(|e| JsError::new(&e.to_string()))?;
+    });
+    let w = f64::from(cols) * square_size_mm;
+    let h = f64::from(rows) * square_size_mm;
+    let bundle = render_target_bundle(&fitted_document(target, w, h, dpi))
+        .map_err(|e| JsError::new(&e.to_string()))?;
     Ok(bundle.png_bytes)
 }
 

--- a/crates/calib-targets-wasm/typescript-extras.d.ts
+++ b/crates/calib-targets-wasm/typescript-extras.d.ts
@@ -1,0 +1,367 @@
+// TypeScript object-shape declarations for `@vitavision/calib-targets`.
+//
+// The auto-generated `calib_targets_wasm.d.ts` (above) types only the
+// function signatures. This block describes the JSON-serialised shapes
+// of every parameter and result type that crosses the WASM boundary.
+//
+// Names and field layouts mirror the Rust serde structs verbatim; renaming
+// any Rust field requires an update here. Public enums on the Rust side
+// are `#[non_exhaustive]`, so consumer match statements should default
+// to a `_:` arm.
+
+// ---------------------------------------------------------------------------
+// Geometry primitives
+// ---------------------------------------------------------------------------
+
+/** `nalgebra::Point2<f32>` serialises as a 2-tuple. */
+export type Point2 = [number, number];
+
+export interface GridCoords {
+  i: number;
+  j: number;
+}
+
+export interface GridTransform {
+  a: number;
+  b: number;
+  c: number;
+  d: number;
+}
+
+export interface GridAlignment {
+  transform: GridTransform;
+  /** Integer translation `[tx, ty]` in grid units. */
+  translation: [number, number];
+}
+
+// ---------------------------------------------------------------------------
+// Corner outputs
+// ---------------------------------------------------------------------------
+
+export interface AxisEstimate {
+  angle: number;
+  sigma: number;
+}
+
+export interface Corner {
+  position: Point2;
+  /** Two orthogonal grid axes (`axes[1] − axes[0] ≈ π/2`). */
+  axes: [AxisEstimate, AxisEstimate];
+  contrast: number;
+  fit_rms: number;
+  strength: number;
+}
+
+export type TargetKind =
+  | "chessboard"
+  | "charuco"
+  | "checkerboard_marker"
+  | "puzzle_board";
+
+export interface LabeledCorner {
+  position: Point2;
+  /** Integer `(i, j)` grid label, rebased so the bounding-box minimum is `(0, 0)`. */
+  grid: GridCoords | null;
+  /** Logical target ID (ChArUco marker-referenced corner, PuzzleBoard master ID). */
+  id: number | null;
+  /** Physical position in mm on the printed board, when known. */
+  target_position: Point2 | null;
+  /** Detector-specific quality score (higher is better). */
+  score: number;
+}
+
+export interface TargetDetection {
+  kind: TargetKind;
+  corners: LabeledCorner[];
+}
+
+// ---------------------------------------------------------------------------
+// Detector-specific result types
+// ---------------------------------------------------------------------------
+
+export interface ChessboardDetectionResult {
+  /** Two orthogonal grid-axis angles in radians, `axes[1] − axes[0] ≈ π/2`. */
+  grid_directions: [number, number];
+  cell_size: number;
+  target: TargetDetection;
+  /** Indices into the input `corners` slice, in the same order as `target.corners`. */
+  strong_indices: number[];
+}
+
+export interface MarkerDetection {
+  id: number;
+  gc: GridCoords;
+  rotation: number;
+  hamming: number;
+  score: number;
+  border_score: number;
+  code: number;
+  inverted: boolean;
+  corners_rect: [Point2, Point2, Point2, Point2];
+  corners_img: [Point2, Point2, Point2, Point2] | null;
+}
+
+export interface CharucoDetectionResult {
+  detection: TargetDetection;
+  markers: MarkerDetection[];
+  alignment: GridAlignment;
+  raw_marker_count: number;
+  raw_marker_wrong_id_count: number;
+}
+
+export interface CircleCandidate {
+  center: Point2;
+  score: number;
+  polarity: "white" | "black";
+}
+
+export interface CircleMatch {
+  cell: GridCoords;
+  candidate_index: number;
+  polarity: "white" | "black";
+}
+
+export interface MarkerBoardDetectionResult {
+  detection: TargetDetection;
+  inliers: number[];
+  circle_candidates: CircleCandidate[];
+  circle_matches: CircleMatch[];
+  alignment: GridAlignment | null;
+  alignment_inliers: number;
+}
+
+export interface PuzzleBoardObservedEdge {
+  row: number;
+  col: number;
+  orientation: "horizontal" | "vertical";
+  bit: 0 | 1;
+  confidence: number;
+}
+
+export interface PuzzleBoardDecodeInfo {
+  edges_observed: number;
+  edges_matched: number;
+  mean_confidence: number;
+  bit_error_rate: number;
+  master_origin_row: number;
+  master_origin_col: number;
+  /** Winning hypothesis score (soft-mode log-likelihood, hard-mode confidence sum). */
+  score_best?: number;
+  score_runner_up?: number;
+  score_margin?: number;
+  runner_up_origin_row?: number;
+  runner_up_origin_col?: number;
+  runner_up_transform?: GridTransform;
+  scoring_mode?: PuzzleBoardScoringMode;
+}
+
+export interface PuzzleBoardDetectionResult {
+  detection: TargetDetection;
+  alignment: GridAlignment;
+  decode: PuzzleBoardDecodeInfo;
+  observed_edges: PuzzleBoardObservedEdge[];
+}
+
+// ---------------------------------------------------------------------------
+// Parameters: ChESS corners
+// ---------------------------------------------------------------------------
+
+export type ThresholdMode = "relative" | "absolute";
+export type DetectorMode = "canonical" | "broad";
+export type DescriptorMode = "follow_detector" | "canonical" | "broad";
+
+export interface RefinerConfig {
+  kind: "center_of_mass" | "forstner" | "saddle_point";
+  center_of_mass: { radius: number };
+  forstner: {
+    radius: number;
+    min_trace: number;
+    min_det: number;
+    max_condition_number: number;
+    max_offset: number;
+  };
+  saddle_point: {
+    radius: number;
+    det_margin: number;
+    max_offset: number;
+    min_abs_det: number;
+  };
+}
+
+export type UpscaleConfig =
+  | { mode: "disabled" }
+  | { mode: "fixed"; factor: number }
+  | { mode: "adaptive"; min_corners: number };
+
+export interface ChessConfig {
+  detector_mode: DetectorMode;
+  descriptor_mode: DescriptorMode;
+  threshold_mode: ThresholdMode;
+  threshold_value: number;
+  nms_radius: number;
+  min_cluster_size: number;
+  refiner: RefinerConfig;
+  pyramid_levels: number;
+  pyramid_min_size: number;
+  refinement_radius: number;
+  merge_radius: number;
+  upscale: UpscaleConfig;
+}
+
+// ---------------------------------------------------------------------------
+// Parameters: chessboard detector (flat 30-ish field shape).
+// ---------------------------------------------------------------------------
+
+export interface ChessboardParams {
+  min_corner_strength: number;
+  max_fit_rms_ratio: number;
+  num_bins: number;
+  max_iters_2means: number;
+  cluster_tol_deg: number;
+  peak_min_separation_deg: number;
+  min_peak_weight_fraction: number;
+  cell_size_hint?: number;
+  seed_edge_tol: number;
+  seed_axis_tol_deg: number;
+  seed_close_tol: number;
+  attach_search_rel: number;
+  attach_axis_tol_deg: number;
+  attach_ambiguity_factor: number;
+  step_tol: number;
+  edge_axis_tol_deg: number;
+  line_tol_rel: number;
+  projective_line_tol_rel: number;
+  line_min_members: number;
+  local_h_tol_rel: number;
+  max_validation_iters: number;
+  enable_line_extrapolation: boolean;
+  enable_gap_fill: boolean;
+  enable_component_merge: boolean;
+  enable_weak_cluster_rescue: boolean;
+  weak_cluster_tol_deg: number;
+  component_merge_min_boundary_pairs: number;
+  max_booster_iters: number;
+  min_labeled_corners: number;
+  max_components: number;
+}
+
+// ---------------------------------------------------------------------------
+// Parameters: ChArUco
+// ---------------------------------------------------------------------------
+
+export type MarkerLayout = "opencv_charuco" | "bottom_left";
+
+export interface CharucoBoardSpec {
+  rows: number;
+  cols: number;
+  cell_size: number;
+  marker_size_rel: number;
+  /** Built-in dictionary name; see `list_aruco_dictionaries()`. */
+  dictionary: string;
+  marker_layout: MarkerLayout;
+}
+
+export interface ScanDecodeConfig {
+  border_bits: number;
+  inset_frac: number;
+  marker_size_rel: number;
+  min_border_score: number;
+  dedup_by_id: boolean;
+  multi_threshold: boolean;
+}
+
+export interface CharucoParams {
+  px_per_square: number;
+  chessboard: ChessboardParams;
+  board: CharucoBoardSpec;
+  scan: ScanDecodeConfig;
+  max_hamming: number;
+  min_marker_inliers: number;
+  min_secondary_marker_inliers: number;
+  grid_smoothness_threshold_rel: number;
+  corner_validation_threshold_rel: number;
+  use_board_level_matcher: boolean;
+  bit_likelihood_slope: number;
+  per_bit_floor: number;
+  alignment_min_margin: number;
+  cell_weight_border_threshold: number;
+}
+
+// ---------------------------------------------------------------------------
+// Parameters: marker board
+// ---------------------------------------------------------------------------
+
+export type CirclePolarity = "white" | "black";
+
+export interface MarkerCircleSpec {
+  cell: GridCoords;
+  polarity: CirclePolarity;
+}
+
+export interface MarkerBoardLayout {
+  rows: number;
+  cols: number;
+  circles: MarkerCircleSpec[];
+}
+
+export interface CircleScoreParams {
+  patch_size: number;
+  diameter_frac: number;
+  ring_thickness_frac: number;
+  ring_radius_mul: number;
+  min_contrast: number;
+  samples: number;
+  center_search_px: number;
+}
+
+export interface CircleMatchParams {
+  max_candidates_per_polarity: number;
+  min_offset_inliers: number;
+}
+
+export interface MarkerBoardParams {
+  layout: MarkerBoardLayout;
+  chessboard: ChessboardParams;
+  circle_score: CircleScoreParams;
+  match_params: CircleMatchParams;
+}
+
+// ---------------------------------------------------------------------------
+// Parameters: PuzzleBoard
+// ---------------------------------------------------------------------------
+
+export interface PuzzleBoardSpec {
+  rows: number;
+  cols: number;
+  cell_size: number;
+  origin_row: number;
+  origin_col: number;
+}
+
+export type PuzzleBoardSearchMode =
+  | { kind: "full" }
+  | { kind: "fixed_board" };
+
+export type PuzzleBoardScoringMode =
+  | { kind: "hard_weighted" }
+  | { kind: "soft_log_likelihood" };
+
+export interface PuzzleBoardDecodeConfig {
+  min_window: number;
+  min_bit_confidence: number;
+  max_bit_error_rate: number;
+  search_all_components: boolean;
+  sample_radius_rel: number;
+  search_mode: PuzzleBoardSearchMode;
+  scoring_mode: PuzzleBoardScoringMode;
+  bit_likelihood_slope: number;
+  per_bit_floor: number;
+  alignment_min_margin: number;
+}
+
+export interface PuzzleBoardParams {
+  px_per_square: number;
+  chessboard: ChessboardParams;
+  board: PuzzleBoardSpec;
+  decode: PuzzleBoardDecodeConfig;
+}

--- a/crates/calib-targets/README.md
+++ b/crates/calib-targets/README.md
@@ -206,7 +206,7 @@ cargo run -p calib-targets --example generate_printable \
 
 - **Python** — [`calib-targets-py`](../calib-targets-py) wraps the same
   facade via `maturin`. The Python package name is `calib_targets`.
-- **WebAssembly** — [`@vitavition/calib-targets`](../calib-targets-wasm)
+- **WebAssembly** — [`@vitavision/calib-targets`](../calib-targets-wasm)
   on npm exposes the detectors to the browser.
 - **C FFI** — [`calib-targets-ffi`](../calib-targets-ffi) exposes a
   stable C ABI with CMake package.

--- a/crates/calib-targets/README.md
+++ b/crates/calib-targets/README.md
@@ -206,8 +206,8 @@ cargo run -p calib-targets --example generate_printable \
 
 - **Python** — [`calib-targets-py`](../calib-targets-py) wraps the same
   facade via `maturin`. The Python package name is `calib_targets`.
-- **WebAssembly** — [`calib-targets-wasm`](../calib-targets-wasm) exposes
-  the detectors to the browser.
+- **WebAssembly** — [`@vitavition/calib-targets`](../calib-targets-wasm)
+  on npm exposes the detectors to the browser.
 - **C FFI** — [`calib-targets-ffi`](../calib-targets-ffi) exposes a
   stable C ABI with CMake package.
 

--- a/demo/bun.lock
+++ b/demo/bun.lock
@@ -1,11 +1,11 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
+  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "calib-targets-demo",
       "dependencies": {
-        "calib-targets-wasm": "file:./pkg",
+        "@vitavition/calib-targets": "file:./pkg",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
       },
@@ -47,7 +47,7 @@
 
     "@babel/helpers": ["@babel/helpers@7.29.2", "", { "dependencies": { "@babel/template": "^7.28.6", "@babel/types": "^7.29.0" } }, "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw=="],
 
-    "@babel/parser": ["@babel/parser@7.29.2", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": { "parser": "bin/babel-parser.js" } }, "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA=="],
+    "@babel/parser": ["@babel/parser@7.29.2", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA=="],
 
     "@babel/plugin-transform-react-jsx-self": ["@babel/plugin-transform-react-jsx-self@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw=="],
 
@@ -123,89 +123,89 @@
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
 
-    "@rollup/plugin-virtual": ["@rollup/plugin-virtual@3.0.2", "", { "peerDependencies": { "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0" } }, "sha512-10monEYsBp3scM4/ND4LNH5Rxvh3e/cVeL3jWTgZ2SrQ+BmUoQcopVQvnaMcOnykb1VkxUFuDAN+0FnpTFRy2A=="],
+    "@rollup/plugin-virtual": ["@rollup/plugin-virtual@3.0.2", "", { "peerDependencies": { "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-10monEYsBp3scM4/ND4LNH5Rxvh3e/cVeL3jWTgZ2SrQ+BmUoQcopVQvnaMcOnykb1VkxUFuDAN+0FnpTFRy2A=="],
 
-    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.60.1", "", { "os": "android", "cpu": "arm" }, "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA=="],
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.60.2", "", { "os": "android", "cpu": "arm" }, "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw=="],
 
-    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.60.1", "", { "os": "android", "cpu": "arm64" }, "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA=="],
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.60.2", "", { "os": "android", "cpu": "arm64" }, "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg=="],
 
-    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.60.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw=="],
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.60.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA=="],
 
-    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.60.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew=="],
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.60.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g=="],
 
-    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.60.1", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w=="],
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.60.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw=="],
 
-    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.60.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g=="],
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.60.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ=="],
 
-    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.60.1", "", { "os": "linux", "cpu": "arm" }, "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g=="],
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.60.2", "", { "os": "linux", "cpu": "arm" }, "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg=="],
 
-    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.60.1", "", { "os": "linux", "cpu": "arm" }, "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg=="],
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.60.2", "", { "os": "linux", "cpu": "arm" }, "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw=="],
 
-    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.60.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ=="],
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.60.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg=="],
 
-    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.60.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA=="],
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.60.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA=="],
 
-    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.60.1", "", { "os": "linux", "cpu": "none" }, "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ=="],
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.60.2", "", { "os": "linux", "cpu": "none" }, "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A=="],
 
-    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.60.1", "", { "os": "linux", "cpu": "none" }, "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw=="],
+    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.60.2", "", { "os": "linux", "cpu": "none" }, "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q=="],
 
-    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.60.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw=="],
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.60.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw=="],
 
-    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.60.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg=="],
+    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.60.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ=="],
 
-    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.60.1", "", { "os": "linux", "cpu": "none" }, "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg=="],
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.60.2", "", { "os": "linux", "cpu": "none" }, "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A=="],
 
-    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.60.1", "", { "os": "linux", "cpu": "none" }, "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg=="],
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.60.2", "", { "os": "linux", "cpu": "none" }, "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ=="],
 
-    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.60.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ=="],
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.60.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA=="],
 
-    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.60.1", "", { "os": "linux", "cpu": "x64" }, "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg=="],
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.60.2", "", { "os": "linux", "cpu": "x64" }, "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ=="],
 
-    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.60.1", "", { "os": "linux", "cpu": "x64" }, "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w=="],
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.60.2", "", { "os": "linux", "cpu": "x64" }, "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw=="],
 
-    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.60.1", "", { "os": "openbsd", "cpu": "x64" }, "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw=="],
+    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.60.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg=="],
 
-    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.60.1", "", { "os": "none", "cpu": "arm64" }, "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA=="],
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.60.2", "", { "os": "none", "cpu": "arm64" }, "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q=="],
 
-    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.60.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g=="],
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.60.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ=="],
 
-    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.60.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg=="],
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.60.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg=="],
 
-    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.60.1", "", { "os": "win32", "cpu": "x64" }, "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg=="],
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.60.2", "", { "os": "win32", "cpu": "x64" }, "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA=="],
 
-    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.1", "", { "os": "win32", "cpu": "x64" }, "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ=="],
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.2", "", { "os": "win32", "cpu": "x64" }, "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA=="],
 
-    "@swc/core": ["@swc/core@1.15.21", "", { "dependencies": { "@swc/counter": "^0.1.3", "@swc/types": "^0.1.25" }, "optionalDependencies": { "@swc/core-darwin-arm64": "1.15.21", "@swc/core-darwin-x64": "1.15.21", "@swc/core-linux-arm-gnueabihf": "1.15.21", "@swc/core-linux-arm64-gnu": "1.15.21", "@swc/core-linux-arm64-musl": "1.15.21", "@swc/core-linux-ppc64-gnu": "1.15.21", "@swc/core-linux-s390x-gnu": "1.15.21", "@swc/core-linux-x64-gnu": "1.15.21", "@swc/core-linux-x64-musl": "1.15.21", "@swc/core-win32-arm64-msvc": "1.15.21", "@swc/core-win32-ia32-msvc": "1.15.21", "@swc/core-win32-x64-msvc": "1.15.21" }, "peerDependencies": { "@swc/helpers": ">=0.5.17" }, "optionalPeers": ["@swc/helpers"] }, "sha512-fkk7NJcBscrR3/F8jiqlMptRHP650NxqDnspBMrRe5d8xOoCy9MLL5kOBLFXjFLfMo3KQQHhk+/jUULOMlR1uQ=="],
+    "@swc/core": ["@swc/core@1.15.30", "", { "dependencies": { "@swc/counter": "^0.1.3", "@swc/types": "^0.1.26" }, "optionalDependencies": { "@swc/core-darwin-arm64": "1.15.30", "@swc/core-darwin-x64": "1.15.30", "@swc/core-linux-arm-gnueabihf": "1.15.30", "@swc/core-linux-arm64-gnu": "1.15.30", "@swc/core-linux-arm64-musl": "1.15.30", "@swc/core-linux-ppc64-gnu": "1.15.30", "@swc/core-linux-s390x-gnu": "1.15.30", "@swc/core-linux-x64-gnu": "1.15.30", "@swc/core-linux-x64-musl": "1.15.30", "@swc/core-win32-arm64-msvc": "1.15.30", "@swc/core-win32-ia32-msvc": "1.15.30", "@swc/core-win32-x64-msvc": "1.15.30" }, "peerDependencies": { "@swc/helpers": ">=0.5.17" }, "optionalPeers": ["@swc/helpers"] }, "sha512-R8VQbQY1BZcbIF2p3gjlTCwAQzx1A194ugWfwld5y+WgVVWqVKm7eURGGOVbQVubgKWzidP2agomBbg96rZilQ=="],
 
-    "@swc/core-darwin-arm64": ["@swc/core-darwin-arm64@1.15.21", "", { "os": "darwin", "cpu": "arm64" }, "sha512-SA8SFg9dp0qKRH8goWsax6bptFE2EdmPf2YRAQW9WoHGf3XKM1bX0nd5UdwxmC5hXsBUZAYf7xSciCler6/oyA=="],
+    "@swc/core-darwin-arm64": ["@swc/core-darwin-arm64@1.15.30", "", { "os": "darwin", "cpu": "arm64" }, "sha512-VvpP+vq08HmGYewMWvrdsxh9s2lthz/808zXm8Yu5kaqeR8Yia2b0eYXleHQ3VAjoStUDk6LzTheBW9KXYQdMA=="],
 
-    "@swc/core-darwin-x64": ["@swc/core-darwin-x64@1.15.21", "", { "os": "darwin", "cpu": "x64" }, "sha512-//fOVntgowz9+V90lVsNCtyyrtbHp3jWH6Rch7MXHXbcvbLmbCTmssl5DeedUWLLGiAAW1wksBdqdGYOTjaNLw=="],
+    "@swc/core-darwin-x64": ["@swc/core-darwin-x64@1.15.30", "", { "os": "darwin", "cpu": "x64" }, "sha512-WiJA0hiZI3nwQAO6mu5RqigtWGDtth4Hiq6rbZxAaQyhIcqKIg5IoMRc1Y071lrNJn29eEDMC86Rq58xgUxlDg=="],
 
-    "@swc/core-linux-arm-gnueabihf": ["@swc/core-linux-arm-gnueabihf@1.15.21", "", { "os": "linux", "cpu": "arm" }, "sha512-meNI4Sh6h9h8DvIfEc0l5URabYMSuNvyisLmG6vnoYAS43s8ON3NJR8sDHvdP7NJTrLe0q/x2XCn6yL/BeHcZg=="],
+    "@swc/core-linux-arm-gnueabihf": ["@swc/core-linux-arm-gnueabihf@1.15.30", "", { "os": "linux", "cpu": "arm" }, "sha512-YANuFUo48kIT6plJgCD0keae9HFXfjxsbvsgevqc0hr/07X/p7sAWTFOGYEc2SXcASaK7UvuQqzlbW8pr7R79g=="],
 
-    "@swc/core-linux-arm64-gnu": ["@swc/core-linux-arm64-gnu@1.15.21", "", { "os": "linux", "cpu": "arm64" }, "sha512-QrXlNQnHeXqU2EzLlnsPoWEh8/GtNJLvfMiPsDhk+ht6Xv8+vhvZ5YZ/BokNWSIZiWPKLAqR0M7T92YF5tmD3g=="],
+    "@swc/core-linux-arm64-gnu": ["@swc/core-linux-arm64-gnu@1.15.30", "", { "os": "linux", "cpu": "arm64" }, "sha512-VndG8jaR4ugY6u+iVOT0Q+d2fZd7sLgjPgN8W/Le+3EbZKl+cRfFxV7Eoz4gfLqhmneZPdcIzf9T3LkgkmqNLg=="],
 
-    "@swc/core-linux-arm64-musl": ["@swc/core-linux-arm64-musl@1.15.21", "", { "os": "linux", "cpu": "arm64" }, "sha512-8/yGCMO333ultDaMQivE5CjO6oXDPeeg1IV4sphojPkb0Pv0i6zvcRIkgp60xDB+UxLr6VgHgt+BBgqS959E9g=="],
+    "@swc/core-linux-arm64-musl": ["@swc/core-linux-arm64-musl@1.15.30", "", { "os": "linux", "cpu": "arm64" }, "sha512-1SYGs2l0Yyyi0pR/P/NKz/x0kqxkoiw+BXeJjLUdecSk/KasncWlJrc6hOvFSgKHOBrzgM5jwuluKtlT8dnrcA=="],
 
-    "@swc/core-linux-ppc64-gnu": ["@swc/core-linux-ppc64-gnu@1.15.21", "", { "os": "linux", "cpu": "ppc64" }, "sha512-ucW0HzPx0s1dgRvcvuLSPSA/2Kk/VYTv9st8qe1Kc22Gu0Q0rH9+6TcBTmMuNIp0Xs4BPr1uBttmbO1wEGI49Q=="],
+    "@swc/core-linux-ppc64-gnu": ["@swc/core-linux-ppc64-gnu@1.15.30", "", { "os": "linux", "cpu": "ppc64" }, "sha512-TXREtiXeRhbfDFbmhnkIsXpKfzbfT73YkV2ZF6w0sfxgjC5zI2ZAbaCOq25qxvegofj2K93DtOpm9RLaBgqR2g=="],
 
-    "@swc/core-linux-s390x-gnu": ["@swc/core-linux-s390x-gnu@1.15.21", "", { "os": "linux", "cpu": "s390x" }, "sha512-ulTnOGc5I7YRObE/9NreAhQg94QkiR5qNhhcUZ1iFAYjzg/JGAi1ch+s/Ixe61pMIr8bfVrF0NOaB0f8wjaAfA=="],
+    "@swc/core-linux-s390x-gnu": ["@swc/core-linux-s390x-gnu@1.15.30", "", { "os": "linux", "cpu": "s390x" }, "sha512-DCR2YYeyd6DQE4OuDhImouuNcjXEiEdnn1Y0DyGteugPEDvVuvYk8Xddi+4o2SgWH6jiW8/I+3emZvbep1NC+g=="],
 
-    "@swc/core-linux-x64-gnu": ["@swc/core-linux-x64-gnu@1.15.21", "", { "os": "linux", "cpu": "x64" }, "sha512-D0RokxtM+cPvSqJIKR6uja4hbD+scI9ezo95mBhfSyLUs9wnPPl26sLp1ZPR/EXRdYm3F3S6RUtVi+8QXhT24Q=="],
+    "@swc/core-linux-x64-gnu": ["@swc/core-linux-x64-gnu@1.15.30", "", { "os": "linux", "cpu": "x64" }, "sha512-5Pizw3NgfOJ5BJOBK8TIRa59xFW2avESTOBDPTAYwZYa1JNDs+KMF9lUfjJiJLM5HiMs/wPheA9eiT0q9m2AoA=="],
 
-    "@swc/core-linux-x64-musl": ["@swc/core-linux-x64-musl@1.15.21", "", { "os": "linux", "cpu": "x64" }, "sha512-nER8u7VeRfmU6fMDzl1NQAbbB/G7O2avmvCOwIul1uGkZ2/acbPH+DCL9h5+0yd/coNcxMBTL6NGepIew+7C2w=="],
+    "@swc/core-linux-x64-musl": ["@swc/core-linux-x64-musl@1.15.30", "", { "os": "linux", "cpu": "x64" }, "sha512-qyqydP/wyH8alcIP4a2hnGSjHLJjm9H7yDFup+CPy9oTahFgLLwnNcv5UHXqO2Qs3AIND+cls5f/Bb6hqpxdgA=="],
 
-    "@swc/core-win32-arm64-msvc": ["@swc/core-win32-arm64-msvc@1.15.21", "", { "os": "win32", "cpu": "arm64" }, "sha512-+/AgNBnjYugUA8C0Do4YzymgvnGbztv7j8HKSQLvR/DQgZPoXQ2B3PqB2mTtGh/X5DhlJWiqnunN35JUgWcAeQ=="],
+    "@swc/core-win32-arm64-msvc": ["@swc/core-win32-arm64-msvc@1.15.30", "", { "os": "win32", "cpu": "arm64" }, "sha512-CaQENgDHVGOg1mSF5sQVgvfFHG9kjMor2rkLMLeLOkfZYNj13ppnJ9+lfaBZLZUMMbnlGQnavCJb8PVBUOso7Q=="],
 
-    "@swc/core-win32-ia32-msvc": ["@swc/core-win32-ia32-msvc@1.15.21", "", { "os": "win32", "cpu": "ia32" }, "sha512-IkSZj8PX/N4HcaFhMQtzmkV8YSnuNoJ0E6OvMwFiOfejPhiKXvl7CdDsn1f4/emYEIDO3fpgZW9DTaCRMDxaDA=="],
+    "@swc/core-win32-ia32-msvc": ["@swc/core-win32-ia32-msvc@1.15.30", "", { "os": "win32", "cpu": "ia32" }, "sha512-30VdLeGk6fugiUs/kUdJ/pAg7z/zpvVbR11RH60jZ0Z42WIeIniYx0rLEWN7h/pKJ3CopqsQ3RsogCAkRKiA2g=="],
 
-    "@swc/core-win32-x64-msvc": ["@swc/core-win32-x64-msvc@1.15.21", "", { "os": "win32", "cpu": "x64" }, "sha512-zUyWso7OOENB6e1N1hNuNn8vbvLsTdKQ5WKLgt/JcBNfJhKy/6jmBmqI3GXk/MyvQKd5SLvP7A0F36p7TeDqvw=="],
+    "@swc/core-win32-x64-msvc": ["@swc/core-win32-x64-msvc@1.15.30", "", { "os": "win32", "cpu": "x64" }, "sha512-4iObHPR+Q4oDY110EF5SF5eIaaVJNpMdG9C0q3Q92BsJ5y467uHz7sYQhP60WYlLFsLQ1el2YrIPUItUAQGOKg=="],
 
     "@swc/counter": ["@swc/counter@0.1.3", "", {}, "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ=="],
 
     "@swc/types": ["@swc/types@0.1.26", "", { "dependencies": { "@swc/counter": "^0.1.3" } }, "sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw=="],
 
-    "@swc/wasm": ["@swc/wasm@1.15.21", "", {}, "sha512-AVomFdpE9LiB8Q0dNo1UqpqGut//Q7HJNyyCzyHsywHSUM/1pKfzywIjdha4WipgjyOPebYb93pTDBUn2iWvVA=="],
+    "@swc/wasm": ["@swc/wasm@1.15.30", "", {}, "sha512-Z/27kZFJpKzmTgcOAlMrQZ3WEZOJDqk879wSY9SEuLtMVHxEZ9t4R3rGNUGj9e7ldY6GP6DCvN7Q0m7UTrhToA=="],
 
     "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
 
@@ -221,15 +221,15 @@
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
+    "@vitavition/calib-targets": ["@vitavition/calib-targets@file:pkg", {}],
+
     "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
 
-    "baseline-browser-mapping": ["baseline-browser-mapping@2.10.13", "", { "bin": "dist/cli.cjs" }, "sha512-BL2sTuHOdy0YT1lYieUxTw/QMtPBC3pmlJC6xk8BBYVv6vcw3SGdKemQ+Xsx9ik2F/lYDO9tqsFQH1r9PFuHKw=="],
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.10.21", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-Q+rUQ7Uz8AHM7DEaNdwvfFCTq7a43lNTzuS94eiWqwyxfV/wJv+oUivef51T91mmRY4d4A1u9rcSvkeufCVXlA=="],
 
-    "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": "cli.js" }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
+    "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
 
-    "calib-targets-wasm": ["calib-targets-wasm@file:pkg", {}],
-
-    "caniuse-lite": ["caniuse-lite@1.0.30001782", "", {}, "sha512-dZcaJLJeDMh4rELYFw1tvSn1bhZWYFOt468FcbHHxx/Z/dFidd1I6ciyFdi3iwfQCyOjqo9upF6lGQYtMiJWxw=="],
+    "caniuse-lite": ["caniuse-lite@1.0.30001790", "", {}, "sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw=="],
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
@@ -237,13 +237,13 @@
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
-    "electron-to-chromium": ["electron-to-chromium@1.5.329", "", {}, "sha512-/4t+AS1l4S3ZC0Ja7PHFIWeBIxGA3QGqV8/yKsP36v7NcyUCl+bIcmw6s5zVuMIECWwBrAK/6QLzTmbJChBboQ=="],
+    "electron-to-chromium": ["electron-to-chromium@1.5.344", "", {}, "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg=="],
 
-    "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": "bin/esbuild" }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
+    "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
-    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" } }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
@@ -251,47 +251,47 @@
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
-    "jsesc": ["jsesc@3.1.0", "", { "bin": "bin/jsesc" }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
+    "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
-    "json5": ["json5@2.2.3", "", { "bin": "lib/cli.js" }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
+    "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "nanoid": ["nanoid@3.3.11", "", { "bin": "bin/nanoid.cjs" }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+    "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
-    "node-releases": ["node-releases@2.0.36", "", {}, "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA=="],
+    "node-releases": ["node-releases@2.0.38", "", {}, "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
-    "postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
+    "postcss": ["postcss@8.5.10", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ=="],
 
-    "react": ["react@19.2.4", "", {}, "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="],
+    "react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
 
-    "react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
+    "react-dom": ["react-dom@19.2.5", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.5" } }, "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag=="],
 
     "react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
 
-    "rollup": ["rollup@4.60.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.1", "@rollup/rollup-android-arm64": "4.60.1", "@rollup/rollup-darwin-arm64": "4.60.1", "@rollup/rollup-darwin-x64": "4.60.1", "@rollup/rollup-freebsd-arm64": "4.60.1", "@rollup/rollup-freebsd-x64": "4.60.1", "@rollup/rollup-linux-arm-gnueabihf": "4.60.1", "@rollup/rollup-linux-arm-musleabihf": "4.60.1", "@rollup/rollup-linux-arm64-gnu": "4.60.1", "@rollup/rollup-linux-arm64-musl": "4.60.1", "@rollup/rollup-linux-loong64-gnu": "4.60.1", "@rollup/rollup-linux-loong64-musl": "4.60.1", "@rollup/rollup-linux-ppc64-gnu": "4.60.1", "@rollup/rollup-linux-ppc64-musl": "4.60.1", "@rollup/rollup-linux-riscv64-gnu": "4.60.1", "@rollup/rollup-linux-riscv64-musl": "4.60.1", "@rollup/rollup-linux-s390x-gnu": "4.60.1", "@rollup/rollup-linux-x64-gnu": "4.60.1", "@rollup/rollup-linux-x64-musl": "4.60.1", "@rollup/rollup-openbsd-x64": "4.60.1", "@rollup/rollup-openharmony-arm64": "4.60.1", "@rollup/rollup-win32-arm64-msvc": "4.60.1", "@rollup/rollup-win32-ia32-msvc": "4.60.1", "@rollup/rollup-win32-x64-gnu": "4.60.1", "@rollup/rollup-win32-x64-msvc": "4.60.1", "fsevents": "~2.3.2" }, "bin": "dist/bin/rollup" }, "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w=="],
+    "rollup": ["rollup@4.60.2", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.2", "@rollup/rollup-android-arm64": "4.60.2", "@rollup/rollup-darwin-arm64": "4.60.2", "@rollup/rollup-darwin-x64": "4.60.2", "@rollup/rollup-freebsd-arm64": "4.60.2", "@rollup/rollup-freebsd-x64": "4.60.2", "@rollup/rollup-linux-arm-gnueabihf": "4.60.2", "@rollup/rollup-linux-arm-musleabihf": "4.60.2", "@rollup/rollup-linux-arm64-gnu": "4.60.2", "@rollup/rollup-linux-arm64-musl": "4.60.2", "@rollup/rollup-linux-loong64-gnu": "4.60.2", "@rollup/rollup-linux-loong64-musl": "4.60.2", "@rollup/rollup-linux-ppc64-gnu": "4.60.2", "@rollup/rollup-linux-ppc64-musl": "4.60.2", "@rollup/rollup-linux-riscv64-gnu": "4.60.2", "@rollup/rollup-linux-riscv64-musl": "4.60.2", "@rollup/rollup-linux-s390x-gnu": "4.60.2", "@rollup/rollup-linux-x64-gnu": "4.60.2", "@rollup/rollup-linux-x64-musl": "4.60.2", "@rollup/rollup-openbsd-x64": "4.60.2", "@rollup/rollup-openharmony-arm64": "4.60.2", "@rollup/rollup-win32-arm64-msvc": "4.60.2", "@rollup/rollup-win32-ia32-msvc": "4.60.2", "@rollup/rollup-win32-x64-gnu": "4.60.2", "@rollup/rollup-win32-x64-msvc": "4.60.2", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ=="],
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
-    "semver": ["semver@6.3.1", "", { "bin": "bin/semver.js" }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+    "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
-    "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+    "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
 
     "typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
 
-    "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": "cli.js" }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
+    "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 
-    "uuid": ["uuid@10.0.0", "", { "bin": "dist/bin/uuid" }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
+    "uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
 
-    "vite": ["vite@6.4.1", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": "bin/vite.js" }, "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g=="],
+    "vite": ["vite@6.4.2", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ=="],
 
     "vite-plugin-top-level-await": ["vite-plugin-top-level-await@1.6.0", "", { "dependencies": { "@rollup/plugin-virtual": "^3.0.2", "@swc/core": "^1.12.14", "@swc/wasm": "^1.12.14", "uuid": "10.0.0" }, "peerDependencies": { "vite": ">=2.8" } }, "sha512-bNhUreLamTIkoulCR9aDXbTbhLk6n1YE8NJUTTxl5RYskNRtzOR0ASzSjBVRtNdjIfngDXo11qOsybGLNsrdww=="],
 

--- a/demo/bun.lock
+++ b/demo/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "calib-targets-demo",
       "dependencies": {
-        "@vitavition/calib-targets": "file:./pkg",
+        "@vitavision/calib-targets": "file:./pkg",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
       },
@@ -221,7 +221,7 @@
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
-    "@vitavition/calib-targets": ["@vitavition/calib-targets@file:pkg", {}],
+    "@vitavision/calib-targets": ["@vitavision/calib-targets@file:pkg", {}],
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
 

--- a/demo/package.json
+++ b/demo/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "@vitavition/calib-targets": "file:./pkg"
+    "@vitavision/calib-targets": "file:./pkg"
   },
   "devDependencies": {
     "@types/react": "^19.1.0",

--- a/demo/package.json
+++ b/demo/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "calib-targets-wasm": "file:./pkg"
+    "@vitavition/calib-targets": "file:./pkg"
   },
   "devDependencies": {
     "@types/react": "^19.1.0",

--- a/demo/package.json
+++ b/demo/package.json
@@ -9,9 +9,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@vitavision/calib-targets": "file:./pkg",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0",
-    "@vitavision/calib-targets": "file:./pkg"
+    "react-dom": "^19.1.0"
   },
   "devDependencies": {
     "@types/react": "^19.1.0",

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -5,110 +5,27 @@ import { ConfigPanel } from "./components/ConfigPanel";
 import { ResultsPanel } from "./components/ResultsPanel";
 import { useDetector } from "./hooks/useDetector";
 import {
+  charucoSweepForBoard,
+  chessboardSweepDefault,
+  defaultCharucoParams,
   defaultChessConfig,
   defaultChessboardParams,
+  defaultMarkerBoardParams,
   defaultPuzzleBoardParams,
+  puzzleboardSweepForBoard,
 } from "./lib/detector";
 import type { ImageData } from "./lib/image-utils";
 import type {
+  CharucoParams,
   ChessConfig,
   ChessboardParams,
-  CharucoDetectorParams,
+  DetectionMode,
   MarkerBoardParams,
   PuzzleBoardParams,
-  DetectionMode,
 } from "./types/calib-targets";
 
-const DEFAULT_CHARUCO_PARAMS: CharucoDetectorParams = {
-  charuco: {
-    rows: 22,
-    cols: 22,
-    marker_size_rel: 0.75,
-    dictionary: "DICT_4X4_1000",
-    marker_layout: "opencv_charuco",
-  },
-  px_per_square: 60,
-  chessboard: {
-    min_corner_strength: 0.5,
-    min_corners: 32,
-    expected_rows: 21,
-    expected_cols: 21,
-    completeness_threshold: 0.05,
-    use_orientation_clustering: true,
-    orientation_clustering_params: {
-      num_bins: 90,
-      max_iters: 10,
-      peak_min_separation_deg: 10,
-      outlier_threshold_deg: 30,
-      min_peak_weight_fraction: 0.05,
-      use_weights: true,
-    },
-    graph: {
-      min_spacing_pix: 5,
-      max_spacing_pix: 50,
-      k_neighbors: 8,
-      orientation_tolerance_deg: 22.5,
-    },
-  },
-  scan: {
-    marker_size_rel: 0.75,
-    inset_frac: 0.06,
-    border_bits: 1,
-    min_border_score: 0.85,
-    dedup_by_id: true,
-  },
-  max_hamming: 2,
-  min_marker_inliers: 8,
-  corner_validation_threshold_rel: 0.3,
-};
-
-const DEFAULT_MARKER_PARAMS: MarkerBoardParams = {
-  layout: {
-    rows: 22,
-    cols: 22,
-    cell_size: 1.0,
-    circles: [
-      { i: 11, j: 11, polarity: "white" },
-      { i: 12, j: 11, polarity: "black" },
-      { i: 12, j: 12, polarity: "white" },
-    ],
-  },
-  chessboard: {
-    min_corner_strength: 0.0,
-    min_corners: 16,
-    expected_rows: 22,
-    expected_cols: 22,
-    completeness_threshold: 0.05,
-    use_orientation_clustering: true,
-    orientation_clustering_params: {
-      num_bins: 90,
-      max_iters: 10,
-      peak_min_separation_deg: 10,
-      outlier_threshold_deg: 30,
-      min_peak_weight_fraction: 0.05,
-      use_weights: true,
-    },
-    graph: {
-      min_spacing_pix: 5,
-      max_spacing_pix: 50,
-      k_neighbors: 8,
-      orientation_tolerance_deg: 22.5,
-    },
-  },
-  circle_score: {
-    patch_size: 64,
-    diameter_frac: 0.5,
-    ring_thickness_frac: 0.35,
-    ring_radius_mul: 1.6,
-    min_contrast: 10,
-    samples: 48,
-    center_search_px: 2,
-  },
-  match_params: {
-    max_candidates_per_polarity: 6,
-    min_offset_inliers: 1,
-  },
-};
+const DEFAULT_CHARUCO_DICTIONARY = "DICT_4X4_50";
+const DEFAULT_CHARUCO_MARKER_REL = 0.75;
 
 export default function App() {
   const { ready, initError, loading, result, error, timeMs, detect } =
@@ -116,59 +33,117 @@ export default function App() {
 
   const [image, setImage] = useState<ImageData | null>(null);
   const [mode, setMode] = useState<DetectionMode>("chessboard");
+  const [useSweep, setUseSweep] = useState(false);
   const [chessCfg, setChessCfg] = useState<ChessConfig | null>(null);
   const [cbParams, setCbParams] = useState<ChessboardParams | null>(null);
-  const [charucoParams, setCharucoParams] =
-    useState<CharucoDetectorParams>(DEFAULT_CHARUCO_PARAMS);
-  const [markerParams, setMarkerParams] =
-    useState<MarkerBoardParams>(DEFAULT_MARKER_PARAMS);
+  const [charucoParams, setCharucoParams] = useState<CharucoParams | null>(null);
+  const [markerParams, setMarkerParams] = useState<MarkerBoardParams | null>(
+    null,
+  );
   const [puzzleParams, setPuzzleParams] = useState<PuzzleBoardParams | null>(
     null,
   );
 
-  // Load defaults from WASM once initialized
+  // Load defaults from WASM once initialised
   useEffect(() => {
     if (ready && !chessCfg) {
       setChessCfg(defaultChessConfig());
       setCbParams(defaultChessboardParams());
+      setCharucoParams(
+        defaultCharucoParams(
+          5,
+          7,
+          DEFAULT_CHARUCO_MARKER_REL,
+          DEFAULT_CHARUCO_DICTIONARY,
+        ),
+      );
+      setMarkerParams(defaultMarkerBoardParams());
       setPuzzleParams(defaultPuzzleBoardParams(10, 10));
     }
   }, [ready, chessCfg]);
 
   const handleDetect = useCallback(() => {
-    if (!image || !chessCfg || !cbParams || !puzzleParams) return;
+    if (
+      !image ||
+      !chessCfg ||
+      !cbParams ||
+      !charucoParams ||
+      !markerParams ||
+      !puzzleParams
+    )
+      return;
 
-    let params:
-      | ChessboardParams
-      | CharucoDetectorParams
-      | MarkerBoardParams
-      | PuzzleBoardParams;
+    const common = {
+      gray: image.gray,
+      width: image.width,
+      height: image.height,
+      chessCfg,
+    };
+
     switch (mode) {
       case "corners":
-        params = cbParams; // unused, but required by signature
+        detect({ mode: "corners", ...common });
         break;
       case "chessboard":
-        params = cbParams;
+        detect({
+          mode: "chessboard",
+          ...common,
+          params: cbParams,
+          sweep: useSweep ? chessboardSweepDefault() : undefined,
+        });
         break;
-      case "charuco":
-        params = charucoParams;
+      case "charuco": {
+        const sweep = useSweep
+          ? charucoSweepForBoard(
+              charucoParams.board.rows,
+              charucoParams.board.cols,
+              charucoParams.board.marker_size_rel,
+              charucoParams.board.dictionary,
+            )
+          : undefined;
+        detect({ mode: "charuco", ...common, params: charucoParams, sweep });
         break;
+      }
       case "marker_board":
-        params = markerParams;
+        // The marker-board crate does not yet ship a sweep preset; the toggle
+        // is a no-op for this mode and falls through to the single-config path.
+        detect({ mode: "marker_board", ...common, params: markerParams });
         break;
-      case "puzzleboard":
-        params = puzzleParams;
+      case "puzzleboard": {
+        const sweep = useSweep
+          ? puzzleboardSweepForBoard(
+              puzzleParams.board.rows,
+              puzzleParams.board.cols,
+            )
+          : undefined;
+        detect({ mode: "puzzleboard", ...common, params: puzzleParams, sweep });
         break;
+      }
     }
-
-    detect(mode, image.gray, image.width, image.height, chessCfg, params);
-  }, [image, mode, chessCfg, cbParams, charucoParams, markerParams, puzzleParams, detect]);
+  }, [
+    image,
+    mode,
+    useSweep,
+    chessCfg,
+    cbParams,
+    charucoParams,
+    markerParams,
+    puzzleParams,
+    detect,
+  ]);
 
   if (initError) {
     return <div className="init-error">Failed to load WASM: {initError}</div>;
   }
 
-  if (!ready || !chessCfg || !cbParams || !puzzleParams) {
+  if (
+    !ready ||
+    !chessCfg ||
+    !cbParams ||
+    !charucoParams ||
+    !markerParams ||
+    !puzzleParams
+  ) {
     return <div className="loading">Loading WASM module...</div>;
   }
 
@@ -187,6 +162,8 @@ export default function App() {
           <ConfigPanel
             mode={mode}
             onModeChange={setMode}
+            useSweep={useSweep}
+            onUseSweepChange={setUseSweep}
             chessCfg={chessCfg}
             onChessCfgChange={setChessCfg}
             chessboardParams={cbParams}

--- a/demo/src/components/ConfigPanel.tsx
+++ b/demo/src/components/ConfigPanel.tsx
@@ -1,22 +1,25 @@
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
+import { listArucoDictionaries } from "../lib/detector";
 import type {
+  CharucoParams,
   ChessConfig,
   ChessboardParams,
-  CharucoDetectorParams,
+  DetectionMode,
   MarkerBoardParams,
   PuzzleBoardParams,
-  DetectionMode,
 } from "../types/calib-targets";
 
 interface Props {
   mode: DetectionMode;
   onModeChange: (mode: DetectionMode) => void;
+  useSweep: boolean;
+  onUseSweepChange: (v: boolean) => void;
   chessCfg: ChessConfig;
   onChessCfgChange: (cfg: ChessConfig) => void;
   chessboardParams: ChessboardParams;
   onChessboardParamsChange: (p: ChessboardParams) => void;
-  charucoParams: CharucoDetectorParams;
-  onCharucoParamsChange: (p: CharucoDetectorParams) => void;
+  charucoParams: CharucoParams;
+  onCharucoParamsChange: (p: CharucoParams) => void;
   markerParams: MarkerBoardParams;
   onMarkerParamsChange: (p: MarkerBoardParams) => void;
   puzzleParams: PuzzleBoardParams;
@@ -92,6 +95,8 @@ function NumberInput({
 export function ConfigPanel({
   mode,
   onModeChange,
+  useSweep,
+  onUseSweepChange,
   chessCfg,
   onChessCfgChange,
   chessboardParams,
@@ -106,6 +111,8 @@ export function ConfigPanel({
   loading,
   hasImage,
 }: Props) {
+  const dictionaries = useMemo(() => listArucoDictionaries(), []);
+
   const updateChess = useCallback(
     (partial: Partial<ChessConfig>) => {
       onChessCfgChange({ ...chessCfg, ...partial });
@@ -121,7 +128,7 @@ export function ConfigPanel({
   );
 
   const updateCharuco = useCallback(
-    (partial: Partial<CharucoDetectorParams>) => {
+    (partial: Partial<CharucoParams>) => {
       onCharucoParamsChange({ ...charucoParams, ...partial });
     },
     [charucoParams, onCharucoParamsChange],
@@ -140,6 +147,8 @@ export function ConfigPanel({
     },
     [puzzleParams, onPuzzleParamsChange],
   );
+
+  const sweepDisabled = mode === "corners" || mode === "marker_board";
 
   return (
     <div className="config-panel">
@@ -166,6 +175,16 @@ export function ConfigPanel({
           </label>
         ))}
       </div>
+
+      <label className="sweep-toggle">
+        <input
+          type="checkbox"
+          checked={useSweep && !sweepDisabled}
+          disabled={sweepDisabled}
+          onChange={(e) => onUseSweepChange(e.target.checked)}
+        />
+        Use 3-config sweep ({sweepDisabled ? "n/a for this mode" : "detect_*_best"})
+      </label>
 
       <h3>ChESS Corner Config</h3>
       <Slider
@@ -197,7 +216,7 @@ export function ConfigPanel({
         <>
           <h3>Chessboard Params</h3>
           <Slider
-            label="Min Strength"
+            label="Min Corner Strength"
             value={chessboardParams.min_corner_strength}
             min={0}
             max={1}
@@ -205,45 +224,28 @@ export function ConfigPanel({
             onChange={(v) => updateCb({ min_corner_strength: v })}
           />
           <Slider
-            label="Min Corners"
-            value={chessboardParams.min_corners}
+            label="Min Labeled Corners"
+            value={chessboardParams.min_labeled_corners}
             min={4}
-            max={200}
+            max={64}
             step={1}
-            onChange={(v) => updateCb({ min_corners: v })}
-          />
-          <NumberInput
-            label="Expected Rows"
-            value={chessboardParams.expected_rows}
-            min={2}
-            max={100}
-            onChange={(v) => updateCb({ expected_rows: v })}
-          />
-          <NumberInput
-            label="Expected Cols"
-            value={chessboardParams.expected_cols}
-            min={2}
-            max={100}
-            onChange={(v) => updateCb({ expected_cols: v })}
+            onChange={(v) => updateCb({ min_labeled_corners: v })}
           />
           <Slider
-            label="Completeness"
-            value={chessboardParams.completeness_threshold}
-            min={0}
-            max={1}
-            step={0.01}
-            onChange={(v) => updateCb({ completeness_threshold: v })}
+            label="Max Components"
+            value={chessboardParams.max_components}
+            min={1}
+            max={8}
+            step={1}
+            onChange={(v) => updateCb({ max_components: v })}
           />
-          <Slider
-            label="Max Spacing (px)"
-            value={chessboardParams.graph.max_spacing_pix}
-            min={10}
+          <NumberInput
+            label="Cell Size Hint (px)"
+            value={chessboardParams.cell_size_hint}
+            min={1}
             max={500}
-            step={5}
             onChange={(v) =>
-              updateCb({
-                graph: { ...chessboardParams.graph, max_spacing_pix: v },
-              })
+              updateCb({ cell_size_hint: v ?? undefined })
             }
           />
         </>
@@ -254,38 +256,55 @@ export function ConfigPanel({
           <h3>ChArUco Board</h3>
           <NumberInput
             label="Board Rows"
-            value={charucoParams.charuco.rows}
+            value={charucoParams.board.rows}
             min={2}
             max={50}
             onChange={(v) =>
               updateCharuco({
-                charuco: { ...charucoParams.charuco, rows: v ?? 8 },
+                board: { ...charucoParams.board, rows: v ?? 5 },
               })
             }
           />
           <NumberInput
             label="Board Cols"
-            value={charucoParams.charuco.cols}
+            value={charucoParams.board.cols}
             min={2}
             max={50}
             onChange={(v) =>
               updateCharuco({
-                charuco: { ...charucoParams.charuco, cols: v ?? 8 },
+                board: { ...charucoParams.board, cols: v ?? 7 },
               })
             }
           />
           <Slider
             label="Marker Size Rel"
-            value={charucoParams.charuco.marker_size_rel}
+            value={charucoParams.board.marker_size_rel}
             min={0.1}
             max={0.95}
             step={0.05}
             onChange={(v) =>
               updateCharuco({
-                charuco: { ...charucoParams.charuco, marker_size_rel: v },
+                board: { ...charucoParams.board, marker_size_rel: v },
               })
             }
           />
+          <div className="input-row">
+            <label>Dictionary:</label>
+            <select
+              value={charucoParams.board.dictionary}
+              onChange={(e) =>
+                updateCharuco({
+                  board: { ...charucoParams.board, dictionary: e.target.value },
+                })
+              }
+            >
+              {dictionaries.map((d) => (
+                <option key={d} value={d}>
+                  {d}
+                </option>
+              ))}
+            </select>
+          </div>
           <Slider
             label="Px Per Square"
             value={charucoParams.px_per_square}
@@ -315,7 +334,7 @@ export function ConfigPanel({
             max={50}
             onChange={(v) =>
               updateMarker({
-                layout: { ...markerParams.layout, rows: v ?? 22 },
+                layout: { ...markerParams.layout, rows: v ?? 6 },
               })
             }
           />
@@ -326,7 +345,7 @@ export function ConfigPanel({
             max={50}
             onChange={(v) =>
               updateMarker({
-                layout: { ...markerParams.layout, cols: v ?? 22 },
+                layout: { ...markerParams.layout, cols: v ?? 8 },
               })
             }
           />

--- a/demo/src/components/ImageCanvas.tsx
+++ b/demo/src/components/ImageCanvas.tsx
@@ -5,7 +5,7 @@ import type {
   Corner,
   GridAlignment,
   LabeledCorner,
-  ObservedEdge,
+  PuzzleBoardObservedEdge,
 } from "../types/calib-targets";
 
 interface Props {
@@ -39,9 +39,16 @@ function cornerColor(corner: LabeledCorner, _idx: number): string {
   return "#00ff00";
 }
 
+function cornerAxisAngle(corner: Corner): number {
+  // The first grid axis (in [0, π)) doubles as a hue source and a stroke
+  // direction; chessboard parity flips axes[0]/axes[1] but the absolute
+  // direction is what we want for an at-a-glance overlay.
+  return corner.axes[0].angle;
+}
+
 function rawCornerColor(corner: Corner, _idx: number): string {
-  // Color by orientation (hue from 0..pi mapped to 0..360)
-  const hue = ((corner.orientation / Math.PI) * 360 + 360) % 360;
+  // Color by axis-0 angle (hue from 0..π mapped to 0..360°).
+  const hue = ((cornerAxisAngle(corner) / Math.PI) * 360 + 360) % 360;
   return `hsl(${hue}, 100%, 50%)`;
 }
 
@@ -72,7 +79,9 @@ export function ImageCanvas({ image, detection }: Props) {
       for (let i = 0; i < detection.corners.length; i++) {
         const c = detection.corners[i]!;
         const color = rawCornerColor(c, i);
-        const radius = Math.max(2, Math.min(6, c.strength * 3));
+        // c.strength is integer corner response (typically 100s–1000s);
+        // bound the dot radius to a sensible UI range.
+        const radius = Math.max(2, Math.min(6, c.strength / 200));
         const [cx, cy] = c.position;
 
         ctx.beginPath();
@@ -81,14 +90,12 @@ export function ImageCanvas({ image, detection }: Props) {
         ctx.globalAlpha = 0.8;
         ctx.fill();
 
-        // Draw orientation line
+        // Draw axis-0 direction line
+        const angle = cornerAxisAngle(c);
         const len = radius * 2.5;
         ctx.beginPath();
         ctx.moveTo(cx, cy);
-        ctx.lineTo(
-          cx + len * Math.cos(c.orientation),
-          cy + len * Math.sin(c.orientation),
-        );
+        ctx.lineTo(cx + len * Math.cos(angle), cy + len * Math.sin(angle));
         ctx.strokeStyle = color;
         ctx.lineWidth = 1.5;
         ctx.stroke();
@@ -99,10 +106,10 @@ export function ImageCanvas({ image, detection }: Props) {
 
     // For detection results with TargetDetection
     let corners: LabeledCorner[] = [];
-    let edges: ObservedEdge[] | null = null;
+    let edges: PuzzleBoardObservedEdge[] | null = null;
     let alignment: GridAlignment | null = null;
     if (detection.mode === "chessboard" && detection.result) {
-      corners = detection.result.detection.corners;
+      corners = detection.result.target.corners;
     } else if (detection.mode === "charuco") {
       corners = detection.result.detection.corners;
     } else if (detection.mode === "marker_board" && detection.result) {
@@ -164,7 +171,7 @@ export function ImageCanvas({ image, detection }: Props) {
       // Horizontal edge at (row=r, col=c): connects local grid (i=c, j=r) → (i=c+1, j=r).
       // Vertical   edge at (row=r, col=c): connects local grid (i=c, j=r) → (i=c,   j=r+1).
       const endpointsFor = (
-        e: ObservedEdge,
+        e: PuzzleBoardObservedEdge,
       ): [LabeledCorner, LabeledCorner] | null => {
         const [ai, aj] = toMaster(e.col, e.row);
         const [bi, bj] =

--- a/demo/src/components/ImageUpload.tsx
+++ b/demo/src/components/ImageUpload.tsx
@@ -1,19 +1,42 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import type { ImageData } from "../lib/image-utils";
 import { loadImage, loadImageFromBytes } from "../lib/image-utils";
-import { renderPuzzleBoardPng, rgbaToGray } from "../lib/detector";
+import {
+  listArucoDictionaries,
+  renderCharucoPng,
+  renderChessboardPng,
+  renderMarkerBoardPng,
+  renderPuzzleBoardPng,
+  rgbaToGray,
+} from "../lib/detector";
+import type { SyntheticTargetKind } from "../types/calib-targets";
 
 interface Props {
   onImageLoaded: (data: ImageData) => void;
 }
 
+const KIND_OPTIONS: ReadonlyArray<readonly [SyntheticTargetKind, string]> = [
+  ["chessboard", "Chessboard"],
+  ["charuco", "ChArUco"],
+  ["marker_board", "Marker board"],
+  ["puzzleboard", "PuzzleBoard"],
+];
+
+const DPI = 300;
+const SQUARE_MM = 12;
+
 export function ImageUpload({ onImageLoaded }: Props) {
   const inputRef = useRef<HTMLInputElement>(null);
   const [dragging, setDragging] = useState(false);
+  const [synthKind, setSynthKind] = useState<SyntheticTargetKind>("puzzleboard");
   const [synthRows, setSynthRows] = useState(10);
   const [synthCols, setSynthCols] = useState(10);
+  const [charucoDict, setCharucoDict] = useState<string>("DICT_4X4_50");
+  const [charucoMarkerRel, setCharucoMarkerRel] = useState(0.75);
   const [synthesising, setSynthesising] = useState(false);
   const [synthError, setSynthError] = useState<string | null>(null);
+
+  const dictionaries = useMemo(() => listArucoDictionaries(), []);
 
   const handleFile = useCallback(
     async (file: File) => {
@@ -54,7 +77,28 @@ export function ImageUpload({ onImageLoaded }: Props) {
       setSynthError(null);
       setSynthesising(true);
       try {
-        const bytes = renderPuzzleBoardPng(synthRows, synthCols, 12.0, 300);
+        let bytes: Uint8Array;
+        switch (synthKind) {
+          case "chessboard":
+            bytes = renderChessboardPng(synthRows, synthCols, SQUARE_MM, DPI);
+            break;
+          case "charuco":
+            bytes = renderCharucoPng(
+              synthRows,
+              synthCols,
+              SQUARE_MM,
+              charucoMarkerRel,
+              charucoDict,
+              DPI,
+            );
+            break;
+          case "marker_board":
+            bytes = renderMarkerBoardPng(synthRows, synthCols, SQUARE_MM, DPI);
+            break;
+          case "puzzleboard":
+            bytes = renderPuzzleBoardPng(synthRows, synthCols, SQUARE_MM, DPI);
+            break;
+        }
         const data = await loadImageFromBytes(bytes, "image/png", rgbaToGray);
         onImageLoaded(data);
       } catch (err) {
@@ -63,7 +107,14 @@ export function ImageUpload({ onImageLoaded }: Props) {
         setSynthesising(false);
       }
     },
-    [onImageLoaded, synthRows, synthCols],
+    [
+      onImageLoaded,
+      synthKind,
+      synthRows,
+      synthCols,
+      charucoDict,
+      charucoMarkerRel,
+    ],
   );
 
   const stop = useCallback(
@@ -89,35 +140,81 @@ export function ImageUpload({ onImageLoaded }: Props) {
       />
       <p>Drop image here or click to browse</p>
       <div className="synthetic-zone" onClick={stop}>
-        <span className="synthetic-label">or generate a synthetic PuzzleBoard</span>
+        <span className="synthetic-label">or generate a synthetic target</span>
         <div className="synthetic-row">
+          <label>
+            kind
+            <select
+              value={synthKind}
+              onClick={stop}
+              onChange={(e) =>
+                setSynthKind(e.target.value as SyntheticTargetKind)
+              }
+            >
+              {KIND_OPTIONS.map(([k, label]) => (
+                <option key={k} value={k}>
+                  {label}
+                </option>
+              ))}
+            </select>
+          </label>
           <label>
             rows
             <input
               type="number"
-              min={4}
-              max={20}
+              min={2}
+              max={64}
               value={synthRows}
               onClick={stop}
-              onChange={(e) => setSynthRows(Math.max(4, Number(e.target.value)))}
+              onChange={(e) => setSynthRows(Math.max(2, Number(e.target.value)))}
             />
           </label>
           <label>
             cols
             <input
               type="number"
-              min={4}
-              max={20}
+              min={2}
+              max={64}
               value={synthCols}
               onClick={stop}
-              onChange={(e) => setSynthCols(Math.max(4, Number(e.target.value)))}
+              onChange={(e) => setSynthCols(Math.max(2, Number(e.target.value)))}
             />
           </label>
-          <button
-            type="button"
-            onClick={onSynthesise}
-            disabled={synthesising}
-          >
+        </div>
+        {synthKind === "charuco" && (
+          <div className="synthetic-row">
+            <label>
+              dictionary
+              <select
+                value={charucoDict}
+                onClick={stop}
+                onChange={(e) => setCharucoDict(e.target.value)}
+              >
+                {dictionaries.map((d) => (
+                  <option key={d} value={d}>
+                    {d}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label>
+              marker rel
+              <input
+                type="number"
+                min={0.1}
+                max={0.95}
+                step={0.05}
+                value={charucoMarkerRel}
+                onClick={stop}
+                onChange={(e) =>
+                  setCharucoMarkerRel(Math.min(0.95, Math.max(0.1, Number(e.target.value))))
+                }
+              />
+            </label>
+          </div>
+        )}
+        <div className="synthetic-row">
+          <button type="button" onClick={onSynthesise} disabled={synthesising}>
             {synthesising ? "Generating…" : "Generate & load"}
           </button>
         </div>

--- a/demo/src/components/ResultsPanel.tsx
+++ b/demo/src/components/ResultsPanel.tsx
@@ -10,7 +10,7 @@ interface Props {
 function cornerCount(result: DetectionResult): number {
   if (result.mode === "corners") return result.corners.length;
   if (result.mode === "chessboard")
-    return result.result?.detection.corners.length ?? 0;
+    return result.result?.target.corners.length ?? 0;
   if (result.mode === "charuco")
     return result.result.detection.corners.length;
   if (result.mode === "marker_board")
@@ -25,7 +25,7 @@ function gridDims(
 ): { rows: number; cols: number } | null {
   let corners;
   if (result.mode === "chessboard" && result.result) {
-    corners = result.result.detection.corners;
+    corners = result.result.target.corners;
   } else if (result.mode === "charuco") {
     corners = result.result.detection.corners;
   } else if (result.mode === "marker_board" && result.result) {

--- a/demo/src/hooks/useDetector.ts
+++ b/demo/src/hooks/useDetector.ts
@@ -4,14 +4,18 @@ import {
   isReady,
   detectCorners,
   detectChessboard,
+  detectChessboardBest,
   detectCharuco,
+  detectCharucoBest,
   detectMarkerBoard,
+  detectMarkerBoardBest,
   detectPuzzleBoard,
+  detectPuzzleBoardBest,
 } from "../lib/detector";
 import type {
   ChessConfig,
   ChessboardParams,
-  CharucoDetectorParams,
+  CharucoParams,
   MarkerBoardParams,
   PuzzleBoardParams,
   Corner,
@@ -29,6 +33,51 @@ export type DetectionResult =
   | { mode: "marker_board"; result: MarkerBoardDetectionResult | null }
   | { mode: "puzzleboard"; result: PuzzleBoardDetectionResult };
 
+export type DetectArgs =
+  | {
+      mode: "corners";
+      gray: Uint8Array;
+      width: number;
+      height: number;
+      chessCfg: ChessConfig;
+    }
+  | {
+      mode: "chessboard";
+      gray: Uint8Array;
+      width: number;
+      height: number;
+      chessCfg: ChessConfig;
+      params: ChessboardParams;
+      sweep?: ChessboardParams[];
+    }
+  | {
+      mode: "charuco";
+      gray: Uint8Array;
+      width: number;
+      height: number;
+      chessCfg: ChessConfig;
+      params: CharucoParams;
+      sweep?: CharucoParams[];
+    }
+  | {
+      mode: "marker_board";
+      gray: Uint8Array;
+      width: number;
+      height: number;
+      chessCfg: ChessConfig;
+      params: MarkerBoardParams;
+      sweep?: MarkerBoardParams[];
+    }
+  | {
+      mode: "puzzleboard";
+      gray: Uint8Array;
+      width: number;
+      height: number;
+      chessCfg: ChessConfig;
+      params: PuzzleBoardParams;
+      sweep?: PuzzleBoardParams[];
+    };
+
 interface UseDetectorReturn {
   ready: boolean;
   initError: string | null;
@@ -36,14 +85,7 @@ interface UseDetectorReturn {
   result: DetectionResult | null;
   error: string | null;
   timeMs: number | null;
-  detect: (
-    mode: DetectionMode,
-    gray: Uint8Array,
-    width: number,
-    height: number,
-    chessCfg: ChessConfig,
-    params: ChessboardParams | CharucoDetectorParams | MarkerBoardParams | PuzzleBoardParams,
-  ) => void;
+  detect: (args: DetectArgs) => void;
 }
 
 export function useDetector(): UseDetectorReturn {
@@ -72,100 +114,123 @@ export function useDetector(): UseDetectorReturn {
     };
   }, []);
 
-  const detect = useCallback(
-    (
-      mode: DetectionMode,
-      gray: Uint8Array,
-      width: number,
-      height: number,
-      chessCfg: ChessConfig,
-      params: ChessboardParams | CharucoDetectorParams | MarkerBoardParams | PuzzleBoardParams,
-    ) => {
-      setLoading(true);
-      setError(null);
+  const detect = useCallback((args: DetectArgs) => {
+    setLoading(true);
+    setError(null);
 
-      // Run detection synchronously (it's WASM, no async needed)
-      // but wrap in setTimeout to allow React to show loading state
-      setTimeout(() => {
-        try {
-          const t0 = performance.now();
-          let detectionResult: DetectionResult;
+    setTimeout(() => {
+      try {
+        const t0 = performance.now();
+        let detectionResult: DetectionResult;
 
-          switch (mode) {
-            case "corners":
-              detectionResult = {
-                mode: "corners",
-                corners: detectCorners(gray, width, height, chessCfg),
-              };
-              break;
-            case "chessboard":
-              detectionResult = {
-                mode: "chessboard",
-                result: detectChessboard(
-                  gray,
-                  width,
-                  height,
-                  chessCfg,
-                  params as ChessboardParams,
-                ),
-              };
-              break;
-            case "charuco":
-              detectionResult = {
-                mode: "charuco",
-                result: detectCharuco(
-                  gray,
-                  width,
-                  height,
-                  chessCfg,
-                  params as CharucoDetectorParams,
-                ),
-              };
-              break;
-            case "marker_board":
-              detectionResult = {
-                mode: "marker_board",
-                result: detectMarkerBoard(
-                  gray,
-                  width,
-                  height,
-                  chessCfg,
-                  params as MarkerBoardParams,
-                ),
-              };
-              break;
-            case "puzzleboard":
-              detectionResult = {
-                mode: "puzzleboard",
-                result: detectPuzzleBoard(
-                  gray,
-                  width,
-                  height,
-                  chessCfg,
-                  params as PuzzleBoardParams,
-                ),
-              };
-              break;
-          }
-
-          const elapsed = performance.now() - t0;
-          if (mountedRef.current) {
-            setResult(detectionResult);
-            setTimeMs(elapsed);
-            setLoading(false);
-          }
-        } catch (e: unknown) {
-          if (mountedRef.current) {
-            setError(e instanceof Error ? e.message : String(e));
-            setResult(null);
-            setTimeMs(null);
-            setLoading(false);
-          }
+        switch (args.mode) {
+          case "corners":
+            detectionResult = {
+              mode: "corners",
+              corners: detectCorners(
+                args.gray,
+                args.width,
+                args.height,
+                args.chessCfg,
+              ),
+            };
+            break;
+          case "chessboard":
+            detectionResult = {
+              mode: "chessboard",
+              result: args.sweep
+                ? detectChessboardBest(
+                    args.gray,
+                    args.width,
+                    args.height,
+                    args.sweep,
+                  )
+                : detectChessboard(
+                    args.gray,
+                    args.width,
+                    args.height,
+                    args.chessCfg,
+                    args.params,
+                  ),
+            };
+            break;
+          case "charuco":
+            detectionResult = {
+              mode: "charuco",
+              result: args.sweep
+                ? detectCharucoBest(
+                    args.gray,
+                    args.width,
+                    args.height,
+                    args.sweep,
+                  )
+                : detectCharuco(
+                    args.gray,
+                    args.width,
+                    args.height,
+                    args.chessCfg,
+                    args.params,
+                  ),
+            };
+            break;
+          case "marker_board":
+            detectionResult = {
+              mode: "marker_board",
+              result: args.sweep
+                ? detectMarkerBoardBest(
+                    args.gray,
+                    args.width,
+                    args.height,
+                    args.sweep,
+                  )
+                : detectMarkerBoard(
+                    args.gray,
+                    args.width,
+                    args.height,
+                    args.chessCfg,
+                    args.params,
+                  ),
+            };
+            break;
+          case "puzzleboard":
+            detectionResult = {
+              mode: "puzzleboard",
+              result: args.sweep
+                ? detectPuzzleBoardBest(
+                    args.gray,
+                    args.width,
+                    args.height,
+                    args.sweep,
+                  )
+                : detectPuzzleBoard(
+                    args.gray,
+                    args.width,
+                    args.height,
+                    args.chessCfg,
+                    args.params,
+                  ),
+            };
+            break;
         }
-      }, 0);
-    },
-    [],
-  );
+
+        const elapsed = performance.now() - t0;
+        if (mountedRef.current) {
+          setResult(detectionResult);
+          setTimeMs(elapsed);
+          setLoading(false);
+        }
+      } catch (e: unknown) {
+        if (mountedRef.current) {
+          setError(e instanceof Error ? e.message : String(e));
+          setResult(null);
+          setTimeMs(null);
+          setLoading(false);
+        }
+      }
+    }, 0);
+  }, []);
 
   return { ready, initError, loading, result, error, timeMs, detect };
 }
+
+export type { DetectionMode };

--- a/demo/src/lib/detector.ts
+++ b/demo/src/lib/detector.ts
@@ -1,4 +1,4 @@
-// Typed wrapper over the raw @vitavition/calib-targets WASM API.
+// Typed wrapper over the raw @vitavision/calib-targets WASM API.
 
 import init, {
   detect_corners as _detect_corners,
@@ -11,7 +11,7 @@ import init, {
   default_chess_config as _default_chess_config,
   default_chessboard_params as _default_chessboard_params,
   default_puzzleboard_params as _default_puzzleboard_params,
-} from "@vitavition/calib-targets";
+} from "@vitavision/calib-targets";
 
 import type {
   ChessConfig,

--- a/demo/src/lib/detector.ts
+++ b/demo/src/lib/detector.ts
@@ -3,20 +3,33 @@
 import init, {
   detect_corners as _detect_corners,
   detect_chessboard as _detect_chessboard,
+  detect_chessboard_best as _detect_chessboard_best,
   detect_charuco as _detect_charuco,
+  detect_charuco_best as _detect_charuco_best,
   detect_marker_board as _detect_marker_board,
+  detect_marker_board_best as _detect_marker_board_best,
   detect_puzzleboard as _detect_puzzleboard,
+  detect_puzzleboard_best as _detect_puzzleboard_best,
   rgba_to_gray as _rgba_to_gray,
+  render_chessboard_png as _render_chessboard_png,
+  render_charuco_png as _render_charuco_png,
+  render_marker_board_png as _render_marker_board_png,
   render_puzzleboard_png as _render_puzzleboard_png,
   default_chess_config as _default_chess_config,
   default_chessboard_params as _default_chessboard_params,
+  default_charuco_params as _default_charuco_params,
+  default_marker_board_params as _default_marker_board_params,
   default_puzzleboard_params as _default_puzzleboard_params,
+  chessboard_sweep_default as _chessboard_sweep_default,
+  charuco_sweep_for_board as _charuco_sweep_for_board,
+  puzzleboard_sweep_for_board as _puzzleboard_sweep_for_board,
+  list_aruco_dictionaries as _list_aruco_dictionaries,
 } from "@vitavision/calib-targets";
 
 import type {
   ChessConfig,
   ChessboardParams,
-  CharucoDetectorParams,
+  CharucoParams,
   MarkerBoardParams,
   PuzzleBoardParams,
   Corner,
@@ -24,7 +37,7 @@ import type {
   CharucoDetectionResult,
   MarkerBoardDetectionResult,
   PuzzleBoardDetectionResult,
-} from "../types/calib-targets";
+} from "@vitavision/calib-targets";
 
 let initialized = false;
 
@@ -39,6 +52,10 @@ export function isReady(): boolean {
   return initialized;
 }
 
+// ---------------------------------------------------------------------------
+// Image utilities
+// ---------------------------------------------------------------------------
+
 export function rgbaToGray(
   rgba: Uint8Array,
   width: number,
@@ -47,12 +64,47 @@ export function rgbaToGray(
   return _rgba_to_gray(rgba, width, height);
 }
 
-/**
- * Synthesise a PuzzleBoard target PNG entirely in WASM.
- *
- * Returns PNG bytes suitable for decoding via `createImageBitmap` and feeding
- * back into the detection pipeline to complete a generate → detect roundtrip.
- */
+// ---------------------------------------------------------------------------
+// Synthetic target generation
+// ---------------------------------------------------------------------------
+
+export function renderChessboardPng(
+  innerRows: number,
+  innerCols: number,
+  squareSizeMm: number,
+  dpi: number,
+): Uint8Array {
+  return _render_chessboard_png(innerRows, innerCols, squareSizeMm, dpi);
+}
+
+export function renderCharucoPng(
+  rows: number,
+  cols: number,
+  squareSizeMm: number,
+  markerSizeRel: number,
+  dictionaryName: string,
+  dpi: number,
+): Uint8Array {
+  return _render_charuco_png(
+    rows,
+    cols,
+    squareSizeMm,
+    markerSizeRel,
+    dictionaryName,
+    dpi,
+  );
+}
+
+export function renderMarkerBoardPng(
+  innerRows: number,
+  innerCols: number,
+  squareSizeMm: number,
+  dpi: number,
+): Uint8Array {
+  return _render_marker_board_png(innerRows, innerCols, squareSizeMm, dpi);
+}
+
+/** Synthesise a PuzzleBoard target PNG entirely in WASM. */
 export function renderPuzzleBoardPng(
   rows: number,
   cols: number,
@@ -62,6 +114,10 @@ export function renderPuzzleBoardPng(
   return _render_puzzleboard_png(rows, cols, squareSizeMm, dpi);
 }
 
+// ---------------------------------------------------------------------------
+// Default config / sweep getters
+// ---------------------------------------------------------------------------
+
 export function defaultChessConfig(): ChessConfig {
   return _default_chess_config() as ChessConfig;
 }
@@ -70,9 +126,63 @@ export function defaultChessboardParams(): ChessboardParams {
   return _default_chessboard_params() as ChessboardParams;
 }
 
-export function defaultPuzzleBoardParams(rows: number, cols: number): PuzzleBoardParams {
+export function defaultCharucoParams(
+  rows: number,
+  cols: number,
+  markerSizeRel: number,
+  dictionaryName: string,
+): CharucoParams {
+  return _default_charuco_params(
+    rows,
+    cols,
+    markerSizeRel,
+    dictionaryName,
+  ) as CharucoParams;
+}
+
+export function defaultMarkerBoardParams(): MarkerBoardParams {
+  return _default_marker_board_params() as MarkerBoardParams;
+}
+
+export function defaultPuzzleBoardParams(
+  rows: number,
+  cols: number,
+): PuzzleBoardParams {
   return _default_puzzleboard_params(rows, cols) as PuzzleBoardParams;
 }
+
+export function chessboardSweepDefault(): ChessboardParams[] {
+  return _chessboard_sweep_default() as ChessboardParams[];
+}
+
+export function charucoSweepForBoard(
+  rows: number,
+  cols: number,
+  markerSizeRel: number,
+  dictionaryName: string,
+): CharucoParams[] {
+  return _charuco_sweep_for_board(
+    rows,
+    cols,
+    markerSizeRel,
+    dictionaryName,
+  ) as CharucoParams[];
+}
+
+export function puzzleboardSweepForBoard(
+  rows: number,
+  cols: number,
+): PuzzleBoardParams[] {
+  return _puzzleboard_sweep_for_board(rows, cols) as PuzzleBoardParams[];
+}
+
+export function listArucoDictionaries(): string[] {
+  return _list_aruco_dictionaries() as string[];
+}
+
+// ---------------------------------------------------------------------------
+// Detection (single config)
+// ---------------------------------------------------------------------------
 
 export function detectCorners(
   gray: Uint8Array,
@@ -104,7 +214,7 @@ export function detectCharuco(
   width: number,
   height: number,
   chessCfg: ChessConfig,
-  params: CharucoDetectorParams,
+  params: CharucoParams,
 ): CharucoDetectionResult {
   return _detect_charuco(
     width,
@@ -144,5 +254,65 @@ export function detectPuzzleBoard(
     gray,
     chessCfg,
     params,
+  ) as PuzzleBoardDetectionResult;
+}
+
+// ---------------------------------------------------------------------------
+// Detection (best-of sweeps)
+// ---------------------------------------------------------------------------
+
+export function detectChessboardBest(
+  gray: Uint8Array,
+  width: number,
+  height: number,
+  configs: ChessboardParams[],
+): ChessboardDetectionResult | null {
+  return _detect_chessboard_best(
+    width,
+    height,
+    gray,
+    configs,
+  ) as ChessboardDetectionResult | null;
+}
+
+export function detectCharucoBest(
+  gray: Uint8Array,
+  width: number,
+  height: number,
+  configs: CharucoParams[],
+): CharucoDetectionResult {
+  return _detect_charuco_best(
+    width,
+    height,
+    gray,
+    configs,
+  ) as CharucoDetectionResult;
+}
+
+export function detectMarkerBoardBest(
+  gray: Uint8Array,
+  width: number,
+  height: number,
+  configs: MarkerBoardParams[],
+): MarkerBoardDetectionResult | null {
+  return _detect_marker_board_best(
+    width,
+    height,
+    gray,
+    configs,
+  ) as MarkerBoardDetectionResult | null;
+}
+
+export function detectPuzzleBoardBest(
+  gray: Uint8Array,
+  width: number,
+  height: number,
+  configs: PuzzleBoardParams[],
+): PuzzleBoardDetectionResult {
+  return _detect_puzzleboard_best(
+    width,
+    height,
+    gray,
+    configs,
   ) as PuzzleBoardDetectionResult;
 }

--- a/demo/src/lib/detector.ts
+++ b/demo/src/lib/detector.ts
@@ -1,4 +1,4 @@
-// Typed wrapper over the raw calib-targets-wasm WASM API.
+// Typed wrapper over the raw @vitavition/calib-targets WASM API.
 
 import init, {
   detect_corners as _detect_corners,
@@ -11,7 +11,7 @@ import init, {
   default_chess_config as _default_chess_config,
   default_chessboard_params as _default_chessboard_params,
   default_puzzleboard_params as _default_puzzleboard_params,
-} from "calib-targets-wasm";
+} from "@vitavition/calib-targets";
 
 import type {
   ChessConfig,

--- a/demo/src/types/calib-targets.ts
+++ b/demo/src/types/calib-targets.ts
@@ -1,261 +1,63 @@
-// TypeScript interfaces mirroring the Rust serde structs.
-// These provide type safety on top of the raw JsValue-based WASM API.
+// Re-export of every object-shape type that crosses the WASM boundary.
+//
+// The shapes themselves live alongside the function signatures in
+// `@vitavision/calib-targets`; this module exists only to keep imports
+// short for the demo and to declare the demo-internal `DetectionMode`
+// enum.
 
-// ---------------------------------------------------------------------------
-// Input config types
-// ---------------------------------------------------------------------------
+export type {
+  AxisEstimate,
+  CharucoBoardSpec,
+  CharucoParams,
+  ChessConfig,
+  ChessboardDetectionResult,
+  ChessboardParams,
+  CharucoDetectionResult,
+  CircleCandidate,
+  CircleMatch,
+  CircleMatchParams,
+  CirclePolarity,
+  CircleScoreParams,
+  Corner,
+  DescriptorMode,
+  DetectorMode,
+  GridAlignment,
+  GridCoords,
+  GridTransform,
+  LabeledCorner,
+  MarkerBoardDetectionResult,
+  MarkerBoardLayout,
+  MarkerBoardParams,
+  MarkerCircleSpec,
+  MarkerDetection,
+  MarkerLayout,
+  Point2,
+  PuzzleBoardDecodeConfig,
+  PuzzleBoardDecodeInfo,
+  PuzzleBoardDetectionResult,
+  PuzzleBoardObservedEdge,
+  PuzzleBoardParams,
+  PuzzleBoardScoringMode,
+  PuzzleBoardSearchMode,
+  PuzzleBoardSpec,
+  RefinerConfig,
+  ScanDecodeConfig,
+  TargetDetection,
+  TargetKind,
+  ThresholdMode,
+  UpscaleConfig,
+} from "@vitavision/calib-targets";
 
-export interface ChessConfig {
-  detector_mode: "canonical" | "broad";
-  descriptor_mode: "follow_detector" | "canonical" | "broad";
-  threshold_mode: "relative" | "absolute";
-  threshold_value: number;
-  nms_radius: number;
-  min_cluster_size: number;
-  refiner: RefinerConfig;
-  pyramid_levels: number;
-  pyramid_min_size: number;
-  refinement_radius: number;
-  merge_radius: number;
-}
-
-export interface RefinerConfig {
-  kind: "center_of_mass" | "forstner" | "saddle_point";
-  center_of_mass: { radius: number };
-  forstner: {
-    radius: number;
-    min_trace: number;
-    min_det: number;
-    max_condition_number: number;
-    max_offset: number;
-  };
-  saddle_point: {
-    radius: number;
-    det_margin: number;
-    max_offset: number;
-    min_abs_det: number;
-  };
-}
-
-export interface GridGraphParams {
-  min_spacing_pix: number;
-  max_spacing_pix: number;
-  k_neighbors: number;
-  orientation_tolerance_deg: number;
-}
-
-export interface OrientationClusteringParams {
-  num_bins: number;
-  max_iters: number;
-  peak_min_separation_deg: number;
-  outlier_threshold_deg: number;
-  min_peak_weight_fraction: number;
-  use_weights: boolean;
-}
-
-export interface ChessboardParams {
-  min_corner_strength: number;
-  min_corners: number;
-  expected_rows?: number | null;
-  expected_cols?: number | null;
-  completeness_threshold: number;
-  use_orientation_clustering: boolean;
-  orientation_clustering_params: OrientationClusteringParams;
-  graph: GridGraphParams;
-}
-
-export interface CharucoBoardSpec {
-  rows: number;
-  cols: number;
-  cell_size?: number | null;
-  marker_size_rel: number;
-  dictionary: string;
-  marker_layout: "opencv_charuco" | "bottom_left";
-}
-
-export interface ScanDecodeConfig {
-  marker_size_rel: number;
-  inset_frac: number;
-  border_bits: number;
-  min_border_score: number;
-  dedup_by_id: boolean;
-}
-
-export interface CharucoDetectorParams {
-  charuco: CharucoBoardSpec;
-  px_per_square: number;
-  chessboard: ChessboardParams;
-  scan: ScanDecodeConfig;
-  max_hamming: number;
-  min_marker_inliers: number;
-  corner_validation_threshold_rel: number;
-}
-
-export interface MarkerCircleSpec {
-  i: number;
-  j: number;
-  polarity: "white" | "black";
-}
-
-export interface MarkerBoardLayout {
-  rows: number;
-  cols: number;
-  cell_size: number;
-  circles: MarkerCircleSpec[];
-}
-
-export interface CircleScoreParams {
-  patch_size: number;
-  diameter_frac: number;
-  ring_thickness_frac: number;
-  ring_radius_mul: number;
-  min_contrast: number;
-  samples: number;
-  center_search_px: number;
-}
-
-export interface CircleMatchParams {
-  max_candidates_per_polarity: number;
-  min_offset_inliers: number;
-}
-
-export interface MarkerBoardParams {
-  layout: MarkerBoardLayout;
-  chessboard: ChessboardParams;
-  circle_score: CircleScoreParams;
-  match_params: CircleMatchParams;
-}
-
-export interface PuzzleBoardSpec {
-  rows: number;
-  cols: number;
-  cell_size: number;
-  origin_row: number;
-  origin_col: number;
-}
-
-export type PuzzleBoardSearchMode =
-  | { kind: "full" }
-  | { kind: "fixed_board" };
-
-export interface PuzzleBoardDecodeConfig {
-  min_window: number;
-  min_bit_confidence: number;
-  max_bit_error_rate: number;
-  search_all_components: boolean;
-  sample_radius_rel: number;
-  search_mode: PuzzleBoardSearchMode;
-}
-
-export interface PuzzleBoardParams {
-  px_per_square: number;
-  chessboard: ChessboardParams;
-  board: PuzzleBoardSpec;
-  decode: PuzzleBoardDecodeConfig;
-}
-
-// ---------------------------------------------------------------------------
-// Output types
-// ---------------------------------------------------------------------------
-
-/** nalgebra::Point2<f32> serializes as [x, y] via serde */
-export type Point2 = [number, number];
-
-export interface Corner {
-  position: Point2;
-  orientation: number;
-  orientation_cluster: number | null;
-  strength: number;
-}
-
-export interface GridCoords {
-  i: number;
-  j: number;
-}
-
-export interface LabeledCorner {
-  position: Point2;
-  grid: GridCoords | null;
-  id: number | null;
-  target_position: Point2 | null;
-  score: number;
-}
-
-export interface TargetDetection {
-  kind: "chessboard" | "charuco" | "checkerboard_marker" | "puzzle_board";
-  corners: LabeledCorner[];
-}
-
-export interface ChessboardDetectionResult {
-  detection: TargetDetection;
-  inliers: number[];
-  orientations: [number, number] | null;
-}
-
-export interface GridTransform {
-  a: number;
-  b: number;
-  c: number;
-  d: number;
-}
-
-export interface GridAlignment {
-  transform: GridTransform;
-  translation: [number, number];
-}
-
-export interface MarkerDetection {
-  id: number;
-  gc: { i: number; j: number };
-  rotation: number;
-  hamming: number;
-  score: number;
-  border_score: number;
-}
-
-export interface CharucoDetectionResult {
-  detection: TargetDetection;
-  markers: MarkerDetection[];
-  alignment: GridAlignment;
-}
-
-export interface MarkerBoardDetectionResult {
-  detection: TargetDetection;
-  inliers: number[];
-  alignment: GridAlignment | null;
-  alignment_inliers: number;
-}
-
-export interface ObservedEdge {
-  row: number;
-  col: number;
-  orientation: "horizontal" | "vertical";
-  bit: 0 | 1;
-  confidence: number;
-}
-
-export interface PuzzleBoardDecodeInfo {
-  edges_observed: number;
-  edges_matched: number;
-  mean_confidence: number;
-  bit_error_rate: number;
-  master_origin_row: number;
-  master_origin_col: number;
-}
-
-export interface PuzzleBoardDetectionResult {
-  detection: TargetDetection;
-  alignment: GridAlignment;
-  decode: PuzzleBoardDecodeInfo;
-  observed_edges: ObservedEdge[];
-}
-
-// ---------------------------------------------------------------------------
-// Detection mode enum
-// ---------------------------------------------------------------------------
-
+/** Detection mode selected from the demo UI. */
 export type DetectionMode =
   | "corners"
+  | "chessboard"
+  | "charuco"
+  | "marker_board"
+  | "puzzleboard";
+
+/** Synthetic-target kinds the demo can render in the browser. */
+export type SyntheticTargetKind =
   | "chessboard"
   | "charuco"
   | "marker_board"

--- a/demo/vite.config.ts
+++ b/demo/vite.config.ts
@@ -10,6 +10,6 @@ export default defineConfig({
   // Vite's esbuild pre-bundler rewrites the JS into .vite/deps/ but does not copy the
   // sibling .wasm, so the fetch 404s and the SPA fallback returns index.html.
   optimizeDeps: {
-    exclude: ["@vitavition/calib-targets"],
+    exclude: ["@vitavision/calib-targets"],
   },
 });

--- a/demo/vite.config.ts
+++ b/demo/vite.config.ts
@@ -10,6 +10,6 @@ export default defineConfig({
   // Vite's esbuild pre-bundler rewrites the JS into .vite/deps/ but does not copy the
   // sibling .wasm, so the fetch 404s and the SPA fallback returns index.html.
   optimizeDeps: {
-    exclude: ["calib-targets-wasm"],
+    exclude: ["@vitavition/calib-targets"],
   },
 });

--- a/docs/puzzle_detection_spec.md
+++ b/docs/puzzle_detection_spec.md
@@ -1,0 +1,163 @@
+Approach: Robust PuzzleBoard Matching by Soft Edge Decoding and Global Graph Inference
+
+Goal
+
+Estimate the correct global PuzzleBoard assignment from a partially observed, noisy corner graph under low resolution, blur, missing corners, and local graph errors.
+
+The approach must prefer:
+
+* global consistency over local hard decisions
+* soft evidence over binary decoding
+* rejection of ambiguous matches over confident wrong matches
+
+⸻
+
+Core idea
+
+PuzzleBoard information is carried by the bits associated with edges between neighboring corners.
+Therefore, matching should not be based on isolated corners or on a raw raster correlation of the whole observation.
+
+Instead, the observation is treated as a sparse graph with uncertain edge bits, and board matching is formulated as a global hypothesis scoring problem.
+
+The method consists of three conceptual stages:
+
+1. soft edge decoding
+    infer probabilistic bit evidence for observed graph edges
+2. local hypothesis generation
+    use small reliable neighborhoods to propose plausible board positions and rotations
+3. global board inference
+    score each candidate hypothesis against the full observed graph and choose the most consistent one
+
+⸻
+
+Representation
+
+The observed target is represented as:
+
+* a set of detected corners
+* a local graph connecting neighboring corners
+* a classification of edges into horizontal and vertical directions
+* for each edge, a soft estimate of the encoded bit
+
+The known PuzzleBoard target is represented as:
+
+* a fixed lattice
+* known horizontal and vertical edge-bit maps
+* the four valid board rotations
+* the local code structure that makes neighborhoods identifiable
+
+⸻
+
+Soft edge decoding
+
+Each observed graph edge is assigned a probability of bit value 0 or 1, rather than a hard binary decision.
+
+This step should use local photometric evidence around the edge and produce:
+
+* a bit likelihood
+* a confidence value
+
+The purpose is to preserve uncertainty.
+A weak or blurred edge should contribute weak evidence, not a potentially destructive hard error.
+
+⸻
+
+Local hypothesis generation
+
+Small local neighborhoods in the observed graph are used as anchors.
+
+Each anchor provides a partial code signature derived from its horizontal and vertical edges.
+That signature is compared against the known PuzzleBoard structure to generate a small set of plausible:
+
+* board rotations
+* board offsets / indexings
+
+The purpose of this stage is not to solve the problem completely, but to reduce the search to a manageable set of globally plausible hypotheses.
+
+⸻
+
+Global board inference
+
+Each candidate hypothesis is evaluated against all observed edges.
+
+For a given hypothesis, each observed edge implies an expected PuzzleBoard bit.
+The observed soft edge evidence is then compared to that expected bit.
+
+The score of a hypothesis is the sum of all weighted edge contributions:
+
+S(H) = \sum_{e} w_e \log p_e(b_e(H))
+
+where:
+
+* H is a global board hypothesis
+* e is an observed edge
+* b_e(H) is the expected bit under that hypothesis
+* p_e(\cdot) is the observed soft bit likelihood
+* w_e is the edge confidence
+
+This gives a board-level likelihood-like score.
+
+The best solution is the hypothesis with the strongest global support across the observed graph, not the one that happens to explain one local patch well.
+
+⸻
+
+Robustness principles
+
+The method should explicitly tolerate:
+
+* missing corners
+* missing edges
+* uncertain edge orientation labels
+* incorrect local graph links
+* local photometric failures
+* partial visibility of the board
+
+A small number of incorrect edges must not dominate the result.
+Weak or unreliable observations should be down-weighted or ignored.
+
+The preferred failure mode is:
+
+* ambiguous / reject
+
+rather than:
+
+* confidently wrong assignment
+
+⸻
+
+Role of repeated structure
+
+If the PuzzleBoard contains repeated code structure, that repetition is treated as a source of redundancy and error correction.
+
+Repeated edge information should strengthen consistent hypotheses and reduce sensitivity to individual decoding errors.
+
+The repeated structure is therefore not just a property of the board design; it is part of the inference signal.
+
+⸻
+
+Final interpretation
+
+Once the best global hypothesis is selected, it defines:
+
+* the board rotation
+* the board indexing / offset
+* the board coordinates of the observed corners
+* the expected bit values on observed edges
+
+This turns the matching problem into a globally constrained assignment problem, where local uncertainties are resolved through consistency with the whole board.
+
+⸻
+
+Summary
+
+This approach replaces brittle hard matching with a probabilistic, board-level interpretation of the observed corner graph.
+
+Its key principles are:
+
+* decode edge bits softly
+* generate hypotheses from local neighborhoods
+* select the solution by global graph consistency
+
+In short:
+
+PuzzleBoard matching should be treated as inference on a sparse noisy code graph, not as local hard decoding and not as raw image correlation.

--- a/scripts/build-site.sh
+++ b/scripts/build-site.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Build the unified GitHub Pages tree locally:
+#   public/                -> mdBook (book chapters + interactive playground)
+#   public/api/            -> cargo doc workspace API reference
+#   public/playground/     -> built React + WASM demo
+#
+# Mirrors the layout produced by .github/workflows/docs.yml.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+cd "$ROOT_DIR"
+
+echo "==> Building cargo doc..."
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps
+printf '<meta http-equiv="refresh" content="0; url=calib_targets_core/index.html">\n' \
+  > target/doc/index.html
+
+echo "==> Building mdBook..."
+mdbook build book
+
+echo "==> Building WASM + demo..."
+./scripts/build-wasm.sh
+(cd demo && bun install && bun run build)
+
+echo "==> Assembling public/..."
+rm -rf public
+mkdir -p public/api public/playground
+rsync -a target/doc/ public/api/
+rsync -a book/book/ public/
+rsync -a demo/dist/ public/playground/
+
+echo "==> Done. Serve the site with: python3 -m http.server -d public 8080"

--- a/scripts/build-wasm.sh
+++ b/scripts/build-wasm.sh
@@ -13,6 +13,12 @@ wasm-pack build "$ROOT_DIR/crates/calib-targets-wasm" \
 
 cp "$ROOT_DIR/crates/calib-targets-wasm/README.md" "$ROOT_DIR/demo/pkg/README.md"
 
+# Append hand-written object-shape types to the auto-generated .d.ts so
+# consumers of the npm package get typed result/parameter shapes (the
+# wasm-bindgen output only types function signatures).
+cat "$ROOT_DIR/crates/calib-targets-wasm/typescript-extras.d.ts" \
+  >> "$ROOT_DIR/demo/pkg/calib_targets_wasm.d.ts"
+
 # Override the published npm name (wasm-pack derives it from the Rust crate
 # name; we ship as the scoped public package @vitavision/calib-targets).
 (cd "$ROOT_DIR/demo/pkg" && npm pkg set name=@vitavision/calib-targets)

--- a/scripts/build-wasm.sh
+++ b/scripts/build-wasm.sh
@@ -13,5 +13,9 @@ wasm-pack build "$ROOT_DIR/crates/calib-targets-wasm" \
 
 cp "$ROOT_DIR/crates/calib-targets-wasm/README.md" "$ROOT_DIR/demo/pkg/README.md"
 
+# Override the published npm name (wasm-pack derives it from the Rust crate
+# name; we ship as the scoped public package @vitavition/calib-targets).
+(cd "$ROOT_DIR/demo/pkg" && npm pkg set name=@vitavition/calib-targets)
+
 echo "WASM package built to demo/pkg/"
 ls -lh "$ROOT_DIR/demo/pkg/"*.wasm

--- a/scripts/build-wasm.sh
+++ b/scripts/build-wasm.sh
@@ -14,8 +14,8 @@ wasm-pack build "$ROOT_DIR/crates/calib-targets-wasm" \
 cp "$ROOT_DIR/crates/calib-targets-wasm/README.md" "$ROOT_DIR/demo/pkg/README.md"
 
 # Override the published npm name (wasm-pack derives it from the Rust crate
-# name; we ship as the scoped public package @vitavition/calib-targets).
-(cd "$ROOT_DIR/demo/pkg" && npm pkg set name=@vitavition/calib-targets)
+# name; we ship as the scoped public package @vitavision/calib-targets).
+(cd "$ROOT_DIR/demo/pkg" && npm pkg set name=@vitavision/calib-targets)
 
 echo "WASM package built to demo/pkg/"
 ls -lh "$ROOT_DIR/demo/pkg/"*.wasm

--- a/scripts/puzzlesnap_overlay.sh
+++ b/scripts/puzzlesnap_overlay.sh
@@ -1,0 +1,2 @@
+cargo run -p calib-targets-puzzleboard --release --example run_dataset --features="dataset" -- --dataset privatedata/130x130_puzzle --out bench_results/130x130_puzzle/manual --rows 130 --cols 130 --cell-size-mm 1.014 --search-mode fixed-board --scoring-mode soft
+python crates/calib-targets-py/examples/overlay_puzzleboard_board_frame.py --reports bench_results/130x130_puzzle/manual --out bench_results/130x130_puzzle/manual

--- a/scripts/puzzlesnap_plot.sh
+++ b/scripts/puzzlesnap_plot.sh
@@ -1,0 +1,1 @@
+python crates/calib-targets-py/examples/inspect_puzzleboard_snap.py --target privatedata/130x130_puzzle/target_11.png --snap 1


### PR DESCRIPTION
## Summary

- Rename the published npm package from unscoped `calib-targets-wasm` to scoped public `@vitavition/calib-targets`. The Rust crate name (`calib-targets-wasm`) is unchanged — only the published npm identifier moves.
- Implementation is a single `npm pkg set name=@vitavition/calib-targets` step after every `wasm-pack build` (`scripts/build-wasm.sh`, `.github/workflows/ci.yml`, `.github/workflows/release-npm.yml`).
- Demo (`demo/package.json`, `detector.ts` import, `vite.config.ts` exclude), the WASM crate README, root README, facade README, `CLAUDE.md`, and `CHANGELOG.md` follow the new name.

The version-check `jq` filter in `release-npm.yml` keeps reading the Rust crate name from `cargo metadata`, so the existing `wasm-v*` tag flow is unchanged. `--access public` already covers public scoped publishing.

## Out-of-repo prerequisites for the next release

1. Create the `vitavition` org on npmjs.com.
2. Configure trusted publisher there for `@vitavition/calib-targets` pointing at this repo's `release-npm.yml` and the `npm` GitHub environment (workflow already has `id-token: write`). OR: do a one-shot manual first publish with a token, then switch to OIDC for subsequent releases.
3. Optional: `npm deprecate calib-targets-wasm@"*" "Moved to @vitavition/calib-targets"` once the first scoped version ships.

## Test plan

- [x] `scripts/build-wasm.sh` → `jq -r .name demo/pkg/package.json` returns `@vitavition/calib-targets`
- [x] `cd demo && rm -rf node_modules bun.lock && bun install && bun run build` succeeds with the renamed local package
- [x] `wasm-pack build crates/calib-targets-wasm --target web --release && (cd crates/calib-targets-wasm/pkg && npm pkg set name=@vitavition/calib-targets && npm publish --dry-run --access public)` reports `@vitavition/calib-targets@0.7.2` would publish
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo doc --workspace --no-deps`
- [ ] CI green on this PR (covers the new `Set scoped npm package name` step in `ci.yml`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)