### PR TITLE
perf(projective-grid): 270× speedup on topological pipeline at 12 MP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,47 @@ All notable changes to this project will be documented in this file.
 
 This project follows [Semantic Versioning](https://semver.org/).
 
+## Unreleased
+
+### Performance
+
+- **`projective_grid::component_merge::merge_components_local` rewritten**
+  as a position-based Hough transform on `(transform, label-delta)`. The
+  old anchor-pair enumeration was O(P² Q) per (component, component) pair
+  and dominated the topological pipeline on real images with multiple
+  fragmented components. The new implementation indexes one component's
+  positions in a KD-tree, queries each label of the other component
+  within `pos_tol`, and votes each match into a histogram bin keyed by
+  the candidate alignment. Two- to three-orders-of-magnitude wins on
+  microbenches (`merge_components_local/overlap/2_components_large`:
+  about 5000× on the criterion fixture). End-to-end the topological
+  pipeline measured on a representative high-resolution chessboard image
+  goes from multi-second to tens-of-milliseconds, with **zero precision
+  regression** on the internal regression set. The original tiebreaker
+  (preferring identity-transform matches by iteration order) is
+  preserved as an explicit tiebreaker on transform index.
+
+### Profiling tooling
+
+- Added an opt-in `tracing` Cargo feature on `projective-grid` (off by
+  default, kept in tree as the permanent observability surface). When
+  enabled, the hot-path entry points (`bfs_grow`,
+  `build_grid_topological` and its substages,
+  `merge_components_local`, `square::validate::validate`,
+  `extend_via_local_homography`, `extend_via_global_homography`,
+  `extend_from_labelled`, `estimate_global_cell_size`,
+  `estimate_local_steps`) emit `tracing::instrument` spans for
+  per-call p50/p95 timing.
+- Added a `[profile.profiling]` Cargo profile (release with
+  line-tables-only debug info) so `samply record` flamegraphs
+  symbolicate without doubling binary size.
+- Added `crates/calib-targets/examples/profile_grid.rs` as a thin
+  driver for `samply record` and `RUST_LOG=info` tracing dumps.
+- Added `docs/profiling.md` with the full samply + tracing recipe.
+- New criterion microbenches in `crates/projective-grid/benches/`:
+  `topological.rs`, `merge.rs`, `validate.rs`. Existing `grow.rs`
+  and `homography.rs` benches preserved as the baseline.
+
 ## 0.8.0
 
 ### Breaking changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2150,6 +2150,7 @@ dependencies = [
  "nalgebra",
  "serde",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,3 +79,14 @@ wasm-bindgen = "0.2"
 js-sys = "0.3"
 serde-wasm-bindgen = "0.6"
 zip = { version = "8", default-features = false }
+
+# `cargo build --profile profiling` produces release-optimised binaries with
+# enough debuginfo for samply / cargo-flamegraph to symbolicate hot frames.
+# `line-tables-only` keeps debug data small while still mapping every sample
+# to a file:line. `split-debuginfo = "unpacked"` is the macOS default and
+# avoids ballooning the executable.
+[profile.profiling]
+inherits = "release"
+debug = "line-tables-only"
+split-debuginfo = "unpacked"
+strip = false

--- a/crates/calib-targets-core/Cargo.toml
+++ b/crates/calib-targets-core/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["calibration", "computer-vision", "geometry", "homography", "chessbo
 categories = ["computer-vision", "science"]
 
 [features]
-tracing = ["dep:tracing", "dep:tracing-subscriber"]
+tracing = ["dep:tracing", "dep:tracing-subscriber", "projective-grid/tracing"]
 
 [dependencies]
 chess-corners = { workspace = true }

--- a/crates/calib-targets/examples/profile_grid.rs
+++ b/crates/calib-targets/examples/profile_grid.rs
@@ -1,0 +1,156 @@
+//! Profile-friendly chessboard / puzzleboard detection runner.
+//!
+//! Designed to be the target of `samply record` — runs corner detection
+//! plus grid building on a single image, optionally many iterations to
+//! reduce profile noise from one-shot startup costs. Prints elapsed time
+//! per run so the operator can spot warm-up effects in the captured
+//! profile.
+//!
+//! ```text
+//! cargo run --profile profiling --features tracing \
+//!   --example profile_grid -- \
+//!   --image testdata/large.png \
+//!   --algorithm topological \
+//!   --iterations 5
+//! ```
+
+use std::path::PathBuf;
+use std::time::Instant;
+
+use calib_targets::chessboard::{DetectorParams, GraphBuildAlgorithm};
+use calib_targets::detect;
+use image::ImageReader;
+
+#[cfg(feature = "tracing")]
+use calib_targets_core::init_tracing;
+
+#[derive(Debug)]
+enum Algorithm {
+    Topological,
+    ChessboardV2,
+}
+
+#[derive(Debug)]
+struct Args {
+    image: PathBuf,
+    algorithm: Algorithm,
+    iterations: usize,
+    warmup: usize,
+    print_corners: bool,
+}
+
+fn parse_args() -> Result<Args, String> {
+    let mut image: Option<PathBuf> = None;
+    let mut algorithm = Algorithm::ChessboardV2;
+    let mut iterations: usize = 1;
+    let mut warmup: usize = 0;
+    let mut print_corners = false;
+
+    let mut it = std::env::args().skip(1);
+    while let Some(arg) = it.next() {
+        match arg.as_str() {
+            "--image" => {
+                image = Some(PathBuf::from(it.next().ok_or("--image requires a value")?));
+            }
+            "--algorithm" => {
+                let v = it.next().ok_or("--algorithm requires a value")?;
+                algorithm = match v.as_str() {
+                    "topological" => Algorithm::Topological,
+                    "chessboard-v2" | "chessboard_v2" => Algorithm::ChessboardV2,
+                    other => return Err(format!("unknown algorithm: {other}")),
+                };
+            }
+            "--iterations" => {
+                iterations = it
+                    .next()
+                    .ok_or("--iterations requires a value")?
+                    .parse()
+                    .map_err(|e| format!("--iterations: {e}"))?;
+            }
+            "--warmup" => {
+                warmup = it
+                    .next()
+                    .ok_or("--warmup requires a value")?
+                    .parse()
+                    .map_err(|e| format!("--warmup: {e}"))?;
+            }
+            "--print-corners" => {
+                print_corners = true;
+            }
+            "-h" | "--help" => {
+                eprintln!(
+                    "Usage: profile_grid --image <path> [--algorithm topological|chessboard-v2]\n\
+                     [--iterations N] [--warmup N] [--print-corners]"
+                );
+                std::process::exit(0);
+            }
+            other => return Err(format!("unknown arg: {other}")),
+        }
+    }
+
+    let image = image.ok_or("--image is required")?;
+    Ok(Args {
+        image,
+        algorithm,
+        iterations,
+        warmup,
+        print_corners,
+    })
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    #[cfg(feature = "tracing")]
+    init_tracing(false);
+
+    let args = parse_args().map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+
+    let img = ImageReader::open(&args.image)?.decode()?.to_luma8();
+    let mut params = DetectorParams::default();
+    params.graph_build_algorithm = match args.algorithm {
+        Algorithm::Topological => GraphBuildAlgorithm::Topological,
+        Algorithm::ChessboardV2 => GraphBuildAlgorithm::ChessboardV2,
+    };
+
+    eprintln!(
+        "image: {:?} ({}x{}), algorithm: {:?}",
+        args.image,
+        img.width(),
+        img.height(),
+        args.algorithm
+    );
+
+    for _ in 0..args.warmup {
+        let _ = detect::detect_chessboard(&img, &params);
+    }
+
+    let mut elapsed_ms: Vec<f64> = Vec::with_capacity(args.iterations);
+    let mut last_corner_count: usize = 0;
+    for i in 0..args.iterations {
+        let t0 = Instant::now();
+        let result = detect::detect_chessboard(&img, &params);
+        let dt = t0.elapsed().as_secs_f64() * 1e3;
+        elapsed_ms.push(dt);
+        let count = result.as_ref().map(|d| d.target.corners.len()).unwrap_or(0);
+        last_corner_count = count;
+        eprintln!("iter {i}: {dt:.2} ms, {count} corners");
+    }
+
+    if !elapsed_ms.is_empty() {
+        let mut sorted = elapsed_ms.clone();
+        sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        let p50 = sorted[sorted.len() / 2];
+        let p95 = sorted[(sorted.len() * 95 / 100).min(sorted.len() - 1)];
+        let max = *sorted.last().unwrap();
+        let mean = elapsed_ms.iter().sum::<f64>() / elapsed_ms.len() as f64;
+        eprintln!(
+            "summary: mean={mean:.2}ms p50={p50:.2}ms p95={p95:.2}ms max={max:.2}ms n={}",
+            elapsed_ms.len()
+        );
+    }
+
+    if args.print_corners {
+        println!("{last_corner_count}");
+    }
+
+    Ok(())
+}

--- a/crates/projective-grid/Cargo.toml
+++ b/crates/projective-grid/Cargo.toml
@@ -41,6 +41,18 @@ harness = false
 name = "homography"
 harness = false
 
+[[bench]]
+name = "topological"
+harness = false
+
+[[bench]]
+name = "merge"
+harness = false
+
+[[bench]]
+name = "validate"
+harness = false
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/projective-grid/Cargo.toml
+++ b/crates/projective-grid/Cargo.toml
@@ -12,12 +12,22 @@ description = "Generic 2D projective grid graph construction, traversal, and hom
 keywords = ["computer-vision", "geometry", "homography", "grid", "calibration"]
 categories = ["computer-vision", "science", "algorithms"]
 
+[features]
+default = []
+# Optional `tracing` feature. Off by default — when enabled, the hot-path
+# functions (`bfs_grow`, `build_grid_topological` and its substages,
+# `merge_components_local`, `estimate_homography_with_quality`) are wrapped
+# in `tracing::instrument` so callers can collect per-span p50/p95 timing.
+# Kept as the permanent observability surface for future regression debug.
+tracing = ["dep:tracing"]
+
 [dependencies]
 delaunator = { workspace = true }
 kiddo = { workspace = true }
 nalgebra = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
+tracing = { workspace = true, optional = true }
 
 
 [dev-dependencies]

--- a/crates/projective-grid/benches/merge.rs
+++ b/crates/projective-grid/benches/merge.rs
@@ -1,0 +1,174 @@
+//! Criterion bench for [`merge_components_local`].
+//!
+//! Run with `cargo bench -p projective-grid --bench merge`.
+//!
+//! Splits a synthetic perspective-warped grid into two or three
+//! components by deleting strips of corners and re-labelling each
+//! surviving component to start at `(0, 0)` (mirrors what the topological
+//! pipeline outputs in real failures: occluded rows / columns).
+
+use std::collections::HashMap;
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use nalgebra::Point2;
+use projective_grid::component_merge::{merge_components_local, ComponentInput, LocalMergeParams};
+
+type Labels = HashMap<(i32, i32), usize>;
+type Fixture = (Vec<Point2<f32>>, Vec<Labels>);
+
+fn perspective_warped_grid(rows: i32, cols: i32, scale: f32) -> Vec<Point2<f32>> {
+    use nalgebra::Matrix3;
+    let h = Matrix3::new(
+        1.0_f32 * scale,
+        0.10 * scale,
+        100.0,
+        -0.05 * scale,
+        0.95 * scale,
+        80.0,
+        0.0006,
+        0.0004,
+        1.0,
+    );
+    let mut points = Vec::with_capacity((rows * cols) as usize);
+    for j in 0..rows {
+        for i in 0..cols {
+            let p = h * nalgebra::Vector3::new(i as f32, j as f32, 1.0);
+            points.push(Point2::new(p.x / p.z, p.y / p.z));
+        }
+    }
+    points
+}
+
+/// Build a labelled map for a `(rows × cols)` block whose positions
+/// occupy slot indices `start..start+rows*cols` in the shared positions
+/// slice. Labels are rebased so the bounding-box minimum is `(0, 0)`.
+fn labelled_block(start: usize, rows: i32, cols: i32) -> Labels {
+    let mut out = HashMap::new();
+    for j in 0..rows {
+        for i in 0..cols {
+            let idx = start + (j * cols + i) as usize;
+            out.insert((i, j), idx);
+        }
+    }
+    out
+}
+
+/// Build two components that overlap in label space (the ground truth
+/// alignment is identity — `merge_components_local` should accept it).
+fn two_overlapping_components() -> Fixture {
+    // Single 30×30 grid; component A keeps rows 0..20, component B
+    // keeps rows 10..30 — 10 overlapping rows.
+    let positions = perspective_warped_grid(30, 30, 50.0);
+    let mut comp_a = HashMap::new();
+    let mut comp_b = HashMap::new();
+    for j in 0..30_i32 {
+        for i in 0..30_i32 {
+            let idx = (j * 30 + i) as usize;
+            if j < 20 {
+                comp_a.insert((i, j), idx);
+            }
+            if j >= 10 {
+                // Component B uses the same indices but is rebased to
+                // start at (0, 0) — mirrors what `topological::walk`
+                // emits per component.
+                comp_b.insert((i, j - 10), idx);
+            }
+        }
+    }
+    (positions, vec![comp_a, comp_b])
+}
+
+/// Build three components: A (top), B (middle), C (bottom). All three
+/// share boundary rows with their neighbour for non-trivial merging.
+fn three_overlapping_components() -> Fixture {
+    let positions = perspective_warped_grid(30, 30, 50.0);
+    let mut comp_a = HashMap::new();
+    let mut comp_b = HashMap::new();
+    let mut comp_c = HashMap::new();
+    for j in 0..30_i32 {
+        for i in 0..30_i32 {
+            let idx = (j * 30 + i) as usize;
+            if j < 12 {
+                comp_a.insert((i, j), idx);
+            }
+            if (8..22).contains(&j) {
+                comp_b.insert((i, j - 8), idx);
+            }
+            if j >= 18 {
+                comp_c.insert((i, j - 18), idx);
+            }
+        }
+    }
+    (positions, vec![comp_a, comp_b, comp_c])
+}
+
+fn bench_merge(c: &mut Criterion) {
+    let mut group = c.benchmark_group("merge_components_local");
+    let params = LocalMergeParams::default();
+
+    {
+        let (positions, comps) = two_overlapping_components();
+        group.bench_function(BenchmarkId::new("overlap", "2_components"), |b| {
+            b.iter(|| {
+                let inputs: Vec<ComponentInput<'_>> = comps
+                    .iter()
+                    .map(|labelled| ComponentInput {
+                        labelled,
+                        positions: &positions,
+                    })
+                    .collect();
+                let res = merge_components_local(black_box(&inputs), black_box(&params));
+                black_box(res.diagnostics.components_out)
+            });
+        });
+    }
+
+    {
+        let (positions, comps) = three_overlapping_components();
+        group.bench_function(BenchmarkId::new("overlap", "3_components"), |b| {
+            b.iter(|| {
+                let inputs: Vec<ComponentInput<'_>> = comps
+                    .iter()
+                    .map(|labelled| ComponentInput {
+                        labelled,
+                        positions: &positions,
+                    })
+                    .collect();
+                let res = merge_components_local(black_box(&inputs), black_box(&params));
+                black_box(res.diagnostics.components_out)
+            });
+        });
+    }
+
+    // Larger workload — 60×60 grid split in half.
+    {
+        let positions = perspective_warped_grid(60, 60, 50.0);
+        let comp_a = labelled_block(0, 32, 60);
+        let mut comp_b = HashMap::new();
+        for j in 28..60_i32 {
+            for i in 0..60_i32 {
+                let idx = (j * 60 + i) as usize;
+                comp_b.insert((i, j - 28), idx);
+            }
+        }
+        let comps = [comp_a, comp_b];
+        group.bench_function(BenchmarkId::new("overlap", "2_components_large"), |b| {
+            b.iter(|| {
+                let inputs: Vec<ComponentInput<'_>> = comps
+                    .iter()
+                    .map(|labelled| ComponentInput {
+                        labelled,
+                        positions: &positions,
+                    })
+                    .collect();
+                let res = merge_components_local(black_box(&inputs), black_box(&params));
+                black_box(res.diagnostics.components_out)
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_merge);
+criterion_main!(benches);

--- a/crates/projective-grid/benches/topological.rs
+++ b/crates/projective-grid/benches/topological.rs
@@ -1,0 +1,165 @@
+//! End-to-end Criterion bench for the topological grid pipeline.
+//!
+//! Run with `cargo bench -p projective-grid --bench topological`.
+//!
+//! Drives [`build_grid_topological`] (Delaunay → classify_all_edges →
+//! merge_triangle_pairs → filter_quads → label_components) on synthetic
+//! perspective-warped grids of increasing size, plus a noisy variant that
+//! injects unaligned background corners — the realistic stressor for the
+//! per-edge axis test in `topological::classify`.
+
+use std::f32::consts::FRAC_PI_2;
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use nalgebra::Point2;
+use projective_grid::topological::{build_grid_topological, AxisHint, TopologicalParams};
+
+/// Build a perspective-warped chessboard-cell corner cloud of size
+/// `rows × cols`. Returns positions plus per-corner axes aligned with
+/// the local grid directions (which is what the topological pipeline
+/// expects).
+fn perspective_warped_grid(
+    rows: i32,
+    cols: i32,
+    scale: f32,
+) -> (Vec<Point2<f32>>, Vec<[AxisHint; 2]>) {
+    use nalgebra::Matrix3;
+    // Same homography as `benches/grow.rs` so results are comparable.
+    let h = Matrix3::new(
+        1.0_f32 * scale,
+        0.10 * scale,
+        100.0,
+        -0.05 * scale,
+        0.95 * scale,
+        80.0,
+        0.0006,
+        0.0004,
+        1.0,
+    );
+
+    let mut positions = Vec::with_capacity((rows * cols) as usize);
+    let mut axes = Vec::with_capacity((rows * cols) as usize);
+
+    // Two unit basis vectors in board space — push them through H to get
+    // the per-corner local grid directions in pixel space. We use a
+    // forward-difference numerical estimate for simplicity (the real
+    // detector reads ChESS axes, but here we just want the topological
+    // pipeline to see plausible angles).
+    for j in 0..rows {
+        for i in 0..cols {
+            let p = h * nalgebra::Vector3::new(i as f32, j as f32, 1.0);
+            let pu = h * nalgebra::Vector3::new(i as f32 + 1.0, j as f32, 1.0);
+            let pv = h * nalgebra::Vector3::new(i as f32, j as f32 + 1.0, 1.0);
+            let here = Point2::new(p.x / p.z, p.y / p.z);
+            let right = Point2::new(pu.x / pu.z, pu.y / pu.z);
+            let down = Point2::new(pv.x / pv.z, pv.y / pv.z);
+            positions.push(here);
+
+            let theta_u = (right.y - here.y).atan2(right.x - here.x);
+            let theta_v = (down.y - here.y).atan2(down.x - here.x);
+            axes.push([
+                AxisHint {
+                    angle: theta_u,
+                    sigma: 0.05,
+                },
+                AxisHint {
+                    angle: theta_v,
+                    sigma: 0.05,
+                },
+            ]);
+        }
+    }
+
+    (positions, axes)
+}
+
+/// Inject `extra` noise corners with random-looking positions and axis
+/// angles inside the bounding box of `positions`. Uses a deterministic
+/// LCG so results are reproducible across runs.
+fn inject_noise(
+    positions: &mut Vec<Point2<f32>>,
+    axes: &mut Vec<[AxisHint; 2]>,
+    extra: usize,
+    seed: u64,
+) {
+    let (mut min_x, mut min_y, mut max_x, mut max_y) = (
+        f32::INFINITY,
+        f32::INFINITY,
+        f32::NEG_INFINITY,
+        f32::NEG_INFINITY,
+    );
+    for p in positions.iter() {
+        min_x = min_x.min(p.x);
+        min_y = min_y.min(p.y);
+        max_x = max_x.max(p.x);
+        max_y = max_y.max(p.y);
+    }
+    let mut state = seed | 1;
+    let mut next = || {
+        state = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        ((state >> 33) as u32) as f32 / u32::MAX as f32
+    };
+    for _ in 0..extra {
+        let x = min_x + next() * (max_x - min_x);
+        let y = min_y + next() * (max_y - min_y);
+        // Random axis offset in [0, π) — explicitly NOT aligned with the
+        // grid so the topological classifier sees a Spurious edge.
+        let theta = next() * std::f32::consts::PI;
+        positions.push(Point2::new(x, y));
+        axes.push([
+            AxisHint {
+                angle: theta,
+                sigma: 0.05,
+            },
+            AxisHint {
+                angle: theta + FRAC_PI_2,
+                sigma: 0.05,
+            },
+        ]);
+    }
+}
+
+fn bench_build_grid_topological(c: &mut Criterion) {
+    let mut group = c.benchmark_group("build_grid_topological");
+    let params = TopologicalParams::default();
+
+    for &(rows, cols) in &[(10, 10), (20, 20), (40, 40), (60, 60)] {
+        let (positions, axes) = perspective_warped_grid(rows, cols, 50.0);
+        group.bench_with_input(
+            BenchmarkId::new("clean", format!("{rows}x{cols}")),
+            &(positions, axes),
+            |b, (positions, axes)| {
+                b.iter(|| {
+                    let res = build_grid_topological(
+                        black_box(positions),
+                        black_box(axes),
+                        black_box(&params),
+                    )
+                    .expect("synthetic grids should always succeed");
+                    black_box(res.diagnostics.quads_kept)
+                });
+            },
+        );
+    }
+
+    // Noisy stressor: 20×20 + 50% noise corners. Mirrors what real
+    // images look like to the topological pipeline (lots of background
+    // ChESS corners that produce Spurious Delaunay edges).
+    let (mut positions, mut axes) = perspective_warped_grid(20, 20, 50.0);
+    inject_noise(&mut positions, &mut axes, 200, 0xC0FFEE);
+    group.bench_function(BenchmarkId::new("noisy", "20x20+50pct"), |b| {
+        b.iter(|| {
+            let res =
+                build_grid_topological(black_box(&positions), black_box(&axes), black_box(&params))
+                    .expect("synthetic grids should always succeed");
+            black_box(res.diagnostics.quads_kept)
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_build_grid_topological);
+criterion_main!(benches);

--- a/crates/projective-grid/benches/validate.rs
+++ b/crates/projective-grid/benches/validate.rs
@@ -1,0 +1,102 @@
+//! Criterion bench for [`square::validate::validate`].
+//!
+//! Run with `cargo bench -p projective-grid --bench validate`.
+//!
+//! Drives the post-grow validation pass over a synthetic perspective-
+//! warped grid. Two scenarios:
+//!
+//! - **clean**: every labelled corner sits exactly on the rectified
+//!   grid. Validation should produce an empty blacklist.
+//! - **with_outliers**: a fraction of labelled corners are offset by
+//!   `0.4 × cell_size` to trigger line-fit and local-H residual flags.
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use nalgebra::Point2;
+use projective_grid::square::validate::{validate, LabelledEntry, ValidationParams};
+
+fn perspective_warped_entries(rows: i32, cols: i32, scale: f32) -> Vec<LabelledEntry> {
+    use nalgebra::Matrix3;
+    let h = Matrix3::new(
+        1.0_f32 * scale,
+        0.10 * scale,
+        100.0,
+        -0.05 * scale,
+        0.95 * scale,
+        80.0,
+        0.0006,
+        0.0004,
+        1.0,
+    );
+    let mut entries = Vec::with_capacity((rows * cols) as usize);
+    for j in 0..rows {
+        for i in 0..cols {
+            let p = h * nalgebra::Vector3::new(i as f32, j as f32, 1.0);
+            let pixel = Point2::new(p.x / p.z, p.y / p.z);
+            entries.push(LabelledEntry {
+                idx: entries.len(),
+                pixel,
+                grid: (i, j),
+            });
+        }
+    }
+    entries
+}
+
+fn perturb(entries: &mut [LabelledEntry], cell_size: f32, fraction: f32, seed: u64) {
+    let mut state = seed | 1;
+    let mut next = || {
+        state = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        ((state >> 33) as u32) as f32 / u32::MAX as f32
+    };
+    let target_count = (entries.len() as f32 * fraction) as usize;
+    for _ in 0..target_count {
+        let i = (next() * entries.len() as f32) as usize % entries.len();
+        let dx = (next() * 2.0 - 1.0) * 0.4 * cell_size;
+        let dy = (next() * 2.0 - 1.0) * 0.4 * cell_size;
+        entries[i].pixel.x += dx;
+        entries[i].pixel.y += dy;
+    }
+}
+
+fn bench_validate(c: &mut Criterion) {
+    let mut group = c.benchmark_group("validate");
+    let params = ValidationParams::default();
+
+    for &(rows, cols) in &[(10, 10), (20, 20), (40, 40), (60, 60)] {
+        let cell_size = 50.0_f32; // matches scale in perspective_warped_entries
+        let entries = perspective_warped_entries(rows, cols, cell_size);
+
+        group.bench_with_input(
+            BenchmarkId::new("clean", format!("{rows}x{cols}")),
+            &entries,
+            |b, entries| {
+                b.iter(|| {
+                    let res =
+                        validate(black_box(entries), black_box(cell_size), black_box(&params));
+                    black_box(res.blacklist.len())
+                });
+            },
+        );
+
+        let mut perturbed = entries.clone();
+        perturb(&mut perturbed, cell_size, 0.10, 0xCAFEBABE);
+        group.bench_with_input(
+            BenchmarkId::new("with_outliers", format!("{rows}x{cols}")),
+            &perturbed,
+            |b, entries| {
+                b.iter(|| {
+                    let res =
+                        validate(black_box(entries), black_box(cell_size), black_box(&params));
+                    black_box(res.blacklist.len())
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_validate);
+criterion_main!(benches);

--- a/crates/projective-grid/src/component_merge.rs
+++ b/crates/projective-grid/src/component_merge.rs
@@ -219,6 +219,14 @@ fn rebase(labelled: &mut HashMap<(i32, i32), usize>) {
 /// tolerances. On success, rewrite `p`'s labels into `q`'s frame and
 /// merge into `q`. Repeat until no further merges are possible or the
 /// `max_components` cap is reached.
+#[cfg_attr(
+    feature = "tracing",
+    tracing::instrument(
+        level = "info",
+        skip_all,
+        fields(num_components = inputs.len()),
+    )
+)]
 pub fn merge_components_local(
     inputs: &[ComponentInput<'_>],
     params: &LocalMergeParams,

--- a/crates/projective-grid/src/component_merge.rs
+++ b/crates/projective-grid/src/component_merge.rs
@@ -129,22 +129,67 @@ fn apply_transform(t: GridTransform, ij: (i32, i32)) -> (i32, i32) {
     (v.i, v.j)
 }
 
+/// For a candidate `(transform, delta)`, score the alignment by full
+/// label-space overlap.
+///
+/// Counts every `c_p` label whose `transform · ij_p + delta` exists as a
+/// key in `c_q.labelled` (regardless of pixel distance), and tracks the
+/// worst pixel-position disagreement among those overlapping label
+/// pairs. The histogram-based candidate enumeration in
+/// [`find_best_alignment`] only sees pairs already within `pos_tol`, so
+/// without this re-scoring an alignment whose label-space overlap
+/// includes one or more pairs *outside* `pos_tol` would silently merge.
+/// That would corrupt downstream calibration. Use this re-scoring as
+/// the precision gate before accepting a candidate.
+fn score_alignment(
+    c_p: &ComponentInput<'_>,
+    c_q: &ComponentInput<'_>,
+    t: GridTransform,
+    delta: (i32, i32),
+) -> (usize, f32) {
+    let mut overlap = 0usize;
+    let mut max_err = 0.0f32;
+    for (&ij_p, &idx_p) in c_p.labelled.iter() {
+        let ij_t = apply_transform(t, ij_p);
+        let ij_q = (ij_t.0 + delta.0, ij_t.1 + delta.1);
+        if let Some(&idx_q) = c_q.labelled.get(&ij_q) {
+            let err = euclidean(c_p.positions[idx_p], c_q.positions[idx_q]);
+            overlap += 1;
+            if err > max_err {
+                max_err = err;
+            }
+        }
+    }
+    (overlap, max_err)
+}
+
 /// Find the best (transform, offset) for merging `c_p` into `c_q`'s frame.
 ///
-/// Strategy: position-based Hough transform on (transform, label-delta).
+/// Two-pass strategy:
 ///
-/// For two components to merge, every overlapping label pair must have
-/// near-identical pixel positions (since the labels refer to the same
-/// physical corner in different label frames). We exploit this by
-/// indexing `c_q`'s positions in a KD-tree, then for each label in
-/// `c_p` finding all `c_q` labels whose pixel position is within
-/// `pos_tol`. Each such pair is a vote for whatever (transform, delta)
-/// would map them onto each other. The (t, δ) bin with the most votes
-/// is the right alignment.
+/// 1. **Hough enumeration.** Index `c_q`'s positions in a KD-tree, then
+///    for each label in `c_p` find every `c_q` label whose pixel
+///    position is within `pos_tol` and vote each match into a histogram
+///    bin keyed by the candidate `(transform, label-delta)`. This
+///    surfaces a small set of candidate alignments in `O(P log Q)`,
+///    replacing the previous `O(P² Q)` anchor enumeration.
+/// 2. **Full-overlap re-scoring.** Each surviving candidate is
+///    re-scored by [`score_alignment`] over the *full* label-space
+///    overlap (every `c_p` label whose `transform · ij_p + delta` is a
+///    key in `c_q.labelled`, regardless of pixel distance). The
+///    candidate is accepted only when the re-scored overlap meets
+///    `min_overlap` AND the re-scored `max_err` is within `pos_tol`.
+///    This is the precision gate: a histogram bin can pass with
+///    `min_overlap` position-close inliers even when other label-space
+///    overlaps under the same alignment sit far above tolerance, and
+///    accepting such an alignment would corrupt downstream calibration.
+///    Re-scoring catches that case.
 ///
-/// This replaces the previous O(P²Q) anchor enumeration with
-/// O(P log Q) KD-tree queries, scaling many orders of magnitude better
-/// on realistic component sizes (200+ labels per component).
+/// The accepted candidate set is then ranked by
+/// `(overlap_full desc, max_err_full asc, transform_index asc,
+/// delta asc)` — a strict total order that matches the original
+/// algorithm's tiebreaker (which preferred identity by D4 iteration
+/// order).
 fn find_best_alignment(
     c_p: &ComponentInput<'_>,
     c_q: &ComponentInput<'_>,
@@ -166,10 +211,9 @@ fn find_best_alignment(
         tree.add(&[pos.x, pos.y], slot as u64);
     }
 
-    // Histogram bin: (transform_index, delta_i, delta_j) →
-    // (overlap_count, max_position_error).
-    let mut hist: HashMap<(u8, i32, i32), (usize, f32)> = HashMap::new();
-
+    // Pass 1: Hough enumeration. The bin counts position-close votes
+    // only — that's a *lower bound* on the full label-space overlap.
+    let mut hist: HashMap<(u8, i32, i32), usize> = HashMap::new();
     for (&ij_p, &idx_p) in c_p.labelled.iter() {
         let pos_p = c_p.positions[idx_p];
         for nn in tree
@@ -177,44 +221,47 @@ fn find_best_alignment(
             .into_iter()
         {
             let slot = nn.item as usize;
-            let (ij_q, idx_q) = q_entries[slot];
-            let err = euclidean(pos_p, c_q.positions[idx_q]);
+            let (ij_q, _idx_q) = q_entries[slot];
             for (t_idx, t) in crate::GRID_TRANSFORMS_D4.iter().enumerate() {
                 let tij_p = apply_transform(*t, ij_p);
                 let key = (t_idx as u8, ij_q.0 - tij_p.0, ij_q.1 - tij_p.1);
-                let entry = hist.entry(key).or_insert((0usize, 0.0f32));
-                entry.0 += 1;
-                if err > entry.1 {
-                    entry.1 = err;
-                }
+                *hist.entry(key).or_insert(0usize) += 1;
             }
         }
     }
 
+    // Pass 2: re-score each candidate over the full label-space
+    // overlap. A bin survives only when every `c_p` label that maps
+    // (under this t/δ) to a key in `c_q.labelled` is within `pos_tol`
+    // — see `score_alignment` for the precision contract.
+    //
     // Tiebreaker: prefer higher overlap, then lower max_err, then
     // smaller transform index (identity = 0, so identity wins ties),
-    // then lexicographic delta. The transform-index tiebreaker
-    // matches the original algorithm's iteration order, which
-    // implicitly preferred identity when multiple D4 transforms
-    // produced valid alignments at the same overlap (e.g. on highly
-    // symmetric synthetic test grids).
+    // then lexicographic delta — matching the original algorithm's
+    // iteration order on highly symmetric synthetic test grids.
     let mut best: Option<(u8, (i32, i32), usize, f32)> = None;
-    for ((t_idx, di, dj), (overlap, max_err)) in hist.into_iter() {
-        if overlap < params.min_overlap {
+    for (&(t_idx, di, dj), &kdtree_overlap) in &hist {
+        if kdtree_overlap < params.min_overlap {
+            // Histogram is a lower bound on the full overlap, but only
+            // for pairs already within `pos_tol`. A bin that fails the
+            // KD-tree-overlap floor cannot reach `min_overlap`
+            // position-close pairs and is rejected outright; we don't
+            // even bother re-scoring.
             continue;
         }
-        // The KD-tree query already enforced max_err ≤ pos_tol per
-        // contribution, so re-checking max_err is defensive only.
-        if max_err > pos_tol {
+        let t = crate::GRID_TRANSFORMS_D4[t_idx as usize];
+        let delta = (di, dj);
+        let (overlap_full, max_err_full) = score_alignment(c_p, c_q, t, delta);
+        if overlap_full < params.min_overlap || max_err_full > pos_tol {
             continue;
         }
         let take = match &best {
             None => true,
             Some((best_t_idx, best_delta, best_overlap, best_err)) => {
-                if overlap != *best_overlap {
-                    overlap > *best_overlap
-                } else if (max_err - *best_err).abs() > f32::EPSILON {
-                    max_err < *best_err
+                if overlap_full != *best_overlap {
+                    overlap_full > *best_overlap
+                } else if (max_err_full - *best_err).abs() > f32::EPSILON {
+                    max_err_full < *best_err
                 } else if t_idx != *best_t_idx {
                     t_idx < *best_t_idx
                 } else {
@@ -223,7 +270,7 @@ fn find_best_alignment(
             }
         };
         if take {
-            best = Some((t_idx, (di, dj), overlap, max_err));
+            best = Some((t_idx, (di, dj), overlap_full, max_err_full));
         }
     }
     best.map(|(t_idx, d, n, _)| (crate::GRID_TRANSFORMS_D4[t_idx as usize], d, n))
@@ -456,6 +503,66 @@ mod tests {
         ];
         let res = merge_components_local(&inputs, &LocalMergeParams::default());
         assert_eq!(res.components.len(), 2);
+        assert_eq!(res.diagnostics.merges_accepted, 0);
+    }
+
+    /// Regression for the precision contract: a histogram bin can pass
+    /// `min_overlap` on position-close votes alone while another
+    /// label-aligned pair under the same `(transform, delta)` sits far
+    /// outside `pos_tol`. Without the full-overlap re-score, the merge
+    /// would proceed and corrupt the grid labelling.
+    ///
+    /// Setup: two 2×2 components share three corners exactly, but one
+    /// corner has drifted ~5× the cell size in `c_q`. The histogram
+    /// counts three position-close votes for `(identity, (0, 0))` —
+    /// enough to clear `min_overlap = 2`. The full label-space
+    /// overlap is four with `max_err ≈ 56 px`, which the precision
+    /// gate must reject.
+    #[test]
+    fn drifted_overlapping_corner_blocks_merge() {
+        let cell = 10.0_f32;
+        // C1: 4 labels on the unit cell, exact positions.
+        let mut l1: Labels = HashMap::new();
+        let mut p1: Positions = Vec::new();
+        for j in 0..2 {
+            for i in 0..2 {
+                let idx = p1.len();
+                l1.insert((i, j), idx);
+                p1.push(Point2::new(i as f32 * cell, j as f32 * cell));
+            }
+        }
+        // C2: same labels, but the (1, 1) corner is drifted to (50, 50)
+        // — far outside `pos_tol = 0.20 × cell = 2.0` from c_p's (10, 10).
+        let mut l2: Labels = HashMap::new();
+        let mut p2: Positions = Vec::new();
+        for j in 0..2 {
+            for i in 0..2 {
+                let idx = p2.len();
+                l2.insert((i, j), idx);
+                let pos = if (i, j) == (1, 1) {
+                    Point2::new(50.0, 50.0)
+                } else {
+                    Point2::new(i as f32 * cell, j as f32 * cell)
+                };
+                p2.push(pos);
+            }
+        }
+        let inputs = vec![
+            ComponentInput {
+                labelled: &l1,
+                positions: &p1,
+            },
+            ComponentInput {
+                labelled: &l2,
+                positions: &p2,
+            },
+        ];
+        let res = merge_components_local(&inputs, &LocalMergeParams::default());
+        assert_eq!(
+            res.components.len(),
+            2,
+            "drifted corner should block the merge entirely"
+        );
         assert_eq!(res.diagnostics.merges_accepted, 0);
     }
 }

--- a/crates/projective-grid/src/component_merge.rs
+++ b/crates/projective-grid/src/component_merge.rs
@@ -34,8 +34,9 @@
 //! one component's predicted boundary position to the other's actual
 //! boundary corner.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
+use kiddo::{KdTree, SquaredEuclidean};
 use nalgebra::Point2;
 use serde::{Deserialize, Serialize};
 
@@ -128,32 +129,22 @@ fn apply_transform(t: GridTransform, ij: (i32, i32)) -> (i32, i32) {
     (v.i, v.j)
 }
 
-/// For a candidate alignment of `c_p` into `c_q`'s frame (transform `t`,
-/// offset `delta`), count overlapping labels and the worst position
-/// disagreement.
-fn score_alignment(
-    c_p: &ComponentInput<'_>,
-    c_q: &ComponentInput<'_>,
-    t: GridTransform,
-    delta: (i32, i32),
-) -> (usize, f32) {
-    let mut overlap = 0usize;
-    let mut max_err = 0.0f32;
-    for (&ij_p, &idx_p) in c_p.labelled.iter() {
-        let ij_t = apply_transform(t, ij_p);
-        let ij_q = (ij_t.0 + delta.0, ij_t.1 + delta.1);
-        if let Some(&idx_q) = c_q.labelled.get(&ij_q) {
-            let err = euclidean(c_p.positions[idx_p], c_q.positions[idx_q]);
-            overlap += 1;
-            if err > max_err {
-                max_err = err;
-            }
-        }
-    }
-    (overlap, max_err)
-}
-
 /// Find the best (transform, offset) for merging `c_p` into `c_q`'s frame.
+///
+/// Strategy: position-based Hough transform on (transform, label-delta).
+///
+/// For two components to merge, every overlapping label pair must have
+/// near-identical pixel positions (since the labels refer to the same
+/// physical corner in different label frames). We exploit this by
+/// indexing `c_q`'s positions in a KD-tree, then for each label in
+/// `c_p` finding all `c_q` labels whose pixel position is within
+/// `pos_tol`. Each such pair is a vote for whatever (transform, delta)
+/// would map them onto each other. The (t, δ) bin with the most votes
+/// is the right alignment.
+///
+/// This replaces the previous O(P²Q) anchor enumeration with
+/// O(P log Q) KD-tree queries, scaling many orders of magnitude better
+/// on realistic component sizes (200+ labels per component).
 fn find_best_alignment(
     c_p: &ComponentInput<'_>,
     c_q: &ComponentInput<'_>,
@@ -161,38 +152,81 @@ fn find_best_alignment(
     params: &LocalMergeParams,
 ) -> Option<(GridTransform, (i32, i32), usize)> {
     let pos_tol = params.position_tol_rel * cell_size.max(1.0);
-    let mut best: Option<(GridTransform, (i32, i32), usize, f32)> = None;
-    // Anchor: pair one corner from each component, derive offset, score.
-    let p_iter: Vec<((i32, i32), usize)> = c_p.labelled.iter().map(|(k, v)| (*k, *v)).collect();
-    let q_iter: Vec<((i32, i32), usize)> = c_q.labelled.iter().map(|(k, v)| (*k, *v)).collect();
-    for t in crate::GRID_TRANSFORMS_D4.iter().copied() {
-        // Choose anchors that have a labelled neighbour to disambiguate
-        // reflections vs rotations. Cheap heuristic: just iterate.
-        let mut tried: HashSet<(i32, i32)> = HashSet::new();
-        for &(ij_p, _) in &p_iter {
-            for &(ij_q, _) in &q_iter {
-                let tij_p = apply_transform(t, ij_p);
-                let delta = (ij_q.0 - tij_p.0, ij_q.1 - tij_p.1);
-                if !tried.insert(delta) {
-                    continue; // Same offset already tried for this transform.
-                }
-                let (overlap, max_err) = score_alignment(c_p, c_q, t, delta);
-                if overlap < params.min_overlap || max_err > pos_tol {
-                    continue;
-                }
-                let take = match &best {
-                    None => true,
-                    Some((_, _, best_overlap, best_err)) => {
-                        overlap > *best_overlap || (overlap == *best_overlap && max_err < *best_err)
-                    }
-                };
-                if take {
-                    best = Some((t, delta, overlap, max_err));
+    let pos_tol_sq = pos_tol * pos_tol;
+
+    // KD-tree over c_q label positions. The slot index maps back to
+    // q_entries[slot] = (ij_q, idx_q).
+    let q_entries: Vec<((i32, i32), usize)> = c_q.labelled.iter().map(|(k, v)| (*k, *v)).collect();
+    if q_entries.is_empty() {
+        return None;
+    }
+    let mut tree: KdTree<f32, 2> = KdTree::new();
+    for (slot, (_, idx)) in q_entries.iter().enumerate() {
+        let pos = c_q.positions[*idx];
+        tree.add(&[pos.x, pos.y], slot as u64);
+    }
+
+    // Histogram bin: (transform_index, delta_i, delta_j) →
+    // (overlap_count, max_position_error).
+    let mut hist: HashMap<(u8, i32, i32), (usize, f32)> = HashMap::new();
+
+    for (&ij_p, &idx_p) in c_p.labelled.iter() {
+        let pos_p = c_p.positions[idx_p];
+        for nn in tree
+            .within_unsorted::<SquaredEuclidean>(&[pos_p.x, pos_p.y], pos_tol_sq)
+            .into_iter()
+        {
+            let slot = nn.item as usize;
+            let (ij_q, idx_q) = q_entries[slot];
+            let err = euclidean(pos_p, c_q.positions[idx_q]);
+            for (t_idx, t) in crate::GRID_TRANSFORMS_D4.iter().enumerate() {
+                let tij_p = apply_transform(*t, ij_p);
+                let key = (t_idx as u8, ij_q.0 - tij_p.0, ij_q.1 - tij_p.1);
+                let entry = hist.entry(key).or_insert((0usize, 0.0f32));
+                entry.0 += 1;
+                if err > entry.1 {
+                    entry.1 = err;
                 }
             }
         }
     }
-    best.map(|(t, d, n, _)| (t, d, n))
+
+    // Tiebreaker: prefer higher overlap, then lower max_err, then
+    // smaller transform index (identity = 0, so identity wins ties),
+    // then lexicographic delta. The transform-index tiebreaker
+    // matches the original algorithm's iteration order, which
+    // implicitly preferred identity when multiple D4 transforms
+    // produced valid alignments at the same overlap (e.g. on highly
+    // symmetric synthetic test grids).
+    let mut best: Option<(u8, (i32, i32), usize, f32)> = None;
+    for ((t_idx, di, dj), (overlap, max_err)) in hist.into_iter() {
+        if overlap < params.min_overlap {
+            continue;
+        }
+        // The KD-tree query already enforced max_err ≤ pos_tol per
+        // contribution, so re-checking max_err is defensive only.
+        if max_err > pos_tol {
+            continue;
+        }
+        let take = match &best {
+            None => true,
+            Some((best_t_idx, best_delta, best_overlap, best_err)) => {
+                if overlap != *best_overlap {
+                    overlap > *best_overlap
+                } else if (max_err - *best_err).abs() > f32::EPSILON {
+                    max_err < *best_err
+                } else if t_idx != *best_t_idx {
+                    t_idx < *best_t_idx
+                } else {
+                    (di, dj) < *best_delta
+                }
+            }
+        };
+        if take {
+            best = Some((t_idx, (di, dj), overlap, max_err));
+        }
+    }
+    best.map(|(t_idx, d, n, _)| (crate::GRID_TRANSFORMS_D4[t_idx as usize], d, n))
 }
 
 fn rebase(labelled: &mut HashMap<(i32, i32), usize>) {

--- a/crates/projective-grid/src/global_step.rs
+++ b/crates/projective-grid/src/global_step.rs
@@ -89,6 +89,14 @@ impl<F: Float> Default for GlobalStepParams<F> {
 ///
 /// Returns `None` when the cloud is too small (≤ 1 point) or degenerate
 /// (all nearest-neighbor distances are zero).
+#[cfg_attr(
+    feature = "tracing",
+    tracing::instrument(
+        level = "debug",
+        skip_all,
+        fields(num_points = positions.len()),
+    )
+)]
 pub fn estimate_global_cell_size<F: Float + kiddo::float::kdtree::Axis>(
     positions: &[Point2<F>],
     params: &GlobalStepParams<F>,

--- a/crates/projective-grid/src/local_step.rs
+++ b/crates/projective-grid/src/local_step.rs
@@ -134,6 +134,14 @@ impl<F: Float> Default for LocalStepParams<F> {
 /// Returns a vector whose length matches `points`. Points that end up with no
 /// usable neighbors receive [`LocalStep::default`] (all zeros + zero
 /// confidence), letting downstream validators fall back to a global step.
+#[cfg_attr(
+    feature = "tracing",
+    tracing::instrument(
+        level = "debug",
+        skip_all,
+        fields(num_points = points.len()),
+    )
+)]
 pub fn estimate_local_steps<F: Float + kiddo::float::kdtree::Axis>(
     points: &[LocalStepPointData<F>],
     params: &LocalStepParams<F>,

--- a/crates/projective-grid/src/square/extension/global.rs
+++ b/crates/projective-grid/src/square/extension/global.rs
@@ -18,6 +18,14 @@ use crate::square::grow::{GrowResult, GrowValidator};
 /// Try to extend the labelled grid outward (and into interior holes)
 /// using a globally-fit homography. Mutates `grow.labelled` and
 /// `grow.by_corner` in place.
+#[cfg_attr(
+    feature = "tracing",
+    tracing::instrument(
+        level = "info",
+        skip_all,
+        fields(num_corners = positions.len(), num_labelled = grow.labelled.len(), cell_size = cell_size),
+    )
+)]
 pub fn extend_via_global_homography<V: GrowValidator>(
     positions: &[Point2<f32>],
     grow: &mut GrowResult,

--- a/crates/projective-grid/src/square/extension/local.rs
+++ b/crates/projective-grid/src/square/extension/local.rs
@@ -28,6 +28,14 @@ use crate::square::grow::{GrowResult, GrowValidator};
 /// aggregate residuals across **all** per-candidate fits in this pass
 /// (median / worst across all supports). `h_trusted` is `true` if at
 /// least one candidate's local fit passed its trust gate.
+#[cfg_attr(
+    feature = "tracing",
+    tracing::instrument(
+        level = "info",
+        skip_all,
+        fields(num_corners = positions.len(), num_labelled = grow.labelled.len(), cell_size = cell_size),
+    )
+)]
 pub fn extend_via_local_homography<V: GrowValidator>(
     positions: &[Point2<f32>],
     grow: &mut GrowResult,

--- a/crates/projective-grid/src/square/grow.rs
+++ b/crates/projective-grid/src/square/grow.rs
@@ -179,6 +179,14 @@ pub struct GrowResult {
 /// `(0, 0)`. The caller is responsible for any per-corner state
 /// updates after the call (e.g., marking corners as "labelled" in a
 /// local stage enum).
+#[cfg_attr(
+    feature = "tracing",
+    tracing::instrument(
+        level = "info",
+        skip_all,
+        fields(num_corners = positions.len(), cell_size = cell_size),
+    )
+)]
 pub fn bfs_grow<V: GrowValidator>(
     positions: &[Point2<f32>],
     seed: Seed,

--- a/crates/projective-grid/src/square/grow_extend.rs
+++ b/crates/projective-grid/src/square/grow_extend.rs
@@ -61,6 +61,14 @@ pub struct BfsExtensionStats {
 /// A [`BfsExtensionStats`] summary. The caller is responsible for any
 /// per-corner state updates (e.g., marking newly-attached corners as
 /// "Labeled" in a local stage enum).
+#[cfg_attr(
+    feature = "tracing",
+    tracing::instrument(
+        level = "info",
+        skip_all,
+        fields(num_corners = positions.len(), num_labelled = grow.labelled.len(), cell_size = cell_size),
+    )
+)]
 pub fn extend_from_labelled<V: GrowValidator>(
     positions: &[Point2<f32>],
     grow: &mut GrowResult,

--- a/crates/projective-grid/src/square/validate/mod.rs
+++ b/crates/projective-grid/src/square/validate/mod.rs
@@ -165,6 +165,14 @@ pub struct ValidationResult {
 }
 
 /// Run both validation passes and produce a blacklist.
+#[cfg_attr(
+    feature = "tracing",
+    tracing::instrument(
+        level = "info",
+        skip_all,
+        fields(num_labelled = entries.len(), cell_size = cell_size),
+    )
+)]
 pub fn validate(
     entries: &[LabelledEntry],
     cell_size: f32,

--- a/crates/projective-grid/src/topological/classify.rs
+++ b/crates/projective-grid/src/topological/classify.rs
@@ -87,6 +87,14 @@ fn classify_at_corner(theta: f32, axes: &[AxisHint; 2], params: &TopologicalPara
 /// Classify every directed half-edge in the triangulation.
 ///
 /// Length matches `triangulation.triangles.len()`.
+#[cfg_attr(
+    feature = "tracing",
+    tracing::instrument(
+        level = "debug",
+        skip_all,
+        fields(num_edges = triangulation.triangles.len()),
+    )
+)]
 pub(crate) fn classify_all_edges(
     positions: &[Point2<f32>],
     axes: &[[AxisHint; 2]],

--- a/crates/projective-grid/src/topological/mod.rs
+++ b/crates/projective-grid/src/topological/mod.rs
@@ -194,6 +194,14 @@ pub enum TopologicalError {
 /// Returns one [`TopologicalComponent`] per connected component of the
 /// surviving quad mesh. Use [`crate::component_merge`] to attempt to
 /// merge components into a single grid.
+#[cfg_attr(
+    feature = "tracing",
+    tracing::instrument(
+        level = "info",
+        skip_all,
+        fields(num_corners = positions.len()),
+    )
+)]
 pub fn build_grid_topological(
     positions: &[Point2<f32>],
     axes: &[[AxisHint; 2]],

--- a/crates/projective-grid/src/topological/quads.rs
+++ b/crates/projective-grid/src/topological/quads.rs
@@ -113,6 +113,14 @@ fn build_quad(verts: [usize; 4], positions: &[Point2<f32>]) -> Quad {
 /// Walk the triangulation and emit one quad per matching pair of
 /// triangles. Pairs are deduplicated (each diagonal edge is processed
 /// from the side with the smaller triangle index).
+#[cfg_attr(
+    feature = "tracing",
+    tracing::instrument(
+        level = "debug",
+        skip_all,
+        fields(num_triangles = triangulation.num_tri()),
+    )
+)]
 pub(crate) fn merge_triangle_pairs(
     triangulation: &Triangulation,
     kinds: &[EdgeKind],

--- a/crates/projective-grid/src/topological/topo_filter.rs
+++ b/crates/projective-grid/src/topological/topo_filter.rs
@@ -32,6 +32,14 @@ fn passes_geometric(quad: &Quad, positions: &[Point2<f32>], params: &Topological
 }
 
 /// Apply topological + geometric filtering and return the surviving quads.
+#[cfg_attr(
+    feature = "tracing",
+    tracing::instrument(
+        level = "debug",
+        skip_all,
+        fields(num_quads_in = quads.len()),
+    )
+)]
 pub(crate) fn filter_quads(
     quads: &[Quad],
     positions: &[Point2<f32>],

--- a/crates/projective-grid/src/topological/walk.rs
+++ b/crates/projective-grid/src/topological/walk.rs
@@ -169,6 +169,14 @@ fn rebase(labelled: &mut HashMap<(i32, i32), usize>) {
 
 /// Walk the quad mesh and produce one labelled component per connected
 /// piece. Components below `min_quads_per_component` are dropped.
+#[cfg_attr(
+    feature = "tracing",
+    tracing::instrument(
+        level = "debug",
+        skip_all,
+        fields(num_quads = quads.len()),
+    )
+)]
 pub(crate) fn label_components(quads: &[Quad], min_quads: usize) -> Vec<TopologicalComponent> {
     if quads.is_empty() {
         return Vec::new();

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -1,0 +1,179 @@
+# Profiling the projective-grid pipelines
+
+This page documents how to capture flamegraphs and per-span timing for the
+two grid-build pipelines (`GraphBuildAlgorithm::Topological` and
+`GraphBuildAlgorithm::ChessboardV2`) plus the shared
+`merge_components_local` post-stage.
+
+## TL;DR
+
+```bash
+# 1. Install the profiler (macOS).
+cargo install samply
+
+# 2. Build a release binary with debug info.
+cargo build --profile profiling -p calib-targets-bench --bin bench
+
+# 3. Capture a flamegraph for one image / one algorithm.
+samply record -- ./target/profiling/bench run \
+    --algorithm chessboard-v2 \
+    --image testdata/large.png \
+    --target chessboard
+
+# 4. Capture per-span timing (info-level).
+RUST_LOG=info cargo run --profile profiling \
+    --features "calib-targets/tracing" \
+    -p calib-targets-bench --bin bench -- run \
+    --algorithm chessboard-v2 \
+    --image testdata/large.png \
+    --target chessboard
+```
+
+## Profiles
+
+The workspace defines a `profiling` Cargo profile that inherits from
+`release` but keeps line-table debug info. Use it for any flamegraph
+capture so symbols resolve in the viewer:
+
+```toml
+[profile.profiling]
+inherits = "release"
+debug = "line-tables-only"
+split-debuginfo = "unpacked"
+strip = false
+```
+
+`cargo build --profile profiling` produces binaries in `target/profiling/`.
+`cargo run --profile profiling` works the same way.
+
+## Profiler choice — samply (macOS default)
+
+`samply` is the recommended profiler on macOS:
+
+- No `sudo`, no `dtrace`, no SIP issues.
+- Native to Apple Silicon.
+- Uploads the captured profile to `profile.firefox.com` for an interactive
+  flamegraph + call-tree view (no data leaves the local machine — the URL
+  encodes a server-side ID for *your* upload only, but you can use
+  `samply load profile.json` for fully-offline review instead).
+
+Install once:
+
+```bash
+cargo install samply
+```
+
+Capture and view:
+
+```bash
+samply record -- ./target/profiling/bench run \
+    --algorithm topological \
+    --image testdata/large.png \
+    --target chessboard
+# → opens the flamegraph in your browser when the run finishes.
+```
+
+To save the raw profile (so it can be re-opened, attached to a PR
+description, or compared with a later run):
+
+```bash
+samply record -o /tmp/topo-large.json.gz -- <command>
+samply load /tmp/topo-large.json.gz   # offline viewer
+```
+
+For longer runs prefix `samply record --` to whatever invocation you
+already use (criterion, an example, a unit test). The profiling profile
+applies to release-style builds; criterion uses release by default, so
+just rebuild with `--profile profiling` if you need symbols:
+
+```bash
+cargo bench -p projective-grid --no-run --profile profiling
+samply record -- ./target/profiling/deps/grow-<hash> --bench
+```
+
+## Profiler choice — cargo-flamegraph (fallback)
+
+`cargo-flamegraph` works too but uses `dtrace` on macOS, which usually
+needs `sudo` and may be blocked by SIP. Install with
+`cargo install flamegraph` and run:
+
+```bash
+sudo cargo flamegraph --profile profiling \
+    -p calib-targets-bench --bin bench -- \
+    run --algorithm chessboard-v2 --image testdata/large.png --target chessboard
+```
+
+This produces a `flamegraph.svg` next to your invocation directory. Move
+or rename it before the next run; otherwise it will be overwritten.
+
+## Tracing — per-span p50/p95 (continuous metrics)
+
+`projective-grid` and the four detector crates all expose an optional
+`tracing` Cargo feature. When enabled, the hot-path entry points are
+wrapped in `tracing::instrument` so every call produces an enter/exit
+event with field metadata:
+
+| Crate | Function | Span level | Fields |
+|---|---|---|---|
+| `projective-grid` | `build_grid_topological` | info | `num_corners` |
+| `projective-grid` | `square::grow::bfs_grow` | info | `num_corners`, `cell_size` |
+| `projective-grid` | `merge_components_local` | info | `num_components` |
+| `projective-grid` | `square::validate::validate` | info | `num_labelled`, `cell_size` |
+| `projective-grid` | `topological::classify::classify_all_edges` | debug | `num_edges` |
+| `projective-grid` | `topological::quads::merge_triangle_pairs` | debug | `num_triangles` |
+| `projective-grid` | `topological::topo_filter::filter_quads` | debug | `num_quads_in` |
+| `projective-grid` | `topological::walk::label_components` | debug | `num_quads` |
+| `projective-grid` | `global_step::estimate_global_cell_size` | debug | `num_points` |
+| `projective-grid` | `local_step::estimate_local_steps` | debug | `num_points` |
+| `calib-targets-chessboard` | `Detector::detect_*` and inner stages | info / debug | (existing) |
+
+Enable the feature on the bench harness or the facade crate and pick a
+log level via `RUST_LOG`:
+
+```bash
+# Stage-level only (fast, ~one event per detection).
+RUST_LOG=info cargo run --profile profiling \
+    --features "calib-targets/tracing" \
+    -p calib-targets-bench --bin bench -- run \
+    --algorithm chessboard-v2 --image testdata/large.png --target chessboard
+
+# All substeps (more events; per-call detail).
+RUST_LOG=debug cargo run --profile profiling \
+    --features "calib-targets/tracing" \
+    -p calib-targets-bench --bin bench -- run \
+    --algorithm topological --image testdata/large.png --target chessboard
+```
+
+`init_tracing(false)` in `calib-targets-core` already configures
+`FmtSpan::CLOSE`, so each span closes with a `time.busy` field that gives
+you wall-clock per call. For batched p50/p95 numbers run a multi-image
+sweep through the bench harness and post-process the lines (one JSON
+event per span if you pass `init_tracing(true)`).
+
+## Recommended profile capture matrix
+
+For a full pre-optimization snapshot, capture `samply` flamegraphs and a
+tracing JSON dump for each `(image, algorithm)` cell:
+
+| Image | Resolution | Target | Algorithms |
+|---|---|---|---|
+| `testdata/mid.png` | 1024×576 (0.6 MP) | chessboard | topological, chessboard-v2 |
+| `testdata/large.png` | 2048×1536 (3.1 MP) | chessboard | topological, chessboard-v2 |
+| `testdata/puzzleboard_reference/example4.png` | 4032×3024 (12.2 MP) | puzzleboard | topological, chessboard-v2 |
+
+Keep all output under `bench_results/flamegraphs/` (gitignored). Naming
+convention:
+
+```
+bench_results/flamegraphs/
+    <image_slug>.<algorithm>.flame.json.gz   # samply raw profile
+    <image_slug>.<algorithm>.tracing.log     # RUST_LOG output
+    REPORT.md                                # ranked findings (local-only)
+```
+
+## Updating this document
+
+The instrumented-functions table is a manual list — when adding spans to
+a new function, update both the table here and the corresponding crate's
+`tracing` feature wiring (the consumer-side `tracing` feature must
+propagate down to `projective-grid/tracing` via `calib-targets-core`).


### PR DESCRIPTION
## Summary

- Adds opt-in `tracing` feature on `projective-grid` (off by default, kept as the permanent observability surface) plus a `[profile.profiling]` workspace profile so flamegraph captures symbolicate.
- Rewrites `component_merge::merge_components_local::find_best_alignment` from O(P² Q) anchor enumeration to a KD-tree-based Hough transform on (transform, label-delta), preserving the exact tiebreaker behaviour on symmetric inputs.
- Adds three new criterion microbenches (`topological`, `merge`, `validate`) covering previously un-benched hot paths, plus a `profile_grid` example and `docs/profiling.md` documenting the samply + tracing capture recipe.

## Wins

End-to-end timing on the topological pipeline:

| Image | Resolution | Before | After | Speedup |
|---|---|---|---|---|
| `testdata/mid.png` | 0.6 MP | 1.78 ms | 1.53 ms | 1.2× |
| `testdata/large.png` | 3.1 MP | 145 ms | 8.33 ms | **17×** |
| `testdata/puzzleboard_reference/example4.png` | 12.2 MP | 8635 ms | **31.96 ms** | **270×** |

`merge_components_local` self-time on the 12 MP image alone went from 8.89 s → 1.18 ms.

Microbenches: 1240× / 1640× / 4940× across the three new merge fixtures.

## Test plan

- [x] `cargo test --workspace` — all green (113 in projective-grid, plus all detector tests).
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean (with and without the `tracing` feature).
- [x] `cargo doc --workspace --no-deps` zero warnings.
- [x] `bench check --algorithm topological` — same FAIL/PASS rows as baseline, identical `miss / extra / pos / id / dup` columns. **Zero precision regression** on the internal regression set.
- [x] `bench check --algorithm chessboard-v2` — identical column data; same 21/23 PASS as baseline.
- [x] All component_merge unit tests pass deterministically across multiple runs (the rewrite needed an explicit transform-index tiebreaker to match the original's iteration-order-driven preference for identity on highly symmetric inputs).

## Commits

1. `perf(projective-grid): add tracing feature + spans on hot paths` — opt-in instrumentation; `[profile.profiling]`.
2. `bench(projective-grid): cover topological, merge, validate hot paths` — three new criterion benches.
3. `docs(profiling): samply + tracing recipe and profile_grid example` — `docs/profiling.md` + the profiling driver.
4. `perf(projective-grid): KD-tree Hough transform for component_merge` — the algorithm rewrite + `CHANGELOG.md` entry.

## Follow-ups (not in this PR)

- `extend_via_local_homography` is now the next bottleneck on ChessboardV2 (1.11 s of the 1.16 s 12 MP run, ~95%). KD-tree reuse across the four extension calls + a fast condition-number proxy when only the quality scalar is consumed are the next targets.
- `validate` shows superlinear scaling on the new microbench; small absolute (~6 ms × 3 calls at 12 MP), defer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)