### PR TITLE
perf(projective-grid): faster homography DLT via 9×9 sym-eig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,61 +4,16 @@ All notable changes to this project will be documented in this file.
 
 This project follows [Semantic Versioning](https://semver.org/).
 
-## Unreleased
-
-### Performance
-
-- **`projective_grid::component_merge::merge_components_local` rewritten**
-  as a position-based Hough transform on `(transform, label-delta)`. The
-  old anchor-pair enumeration was O(P² Q) per (component, component) pair
-  and dominated the topological pipeline on real images with multiple
-  fragmented components. The new implementation indexes one component's
-  positions in a KD-tree, queries each label of the other component
-  within `pos_tol`, and votes each match into a histogram bin keyed by
-  the candidate alignment. Two- to three-orders-of-magnitude wins on
-  microbenches (`merge_components_local/overlap/2_components_large`:
-  about 5000× on the criterion fixture). End-to-end the topological
-  pipeline measured on a representative high-resolution chessboard image
-  goes from multi-second to tens-of-milliseconds, with **zero precision
-  regression** on the internal regression set. The original tiebreaker
-  (preferring identity-transform matches by iteration order) is
-  preserved as an explicit tiebreaker on transform index.
-- **`projective_grid::square::extension::local::nearest_labelled_by_grid`
-  switched from full-sort to bounded max-heap.** The previous
-  implementation allocated a `Vec` of all labelled corners, sorted by
-  Manhattan distance, and took the top-K — `O(L log L)` per cell. With
-  ~1100 labelled corners and ~9000 candidate cells per extension pass,
-  this routine accounted for roughly 84 % of `extend_via_local_homography`
-  self-time on a representative high-resolution frame. The new
-  bounded-heap variant is `O(L log K)` per cell (`K = 8` by default)
-  and avoids the per-cell allocation entirely. Cuts the overall
-  ChessboardV2 extension stage wall-clock by roughly 4× end-to-end on
-  the same frame, with the same deterministic
-  `(distance, i, j, idx)` ordering downstream callers depend on, and
-  zero precision regression on the internal regression set.
-
-### Profiling tooling
-
-- Added an opt-in `tracing` Cargo feature on `projective-grid` (off by
-  default, kept in tree as the permanent observability surface). When
-  enabled, the hot-path entry points (`bfs_grow`,
-  `build_grid_topological` and its substages,
-  `merge_components_local`, `square::validate::validate`,
-  `extend_via_local_homography`, `extend_via_global_homography`,
-  `extend_from_labelled`, `estimate_global_cell_size`,
-  `estimate_local_steps`) emit `tracing::instrument` spans for
-  per-call p50/p95 timing.
-- Added a `[profile.profiling]` Cargo profile (release with
-  line-tables-only debug info) so `samply record` flamegraphs
-  symbolicate without doubling binary size.
-- Added `crates/calib-targets/examples/profile_grid.rs` as a thin
-  driver for `samply record` and `RUST_LOG=info` tracing dumps.
-- Added `docs/profiling.md` with the full samply + tracing recipe.
-- New criterion microbenches in `crates/projective-grid/benches/`:
-  `topological.rs`, `merge.rs`, `validate.rs`. Existing `grow.rs`
-  and `homography.rs` benches preserved as the baseline.
-
 ## 0.8.0
+
+Coordinated workspace release that hardens the ChessboardV2 detector
+with a mandatory final-geometry check, lands an opt-in topological
+grid pipeline alongside the seed-and-grow default, and rewrites the
+per-cell DLT and component-merge hot paths for an order-of-magnitude
+speedup on high-resolution frames. Several internal modules are
+re-organised into per-stage subdirectories and `GridIndex` /
+`GridHomography` / `GridHomographyMesh` are renamed; see "Breaking
+changes" below. Workspace minor-bumps in lockstep at `0.8.0`.
 
 ### Breaking changes
 
@@ -185,6 +140,110 @@ This project follows [Semantic Versioning](https://semver.org/).
   decision predicate, output, dominant failure modes, and governing
   `DetectorParams` knobs. Working reference for diagnosing failures
   on real images.
+- **Topological grid pipeline.** `projective_grid::build_grid_topological`
+  implements the Shu / Brunton / Fiala 2009 grid finder: Delaunay
+  triangulation over the corner cloud, edge classification by
+  per-edge axis match, triangle-pair → quad merge, and flood-fill
+  `(i, j)` labelling. Image-free (no per-cell colour sampling — the
+  original paper's image-domain test is replaced by an axis-driven
+  cell predicate so `projective-grid` stays standalone). Selectable
+  from chessboard-v2 via
+  `DetectorParams::graph_build_algorithm = GraphBuildAlgorithm::Topological`;
+  default stays `ChessboardV2` because the topological pipeline
+  currently regresses recall on ChArUco-style images (marker-internal
+  corners poison the per-cell axis test). Runs faster + denser on
+  clean PuzzleBoards. ChArUco unconditionally pins `ChessboardV2`
+  inside `CharucoDetector::new` regardless of caller choice.
+- **Stage 6 local-homography extension.**
+  `projective_grid::square::extension::local::extend_via_local_homography`
+  fits a per-candidate `H` from the `K` nearest labelled corners (by
+  grid Manhattan distance) instead of one global homography. Tolerates
+  heavy radial distortion and multi-region perspective where a single
+  `H` breaks. Configured via `LocalExtensionParams`; complements the
+  pre-existing global-H pass.
+- **Shared component-merge.**
+  `projective_grid::component_merge::merge_components_local` is the
+  post-stage that reunites partial components from either pipeline
+  (ChessboardV2 boosters or topological flood-fill) using local
+  geometry only — no global homography, so it tolerates heavy radial
+  distortion. The chessboard crate's historical
+  `enable_component_merge` flag is now backed by this shared
+  implementation via `DetectorParams::component_merge: LocalMergeParams`.
+
+### Performance
+
+- **`projective_grid::homography::estimate_homography` rewritten** to
+  use normal equations + a 9×9 symmetric eigendecomposition of `Aᵀ A`
+  instead of a full `(2N × 9)` SVD on the DLT data matrix. Hartley
+  normalisation stays — preconditioning matters more under normal
+  equations because cond(`Aᵀ A`) = cond(`A`)² — and the f32 condition
+  number stays comfortable on real workloads. The 4-point fast path
+  (`homography_from_4pt`, 8×8 LU) is unchanged. Microbench shows 1.8×
+  at `N=9`, 2× at `N=25`, 2.6× at `N=100`, 3.3× at `N=225` (the
+  speedup grows because the old path's bidiagonalisation is `O(N²)`
+  while the new path's `Aᵀ A` accumulation is `O(N)`). Sign of the
+  smallest eigenvector is unconstrained; downstream
+  `normalize_homography` (divides by `h[(2,2)]`) pins it. Numerical
+  contract: agrees with the SVD reference to ≤ 0.01 px in
+  pixel-domain on a 1000-sample randomised homography battery; H
+  entries themselves can drift up to ~1e-3 relative (the textbook f32
+  cond² penalty), but downstream consumers feed `H` through
+  `apply(...)` to predict cell positions and never read entries.
+  `HomographyQuality::from_homography` stays on the 3×3 SVD path —
+  same penalty would apply there too and the consumer is no longer
+  in the per-cell hot loop.
+- **`extend_via_local_homography` skips the wasted 3×3 quality SVD.**
+  The local-extension call site discarded the `HomographyQuality`
+  struct (`let Some((h, _)) = ...`) and gates on manually-computed
+  reprojection residuals over the K supports. Switched to bare
+  `estimate_homography` so each per-cell call drops one nalgebra
+  `Matrix3::svd`. No behaviour change.
+- **`projective_grid::component_merge::merge_components_local`
+  rewritten** as a position-based Hough transform on
+  `(transform, label-delta)`. The old anchor-pair enumeration was
+  `O(P² Q)` per (component, component) pair and dominated the
+  topological pipeline on real images with multiple fragmented
+  components. The new implementation indexes one component's positions
+  in a KD-tree, queries each label of the other component within
+  `pos_tol`, and votes each match into a histogram bin keyed by the
+  candidate alignment. Two- to three-orders-of-magnitude wins on
+  microbenches; the topological pipeline measured on a representative
+  high-resolution chessboard image goes from multi-second to
+  tens-of-milliseconds. The original tiebreaker (preferring
+  identity-transform matches by iteration order) is preserved as an
+  explicit tiebreaker on transform index.
+- **`extension::local::nearest_labelled_by_grid` switched from
+  full-sort to bounded max-heap.** Allocates once and runs in
+  `O(L log K)` per cell instead of `O(L log L)` (`L = labelled
+  corners`, `K = k_nearest`). Cuts the overall ChessboardV2 extension
+  stage wall-clock by roughly 4× end-to-end on a representative
+  high-resolution frame, with the same deterministic
+  `(distance, i, j, idx)` ordering downstream callers depend on.
+- Combined effect on a 12 MP chessboard frame: full
+  `detect_chessboard` runs in tens of milliseconds instead of seconds,
+  with zero precision regression on the internal regression set.
+
+### Tooling
+
+- Added an opt-in `tracing` Cargo feature on `projective-grid` (off by
+  default). When enabled, the hot-path entry points (`bfs_grow`,
+  `build_grid_topological` and its substages,
+  `merge_components_local`, `square::validate::validate`,
+  `extend_via_local_homography`, `extend_via_global_homography`,
+  `extend_from_labelled`, `estimate_global_cell_size`,
+  `estimate_local_steps`) emit `tracing::instrument` spans for
+  per-call p50/p95 timing.
+- Added a `[profile.profiling]` Cargo profile (release with
+  line-tables-only debug info) so `samply record` flamegraphs
+  symbolicate without doubling binary size.
+- `crates/calib-targets/examples/profile_grid.rs` is a thin driver for
+  `samply record` and `RUST_LOG=info` tracing dumps.
+- `docs/profiling.md` documents the full samply + tracing recipe.
+- New criterion microbenches in `crates/projective-grid/benches/`:
+  `topological.rs`, `merge.rs`, `validate.rs`. Existing `grow.rs` and
+  `homography.rs` benches preserved as the baseline; `homography.rs`
+  gains `K=8/12/20` cases mirroring the production
+  `LocalExtensionParams` defaults.
 
 ## [0.7.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,246 +4,114 @@ All notable changes to this project will be documented in this file.
 
 This project follows [Semantic Versioning](https://semver.org/).
 
+Older releases are archived under [`docs/changelog/`](docs/changelog/);
+see [Older releases](#older-releases) at the bottom for the index.
+
 ## 0.8.0
 
-Coordinated workspace release that hardens the ChessboardV2 detector
-with a mandatory final-geometry check, lands an opt-in topological
-grid pipeline alongside the seed-and-grow default, and rewrites the
-per-cell DLT and component-merge hot paths for an order-of-magnitude
-speedup on high-resolution frames. Several internal modules are
-re-organised into per-stage subdirectories and `GridIndex` /
-`GridHomography` / `GridHomographyMesh` are renamed; see "Breaking
-changes" below. Workspace minor-bumps in lockstep at `0.8.0`.
+Hardens the chessboard detector with a mandatory final-geometry
+check, lands an opt-in topological grid pipeline alongside the
+seed-and-grow default, and rewrites the per-cell DLT and
+component-merge hot paths for an order-of-magnitude speedup on
+high-resolution frames.
 
-### Breaking changes
+### Breaking
 
-- **N-17** `calib-targets-core/src/chess.rs`: replaced the near-verbatim mirror of
-  `chess-corners` config types with direct `pub use` re-exports for all non-divergent
-  types (`CenterOfMassConfig`, `ForstnerConfig`, `SaddlePointConfig`, `UpscaleConfig`,
-  `UpscaleMode`, `DescriptorMode`, `ThresholdMode`, `ChessCornerParams`, `PyramidParams`,
-  `CoarseToFineParams`). `chess-corners` is now a direct dependency of
-  `calib-targets-core`. `DetectorMode` adds `Radon` variant, `RefinementMethod` adds
-  `RadonPeak`, `ChessConfig` exposes `radon_detector`. `RefinerKindConfig` and
-  `ChessConfig::from_parts` are removed. Adapter shims in `detect.rs` collapsed.
-
-- **N-1** `GridIndex` renamed to `GridCoords` across the entire workspace (the name
-  `calib-targets-core` consumers already used). The old `GridCoords` alias in
-  `calib-targets-core` is now the actual type definition. All `(i32, i32)` tuple
-  maps in the grow/validate/topological/merge pipelines replaced with `GridCoords`.
-  `GridTransform::apply` returns `GridCoords` instead of `[i32; 2]`.
-
-- **N-2** Square-grid types gain `Square` prefix: `GridHomography` →
-  `SquareGridHomography`, `GridHomographyMesh` → `SquareGridHomographyMesh`,
-  `predict_grid_position` → `square_predict_grid_position`,
-  `find_inconsistent_corners` → `square_find_inconsistent_corners`,
-  `find_inconsistent_corners_step_aware` → `square_find_inconsistent_corners_step_aware`.
-
-- **N-3** `SeedQuadValidator::axes` returns `[AxisHint; 2]` instead of `[f32; 2]`.
-  `LocalStepPointData::{axis_u, axis_v}` merged into `axes: [AxisHint; 2]`.
-  `AxisHint::from_angle` constructor added.
-
-- **N-5** `seed_finder.rs` merged into `seed/finder.rs` submodule. `Seed` struct
-  moved from `grow.rs` to `seed/mod.rs`. External import paths unchanged via
-  re-exports in `square/mod.rs`.
-
-- **N-6** `ExtensionCommonParams` extracted from `ExtensionParams` and
-  `LocalExtensionParams`. Both now hold `pub common: ExtensionCommonParams`.
-
-- **N-10** All "count of items" public diagnostic fields standardised on `usize`
-  (`GlobalStepEstimate.support`, `LocalStep.supporters_*`, `ExtensionStats.attached`,
-  `BfsExtensionStats.attached`, etc.).
-
-- **N-16** Module splits: `grow_extension.rs` → `extension/{mod,common,global,local}.rs`;
-  `grow.rs` → `grow.rs` + `grow_extend.rs`; `validate.rs` →
-  `validate/{mod,lines,local_h,step}.rs`. Inner `bfs_grow` body extracted to
-  `process_boundary_cell`. All public re-exports unchanged.
+- `chess-corners` bumped 0.7 → 0.8; the direct `chess-corners-core`
+  dep is gone (the 0.8 facade re-exports every primitive we used).
+  Several upstream config types are now `#[non_exhaustive]` —
+  downstream construction must use `RefinerConfig::saddle_point()` /
+  `::build(...)` rather than struct literals.
+- `calib-targets-core::chess` now `pub use`-re-exports
+  `chess-corners` config types directly instead of mirroring them.
+  `DetectorMode::Radon` and `RefinementMethod::RadonPeak` are
+  exposed; `RefinerKindConfig` and `ChessConfig::from_parts` are
+  removed.
+- `GridIndex` renamed to `GridCoords` workspace-wide; square-grid
+  types gain a `Square` prefix (`SquareGridHomography`,
+  `SquareGridHomographyMesh`, `square_predict_grid_position`, …).
+- `SeedQuadValidator::axes` now returns `[AxisHint; 2]`;
+  `LocalStepPointData::{axis_u, axis_v}` merged into `axes`.
+- `ExtensionCommonParams` extracted as `pub common` on
+  `ExtensionParams` / `LocalExtensionParams`.
+- Public `count` diagnostic fields standardised on `usize`.
+- Internal module splits in `calib-targets-chessboard` (extension/,
+  validate/, grow_extend); public re-exports preserved.
 
 ### Added
 
-- **Mandatory final geometry check** in chessboard-v2 detector —
-  every emitted `Detection` now goes through a Stage-9 precision gate
-  that:
-  1. drops gross mislabels via `validate()` with looser tolerances
-     (`geometry_check_line_tol_rel = 0.45`,
-     `geometry_check_local_h_tol_rel = 0.6` of cell_size) — full-
-     cell / diagonal shifts produce ~1.4 cell residuals, well above
-     these tolerances; perspective-distorted corners are spared;
-  2. drops labelled corners not in the largest cardinally-connected
-     component. A chessboard detection is by construction one
-     `(i, j)`-labelled connected planar graph; isolated singletons
-     and small-component leaks are false positives (typically a
-     marker corner that passed the cluster + parity gates but sits
-     well outside the main grid — e.g. `small2.png` had two such
-     orphans below the labelled grid before this filter).
-  `min_labeled_corners` survivors are required after the drop,
-  otherwise the detection is refused entirely. Catches wrong `(i, j)`
-  labels and isolated false positives that the per-attachment gates
-  couldn't — bench `pos=` does not validate new `(i, j)`
-  assignments, so this is the precision safety net.
-- **Stage 6.75 — post-grow centre refit.** After Stage 6.5 / boosters
-  converge, recompute `(θ₀, θ₁)` from the labelled set's axes alone
-  using the undirected circular mean. Marker-internal corners — which
-  bias the histogram-driven Stage-3 centres ~3° below the true
-  chessboard axes on some ChArUco-style images — don't contribute
-  here, so the refined centres are unbiased. If the shift exceeds
-  `refit_min_shift_deg`, re-classify Strong / NoCluster corners under
-  the new centres, then run two complementary growth passes (in
-  order):
-  - **BFS regrow** (`enable_post_grow_bfs_regrow`, default `true`):
-    demote every `Labeled` corner back to `Clustered` and re-run
-    `grow_from_seed` with the refined centres. Lifts recall on
-    cases where the orphan strip is 1+ cells past the existing
-    bbox edge (small3.png left strip, +21 corners). Can drop a few
-    borderline corners under the centre shift.
-  - **Cardinal-neighbour BFS extension**
-    (`enable_post_grow_bfs_extend`, default `true`,
-    `projective_grid::square::grow::extend_from_labelled`):
-    non-destructive walk over the labelled bbox boundary using
-    cardinal-only prediction (K=1). Recovers corners the regrow
-    above dropped under the centre shift, without precision risk
-    (same tolerances as the initial BFS — wider radii produce
-    SHIFT-INCONSISTENT labelling).
-  - Then Stage 6 / 6.5 with the refined centres for any cells the
-    BFS still missed.
-  Defaults: enabled, `refit_min_labelled = 8`,
-  `refit_min_shift_deg = 0.5°`. Trade-off: chessboard targets gain
-  recall (small3.png 91→104); puzzleboard targets that go through
-  chessboard-v2 incidentally lose perimeter rows
-  (`example2.png` 136→91 — these go through their own pipeline
-  in production). Zero `pos` / `id` / `dup` / SHIFT-INCONSISTENT
-  regressions across the entire bench.
-- **`projective_grid::square::grow::extend_from_labelled`** — new
-  public BFS extension over an existing labelled set. Used by the
-  chessboard refit pass; reusable by any pattern-specific detector
-  that wants to absorb newly-eligible corners without re-running
-  BFS from scratch. Returns `BfsExtensionStats` with
-  `attached / rejected_*` counters.
-- **PIPELINE.md docs** for chessboard, charuco, puzzleboard, marker,
-  and the topological grid sub-pipeline. Concise atomic stage tables
-  (input / decision / output / failure modes / knobs) at
-  `crates/<crate>/docs/PIPELINE.md` (and
-  `crates/projective-grid/docs/TOPOLOGICAL_PIPELINE.md`). Working
-  reference for diagnosing failures, supersedes the prose sections
-  of `docs/projective_grid_overview.md` for per-pipeline depth.
-- **`IterationTrace.rescue / refit / extension2 / rescue2 /
-  geometry_check`** in `calib-targets-chessboard` — every post-BFS
-  stage now records its `attached / rejected_*` breakdown, so a
-  `bench diagnose` JSON pinpoints exactly where a corner was dropped.
-  `IterationTrace` is now `#[non_exhaustive]` (matches the workspace
-  convention for diagnostic structs).
-- **`bench {run,check,diagnose} --chessboard-config <FILE>`** —
-  optional partial-JSON override for `DetectorParams`, used to sweep
-  detector knobs without rebuilding. Missing fields fall back to
-  defaults via the existing `#[serde(default)]` attributes.
-- **`crates/calib-targets-chessboard/docs/PIPELINE.md`** — atomic
-  stage-by-stage map of the chessboard-v2 detector: per-stage input,
-  decision predicate, output, dominant failure modes, and governing
-  `DetectorParams` knobs. Working reference for diagnosing failures
-  on real images.
-- **Topological grid pipeline.** `projective_grid::build_grid_topological`
-  implements the Shu / Brunton / Fiala 2009 grid finder: Delaunay
-  triangulation over the corner cloud, edge classification by
-  per-edge axis match, triangle-pair → quad merge, and flood-fill
-  `(i, j)` labelling. Image-free (no per-cell colour sampling — the
-  original paper's image-domain test is replaced by an axis-driven
-  cell predicate so `projective-grid` stays standalone). Selectable
-  from chessboard-v2 via
-  `DetectorParams::graph_build_algorithm = GraphBuildAlgorithm::Topological`;
-  default stays `ChessboardV2` because the topological pipeline
-  currently regresses recall on ChArUco-style images (marker-internal
-  corners poison the per-cell axis test). Runs faster + denser on
-  clean PuzzleBoards. ChArUco unconditionally pins `ChessboardV2`
-  inside `CharucoDetector::new` regardless of caller choice.
-- **Stage 6 local-homography extension.**
-  `projective_grid::square::extension::local::extend_via_local_homography`
-  fits a per-candidate `H` from the `K` nearest labelled corners (by
-  grid Manhattan distance) instead of one global homography. Tolerates
-  heavy radial distortion and multi-region perspective where a single
-  `H` breaks. Configured via `LocalExtensionParams`; complements the
-  pre-existing global-H pass.
+- **Mandatory final geometry check** in the chessboard detector:
+  every emitted `Detection` is run through a precision gate that
+  drops gross mislabels (looser line/local-H tolerances than the
+  per-attachment gates) and any corner outside the largest
+  cardinally-connected component. Catches wrong `(i, j)` labels
+  and isolated false positives that prior stages miss.
+- **Post-grow centre refit (Stage 6.75)**: after the boosters
+  converge, recompute axis centres from the labelled set alone
+  (undirected circular mean), reclassify, and run a BFS regrow
+  plus a cardinal-only BFS extension to pick up cells the original
+  centres missed. Trades 1-2 borderline corners for whole orphan
+  strips on ChArUco-style images.
+- **Topological grid pipeline.**
+  `projective_grid::build_grid_topological` implements the
+  Shu / Brunton / Fiala 2009 grid finder (Delaunay → triangle
+  classification → quad merge → flood-fill labelling). Image-free
+  (axis-driven cell predicate replaces the paper's colour test).
+  Opt-in via
+  `DetectorParams::graph_build_algorithm = Topological`; default
+  stays `ChessboardV2`. ChArUco pins `ChessboardV2` regardless of
+  caller choice.
+- **Local-homography extension.**
+  `extend_via_local_homography` fits a per-candidate `H` from the
+  `K` nearest labelled corners instead of one global fit; tolerates
+  heavy radial distortion and multi-region perspective.
 - **Shared component-merge.**
-  `projective_grid::component_merge::merge_components_local` is the
-  post-stage that reunites partial components from either pipeline
-  (ChessboardV2 boosters or topological flood-fill) using local
-  geometry only — no global homography, so it tolerates heavy radial
-  distortion. The chessboard crate's historical
-  `enable_component_merge` flag is now backed by this shared
-  implementation via `DetectorParams::component_merge: LocalMergeParams`.
+  `projective_grid::component_merge::merge_components_local`
+  reunites partial components from either pipeline using local
+  geometry only. The chessboard crate's `enable_component_merge`
+  flag is backed by this shared implementation.
+- **`projective_grid::square::grow::extend_from_labelled`** —
+  reusable cardinal-only BFS extension over an existing labelled
+  set.
+- **PIPELINE.md** per-detector docs (chessboard, charuco,
+  puzzleboard, marker, topological): atomic stage tables of input
+  / decision / output / failure modes / knobs.
+- **Per-stage diagnostics.** `IterationTrace` gains
+  `rescue / refit / extension2 / rescue2 / geometry_check` buckets
+  with `attached / rejected_*` counters; now `#[non_exhaustive]`.
+- `bench {run,check,diagnose} --chessboard-config <FILE>` for
+  partial-JSON override of `DetectorParams` without rebuilds.
 
 ### Performance
 
-- **`projective_grid::homography::estimate_homography` rewritten** to
-  use normal equations + a 9×9 symmetric eigendecomposition of `Aᵀ A`
-  instead of a full `(2N × 9)` SVD on the DLT data matrix. Hartley
-  normalisation stays — preconditioning matters more under normal
-  equations because cond(`Aᵀ A`) = cond(`A`)² — and the f32 condition
-  number stays comfortable on real workloads. The 4-point fast path
-  (`homography_from_4pt`, 8×8 LU) is unchanged. Microbench shows 1.8×
-  at `N=9`, 2× at `N=25`, 2.6× at `N=100`, 3.3× at `N=225` (the
-  speedup grows because the old path's bidiagonalisation is `O(N²)`
-  while the new path's `Aᵀ A` accumulation is `O(N)`). Sign of the
-  smallest eigenvector is unconstrained; downstream
-  `normalize_homography` (divides by `h[(2,2)]`) pins it. Numerical
-  contract: agrees with the SVD reference to ≤ 0.01 px in
-  pixel-domain on a 1000-sample randomised homography battery; H
-  entries themselves can drift up to ~1e-3 relative (the textbook f32
-  cond² penalty), but downstream consumers feed `H` through
-  `apply(...)` to predict cell positions and never read entries.
-  `HomographyQuality::from_homography` stays on the 3×3 SVD path —
-  same penalty would apply there too and the consumer is no longer
-  in the per-cell hot loop.
-- **`extend_via_local_homography` skips the wasted 3×3 quality SVD.**
-  The local-extension call site discarded the `HomographyQuality`
-  struct (`let Some((h, _)) = ...`) and gates on manually-computed
-  reprojection residuals over the K supports. Switched to bare
-  `estimate_homography` so each per-cell call drops one nalgebra
-  `Matrix3::svd`. No behaviour change.
-- **`projective_grid::component_merge::merge_components_local`
-  rewritten** as a position-based Hough transform on
-  `(transform, label-delta)`. The old anchor-pair enumeration was
-  `O(P² Q)` per (component, component) pair and dominated the
-  topological pipeline on real images with multiple fragmented
-  components. The new implementation indexes one component's positions
-  in a KD-tree, queries each label of the other component within
-  `pos_tol`, and votes each match into a histogram bin keyed by the
-  candidate alignment. Two- to three-orders-of-magnitude wins on
-  microbenches; the topological pipeline measured on a representative
-  high-resolution chessboard image goes from multi-second to
-  tens-of-milliseconds. The original tiebreaker (preferring
-  identity-transform matches by iteration order) is preserved as an
-  explicit tiebreaker on transform index.
-- **`extension::local::nearest_labelled_by_grid` switched from
-  full-sort to bounded max-heap.** Allocates once and runs in
-  `O(L log K)` per cell instead of `O(L log L)` (`L = labelled
-  corners`, `K = k_nearest`). Cuts the overall ChessboardV2 extension
-  stage wall-clock by roughly 4× end-to-end on a representative
-  high-resolution frame, with the same deterministic
-  `(distance, i, j, idx)` ordering downstream callers depend on.
-- Combined effect on a 12 MP chessboard frame: full
-  `detect_chessboard` runs in tens of milliseconds instead of seconds,
-  with zero precision regression on the internal regression set.
+End-to-end: full `detect_chessboard` on a 12 MP frame drops from
+seconds to tens of milliseconds, zero precision regression on the
+internal regression set.
+
+- `projective_grid::homography::estimate_homography` rewritten via
+  normal equations + 9×9 symmetric eigendecomposition (was a full
+  `(2N × 9)` SVD). Hartley normalisation preserved; agreement with
+  the SVD reference is ≤ 0.01 px in pixel-domain on a randomised
+  battery. Microbench: 1.8× / 2× / 2.6× / 3.3× speedups at
+  N = 9 / 25 / 100 / 225.
+- `extend_via_local_homography` drops the wasted 3×3 quality SVD
+  per cell.
+- `merge_components_local` rewritten as a KD-tree-indexed Hough
+  vote on `(transform, label-delta)`; was `O(P² Q)` per component
+  pair, now linear in matched corners. Two-to-three orders of
+  magnitude on microbenches.
+- `nearest_labelled_by_grid` switched from full-sort to bounded
+  max-heap (`O(L log K)`); cuts the extension stage ~4× end-to-end.
 
 ### Tooling
 
-- Added an opt-in `tracing` Cargo feature on `projective-grid` (off by
-  default). When enabled, the hot-path entry points (`bfs_grow`,
-  `build_grid_topological` and its substages,
-  `merge_components_local`, `square::validate::validate`,
-  `extend_via_local_homography`, `extend_via_global_homography`,
-  `extend_from_labelled`, `estimate_global_cell_size`,
-  `estimate_local_steps`) emit `tracing::instrument` spans for
-  per-call p50/p95 timing.
-- Added a `[profile.profiling]` Cargo profile (release with
-  line-tables-only debug info) so `samply record` flamegraphs
-  symbolicate without doubling binary size.
-- `crates/calib-targets/examples/profile_grid.rs` is a thin driver for
-  `samply record` and `RUST_LOG=info` tracing dumps.
-- `docs/profiling.md` documents the full samply + tracing recipe.
-- New criterion microbenches in `crates/projective-grid/benches/`:
-  `topological.rs`, `merge.rs`, `validate.rs`. Existing `grow.rs` and
-  `homography.rs` benches preserved as the baseline; `homography.rs`
-  gains `K=8/12/20` cases mirroring the production
-  `LocalExtensionParams` defaults.
+- Opt-in `tracing` feature on `projective-grid`; hot-path entry
+  points emit `tracing::instrument` spans.
+- New `[profile.profiling]` Cargo profile and
+  `examples/profile_grid.rs` driver for `samply record` /
+  `RUST_LOG` tracing dumps; full recipe in `docs/profiling.md`.
+- New criterion microbenches: `topological.rs`, `merge.rs`,
+  `validate.rs`; `homography.rs` adds `K=8/12/20` cases.
 
 ## [0.7.3]
 
@@ -559,445 +427,18 @@ bumps in lockstep: every crate publishes at `0.7.0`.
   `markerboard_roundtrip.py` (the `puzzleboard_roundtrip.py` example
   already existed).
 
-## [0.6.0]
-
-Coordinated workspace release that ships the new
-`calib-targets-puzzleboard` crate. `calib-targets-core` adds the
-`TargetKind::PuzzleBoard` variant, which is a non-additive change to a
-`#[non_exhaustive]` enum but bumps the workspace minor version anyway so
-all crates publish in lockstep at `0.6.0`.
-
-### Added
-
-- Add first-class PuzzleBoard support with a new
-  `calib-targets-puzzleboard` crate. The detector samples edge-midpoint code
-  dots on a chessboard grid, decodes the embedded 501 x 501 master pattern,
-  and returns absolute corner IDs plus target-space positions.
-- Add `TargetKind::PuzzleBoard` variant in `calib-targets-core` so the new
-  detector can populate `TargetDetection.kind`.
-- Add committed PuzzleBoard code-map blobs, generation/verification tools,
-  synthetic and real-image regression tests, and generated PuzzleBoard
-  testdata.
-- Ship the PStelldinger/PuzzleBoard author-canonical `code1`/`code2` maps
-  (`map_a.bin` / `map_b.bin`) and a new `import_author_maps.rs` tool so the
-  shipped maps match the upstream reference implementation; add
-  `tests/interop_authors.rs` to keep the maps byte-compatible.
-- Add PuzzleBoard printable target generation through `calib-targets-print`,
-  including JSON/SVG/PNG output bundles and Python printable dataclasses.
-- Add PuzzleBoard facade helpers, Rust examples, Python bindings, WASM
-  bindings, FFI C ABI structs/functions, and regenerated native headers.
-- Add PuzzleBoard documentation in the crate README, workspace README,
-  mdBook, and release/development command references.
-- Add `PuzzleBoardSearchMode::FixedBoard`. Matches observations directly
-  against the declared board's own bit pattern (derived from
-  `PuzzleBoardSpec` at decode time) under `8 × (rows+1)²` candidate
-  shifts, so any partial view of that specific board decodes to the same
-  master IDs a full-view decode would produce. Cheaper than `Full` for
-  small boards and fast enough for the large ones. Default stays `Full`;
-  opt in via `params.decode.search_mode = PuzzleBoardSearchMode::FixedBoard`.
-  Mirrored in the Python dataclass and WASM TypeScript types; FFI stays
-  on `Full`.
-- Add `cargo bench -p calib-targets --bench puzzleboard_sizes` (criterion
-  comparison of `Full` vs `FixedBoard` across sizes 6, 8, 10, 12, 13, 16,
-  20, 30) and `cargo run --release -p calib-targets --example
-  puzzleboard_size_sweep` (per-stage success/failure/timing table used to
-  pinpoint which pipeline stage a given board size fails at).
-- Overlay every decoded PuzzleBoard edge-bit dot in the WASM demo: sky-blue
-  ring around `bit=1` (white puzzle dot), orange ring around `bit=0` (black
-  puzzle dot), opacity scaled by per-bit confidence.
-
-### Fixed
-
-- Filter PuzzleBoard decode candidates by bit-error rate before selecting the
-  best weighted score, avoiding false negatives when a higher-score candidate
-  exceeds the configured error budget.
-- Re-check the PuzzleBoard minimum edge count after confidence filtering so
-  weak edge samples cannot pass into the decoder as an undersized window.
-- Demo dev server no longer 404s on `calib_targets_wasm_bg.wasm` — Vite's
-  esbuild pre-bundler was rewriting the JS into `.vite/deps/` without
-  copying the sibling `.wasm`, so the `new URL(..., import.meta.url)` fetch
-  hit the SPA fallback. Fixed by adding `calib-targets-wasm` to
-  `optimizeDeps.exclude`.
-- Demo `ResultsPanel` grid readout now reports `max − min + 1` instead of
-  `max + 1`, so a 10 × 10 PuzzleBoard no longer displays as "177 × 177"
-  (master-grid indices start near 167).
-- Demo PuzzleBoard edge-bit overlay now maps `observed_edges` from local to
-  master coordinates via the alignment's D4 + translation before looking up
-  corners, fixing the previously empty overlay.
-- Fix `GridAlignment.transform` TypeScript type in the WASM demo (was
-  `string`; actual serde shape is `{a, b, c, d}`).
-
-### Changed
-
-- Demo toolchain switched from `npm` to `bun` (`demo/bun.lock` is the
-  committed lockfile; `demo/package-lock.json` removed). CI wasm job now
-  uses `oven-sh/setup-bun` + `bun install --frozen-lockfile`.
-- `.claude/CLAUDE.md` gains the new bench + diagnostic example commands
-  and documents the `bun` switch.
-
-## [0.5.3]
-
-### Fixes
-
-- **Python bindings:** fix `MarkerDetection.gc` deserialization. Rust emits
-  `{"i","j"}` (from `GridCoords`), but the Python wrapper was typed as a
-  separate `GridCell` dataclass requiring `{"gx","gy"}`, so every
-  `detect_charuco` call with markers crashed in `from_dict`. Dropped the
-  redundant `GridCell` type; `MarkerDetection.gc` now uses `GridCoords`,
-  matching `LabeledCorner.grid` and `CircleCandidate.cell`.
-- Added `python_tests/test_detect_roundtrip.py` that runs the real extension
-  on repo test images and round-trips result dicts, so Rust/Python dict-key
-  drift fails loudly instead of being masked by hand-written fixtures.
-
-## [0.5.2]
-
-### Changed
-
-- **`projective-grid`:** all public types and functions are now generic over
-  floating-point type (`f32` / `f64`). All types default to `f32`, so existing
-  code compiles unchanged. New `Float` trait alias (`RealField + Copy`) is
-  re-exported from the crate root.
-- `Homography` internal matrix is now `Matrix3<F>` (previously always `f64`).
-  For `f32` users this means slightly less internal precision but no
-  cross-type conversions; `f64` users get full double-precision throughout.
-
-## [0.5.1]
-
-### Fixes
-
-- Fix FFI C++ consumer examples: `config.graph.*` → `config.chessboard.graph.*`
-  after API redesign nested `GridGraphParams` inside `ChessboardParams`.
-- Fix broken intra-doc links (`detect_from_corners`, `min_marker_inliers`).
-- Fix `cargo doc` binary name collision by adding `doc = false` to CLI bin.
-- Regenerate FFI header and Python typing stubs after `#[non_exhaustive]` changes.
-- Add `detect_*_best` sweep functions to Python and WASM bindings.
-- Document pre-release quality gates in CLAUDE.md.
-
-## [0.5.0]
-
-### API redesign
-
-- **Breaking:** `ChessConfig` is now embedded inside each detector's params struct.
-  Facade `detect_*` functions take a single `&Params` argument instead of
-  separate `(&ChessConfig, Params)`. Removed `detect_charuco_default` and
-  `detect_marker_board_default`.
-- **Breaking:** `CharucoDetectorParams` renamed to `CharucoParams`.
-- **Breaking:** `CharucoParams.charuco` field renamed to `.board`.
-- **Breaking:** `MarkerBoardLayout` renamed to `MarkerBoardSpec`.
-- **Breaking:** `GridCell` replaced with `GridCoords` in aruco crate.
-  `BoardCell` removed.
-- Add multi-config sweep API: `detect_chessboard_best`, `detect_charuco_best`,
-  `detect_marker_board_best` try multiple parameter configs and return the best
-  result (most markers, then most corners).
-- Add `CharucoParams::sweep_for_board()` and `ChessboardParams::sweep_default()`
-  presets for common multi-threshold sweep scenarios.
-- Extract shared `calib_targets_core::io::{load_json, write_json, IoError}` to
-  replace duplicated IO boilerplate across crates.
-- Python and WASM bindings accept the new single-config API. The `chess_cfg`
-  parameter is still accepted for backward compatibility (overrides
-  `params.chess` or `params.chessboard.chess` when provided).
-- Python: `CharucoParams` and `MarkerBoardSpec` are the canonical names;
-  `CharucoDetectorParams` and `MarkerBoardLayout` remain as aliases.
-
-### Multi-component ChArUco detection
-
-- Merge disconnected grid components for 30-50% more corners on challenging
-  images (Scheimpflug optics, narrow focus strips). Each component is aligned
-  independently via marker-based D4 rotation, then merged.
-
-### AprilTag max_hamming fix
-
-- `CharucoParams::for_board()` now sets `max_hamming` to
-  `min(2, dictionary.max_correction_bits)` instead of 0, improving recall for
-  AprilTag-based ChArUco boards (e.g. `DICT_APRILTAG_36h10`).
-
-### WebAssembly bindings and browser demo
-
-- Add the new `calib-targets-wasm` crate (`crates/calib-targets-wasm/`) with
-  `wasm-bindgen` exports for all detection pipelines: `detect_corners`,
-  `detect_chessboard`, `detect_charuco`, and `detect_marker_board`. The crate
-  depends directly on the detector crates and `chess-corners` (without `rayon`
-  or `ml-refiner`) so it compiles cleanly for `wasm32-unknown-unknown`.
-- Expose `rgba_to_gray` for browser canvas RGBA-to-grayscale conversion and
-  `default_chess_config` / `default_chessboard_params` /
-  `default_marker_board_params` helpers for populating UI defaults from Rust.
-- Config and result objects are passed as plain JS objects via
-  `serde-wasm-bindgen` (no JSON string round-trips).
-- WASM binary: ~436 KB raw, ~195 KB gzipped.
-- Add a React/TypeScript demo app at `demo/` (Vite 6, React 19) with:
-  image upload (drag-and-drop), detection mode selector (Corners / Chessboard /
-  ChArUco / Marker Board), interactive parameter sliders, canvas overlay with
-  colored corners and grid edges, and a results panel with timing and JSON view.
-- Add `wasm` CI job to `.github/workflows/ci.yml`: builds WASM with
-  `wasm-pack`, verifies output artifacts, and builds the demo app with
-  TypeScript checking.
-- Add `scripts/build-wasm.sh` helper to build WASM into `demo/pkg/`.
-- Add `default-members` to the root workspace manifest so `cargo test` excludes
-  the WASM crate by default.
-
-### Python bindings API refactoring
-
-- Flatten `ChessConfig` in Python: remove nested `ChessCornerParams`,
-  `CoarseToFineParams`, `PyramidParams`; all fields are now top-level with
-  concrete defaults. Add `RefinerConfig`, `CenterOfMassConfig`,
-  `ForstnerConfig`, `SaddlePointConfig`.
-- Fold `GridGraphParams` into `ChessboardParams` as `chessboard.graph` across
-  all Rust crates, Python bindings, FFI, and JSON configs.
-- Add `ChessboardDetectConfig` / `ChessboardDetectReport` and
-  `MarkerBoardDetectConfig` / `MarkerBoardDetectReport` for JSON-driven
-  detection workflows.
-- Rewrite `calib-targets-py/src/lib.rs` from ~3600 lines to ~290 lines using a
-  dict-based JSON bridge (Python dataclass `to_dict()` -> `serde_json` ->
-  Rust type). Remove all `*Source` enums, `*Overrides` structs, and manual
-  extraction functions.
-
-## [0.4.2]
-
-### Release engineering
-
-- Technical release: bump coordinated crate versions to `0.4.2` after
-  publish-workflow fixes.
-
-## [0.4.1]
-
-### Release engineering
-
-- Technical release: bump coordinated crate versions to `0.4.1` to fix
-  publication issues.
-
-## [0.4.0]
-
-### Standalone `projective-grid` crate
-
-- Add the new publishable [`projective-grid`](https://crates.io/crates/projective-grid)
-  crate for pattern-agnostic 2D grid tooling: pluggable `NeighborValidator`
-  traits, grid graph construction, connected-component traversal, BFS grid
-  coordinate assignment, homography estimation, global rectification, per-cell
-  mesh rectification, and grid smoothness prediction.
-- Extract the generic square-grid geometry and homography machinery from
-  `calib-targets-core` into `projective-grid`. `calib-targets-core` keeps the
-  image-space pieces (`GrayImage*`, sampling, `warp_perspective_gray`) and
-  re-exports `Homography`, `GridCoords` (`GridIndex` alias), `GridAlignment`,
-  `GridTransform`, and homography-estimation helpers for downstream
-  compatibility.
-- Refactor `calib-targets-chessboard` to delegate grid-graph construction and
-  traversal to `projective-grid`, while keeping chessboard-specific neighbor
-  validation in-crate. Switch ChArUco grid smoothness to the shared
-  `projective_grid::predict_grid_position` helper instead of maintaining a
-  separate midpoint-prediction implementation.
-
-### Hex grids and built-in validators
-
-- Add `projective_grid::hex` with pointy-top axial-coordinate support for
-  6-connected graph construction, BFS coordinate assignment, grid smoothness
-  prediction, `D6` alignment transforms, `HexGridHomography`, and
-  `HexGridHomographyMesh` for per-triangle affine/projective rectification.
-- Add ready-to-use validator implementations in
-  `projective_grid::validators`:
-  `XJunctionValidator` for ChESS-like oriented square-grid corners,
-  `SpatialSquareValidator` for unoriented square lattices, and
-  `SpatialHexValidator` for unoriented hex lattices such as ringgrids.
-
-### Native C API and bindings
-
-- Expose `ScanDecodeConfig::multi_threshold` in the FFI as
-  `ct_scan_decode_config_t::multi_threshold` so native callers can control the
-  multi-threshold marker decode path instead of being forced to the Rust
-  default.
-- Add native test coverage that verifies `ct_scan_decode_config_t` preserves
-  the `multi_threshold` flag when converting into the Rust
-  `ScanDecodeConfig`.
-- Make the Python typing-artifact generator robust to multiline
-  `#[pyclass(...)]` attributes so generated `_core.pyi` stubs stay in sync
-  after adding `skip_from_py_object` to config-heavy binding classes.
-
-### Workspace and release engineering
-
-- Centralize shared crate metadata and dependency versions in the workspace
-  root via `[workspace.package]` and `[workspace.dependencies]` so the Rust
-  crates inherit coordinated `0.4` versioning and one dependency set.
-- Raise the documented MSRV to Rust `1.88` and surface it in the workspace
-  metadata and top-level README badge.
-- Update docs and packaging references from `0.3` to `0.4`, including the
-  getting-started dependency snippets and the coordinated Rust/Python/native
-  release metadata.
-- Include `projective-grid` in the coordinated crates.io release flow and add
-  CI validation that the publish order matches inter-crate dependencies before
-  attempting the tagged publish job.
-
-## [0.3.2]
-
-### ChArUco — local grid smoothness pre-filter
-
-- **New `grid_smoothness` module** in `calib-targets-charuco`: runs between
-  `build_corner_map` and `build_marker_cells` to detect corners whose pixel
-  position is inconsistent with their grid neighbors (midpoint prediction).
-  This catches false corners from ArUco marker internal features picked up by
-  ChESS under a loose orientation tolerance (e.g. 22.5°).  Flagged corners are
-  re-detected locally via `redetect_corner_in_roi`; if re-detection fails, the
-  corner is snapped to the predicted position (never removed) so that marker
-  cell completeness — and thus marker detection recall — is preserved.
-- **New `grid_smoothness_threshold_rel` parameter** on
-  `CharucoDetectorParams` (default `0.05`, i.e. 3 px at 60 px/sq).
-  Set to `f32::INFINITY` to disable.  Also exposed in the FFI
-  (`ct_charuco_detector_params_t`) with the same default.
-- Promote `redetect_corner_in_roi` from private to `pub(crate)` in
-  `corner_validation.rs` so the grid smoothness module can reuse it.
-
-## [0.3.1]
-
-### Chessboard grid graph — perspective-invariant neighbor direction fix
-
-- **Fix direction symmetry in `is_good_neighbor_with_orientation`**: the old
-  code indexed diagonal directions by the source/neighbor cluster index
-  (`grid_diagonals[ci]` / `grid_diagonals[cj]`), so the sign of `v_minus = oi
-  - oj` depended on which corner was the "source" and which was the "neighbor".
-  This broke the A→B Right ↔ B→A Left invariant the BFS relies on, causing
-  spurious disconnected components and missing grid edges on rotated or
-  perspective-distorted boards.
-- **Canonical reference frame**: switch to `grid_diagonals[0]` and
-  `grid_diagonals[1]` (independent of edge direction) so all edges in the graph
-  share the same `v_plus`/`v_minus` axes. Canonicalize the sign of `v_minus`
-  via the cross-product determinant so that `(v_minus, v_plus)` always form a
-  right-handed frame in image coordinates, regardless of the arbitrary order
-  produced by orientation clustering.
-- **Perspective-invariant direction classification**: replace the image-space
-  `direction_quadrant` heuristic (which broke for rotated boards) with signed
-  dot products against the local grid axes. The resulting Right/Left/Down/Up
-  labels are now consistent with the local grid geometry under perspective, not
-  just when the board is nearly axis-aligned.
-- Add a `rotated_grid_forms_single_component` unit test that constructs a 4×4
-  corner grid at an arbitrary 40° rotation and verifies the graph BFS produces
-  a single connected component with correct grid coordinates.
-
-### ChArUco marker detection — improved recall on blurry images
-
-- **Multi-threshold binarization**: the marker decode step now tries multiple
-  binarization thresholds per cell (Otsu, Otsu±10, Otsu±15, two percentile
-  thresholds, and a border-guided midpoint) and selects the one that yields a
-  valid dictionary match with hamming=0. This recovers markers that were
-  previously lost on blurry or unevenly-lit images because a single Otsu
-  threshold flipped one or two border or payload bits. Controlled by the new
-  `ScanDecodeConfig::multi_threshold` field (default `true`); exposed as
-  `ArucoScanConfig::multi_threshold` for JSON-level overrides.
-- **Lower default `min_border_score` for ChArUco**: the per-cell border-black
-  ratio threshold is now `0.75` (was `0.85`) in `CharucoDetectorParams::for_board`.
-  The downstream alignment and corner-validation stages already act as
-  false-positive guards, so the looser scan-stage bar improves recall without
-  introducing spurious detections.
-- Add `percentile_threshold`, `border_guided_threshold`, and
-  `compute_threshold_candidates` helper functions to `calib-targets-aruco`
-  (crate-private).
-- Move `log` from a dev-dependency to a regular dependency in
-  `calib-targets-aruco` to support debug logging in production builds.
-
-### Diagnostic logging across the detection pipeline
-
-- **`calib-targets-chessboard`**: add `log::debug!` at every significant
-  rejection point in the chessboard detector — early corner count check,
-  post-orientation-filter count, per-component BFS/grid-fit/completeness
-  rejections, and the accepted-candidate summary. Add `log_graph_summary`
-  helper that logs grid-graph component sizes and node-degree distribution.
-- **`calib-targets-charuco` pipeline**: add `log::debug!` / `log::warn!` at
-  each stage — chessboard success/failure (with config details on failure),
-  marker sampling cell counts, scan result count, alignment result (transform +
-  inlier count), pre- and post-validation corner counts. Failed-cell details
-  (border-score, observed code) now logged at `debug` level from
-  `scan_decode_markers_in_cells`.
-- **`charuco_detect` example**: switch default log level to `debug`; add
-  config-echo logging on startup.
-
-## [0.3.0]
-
-### Printable targets
-
-- Add the dedicated `calib-targets-print` crates.io crate to the coordinated
-  Rust release flow and document it as a first-class published printable-target
-  entry point alongside `calib_targets::printable`.
-- Add a canonical printable-target guide with JSON, Rust, CLI, and Python
-  flows, output-bundle expectations, and print-at-100%-scale guidance.
-- Productize the repo-local `calib-targets-cli` workflow with
-  `list-dictionaries` and `validate`, clearer help text, and integration
-  coverage for discover/init/validate/generate flows.
-- Add explicit millimeter-aware conversions from `CharucoBoardSpec` and
-  `MarkerBoardLayout` into printable target specs and printable documents.
-
-### Native C API
-
-- Add the repo-local `calib-targets-ffi` crate and generated public C header
-  for native consumers. The FFI crate remains `publish = false` and is built
-  from the workspace rather than distributed on crates.io.
-- Add fixed-struct C detector APIs for chessboard, ChArUco, and checkerboard
-  marker-board detection over 8-bit grayscale images, with opaque handles,
-  explicit status codes, caller-owned query/fill buffers, full ChESS
-  configuration, and built-in dictionary names only.
-- Add repo-owned native validation for the C API: generated-header drift
-  checks, a plain C smoke example, a thin header-only C++17 RAII
-  wrapper/example, and a Cargo-driven smoke test that compiles and runs
-  external C and C++ consumers against the built shared library.
-- Add repo-local ergonomic C++/CMake consumer packaging: stage Cargo-built
-  artifacts into a deterministic CMake package prefix, export
-  `calib_targets_ffi::c` and `calib_targets_ffi::cpp` targets, and validate a
-  repo-owned `find_package(...)` consumer example in CI.
-- Add tagged native release assets for `calib-targets-ffi`: supported GitHub
-  releases now attach per-platform archives containing the staged `include/`,
-  `lib/`, and `lib/cmake/` prefix so downstream C/C++ consumers can integrate
-  without building Rust from source.
-- Clarify current native-consumer boundaries: the release archives are the
-  supported distribution format for Linux, macOS, and Windows tags, but there
-  is still no crates.io/package-manager distribution, installer flow, or signed
-  native package.
-
-## [0.2.5]
-- Maintenance release: bump crate versions to `0.2.5`.
-
-## [0.2.4]
-- Fix ChArUco false-corner detection: ArUco marker-interior saddle points
-  could displace true chessboard-grid corners in the graph BFS and produce
-  ChArUco corners with correct IDs but wrong pixel positions.
-- Add marker-constrained corner validation stage in `calib-targets-charuco`:
-  estimates a board-to-image homography from all inlier marker corners and
-  flags corners whose reprojection error exceeds `corner_validation_threshold_rel
-  * px_per_square` (default 8%). Flagged corners are re-detected via a local
-  ChESS patch search seeded at the projected position.
-- Add `corner_validation_threshold_rel` and `corner_redetect_params` to
-  `CharucoDetectorParams`.
-- Add `chess-corners-core` as a production dependency of `calib-targets-charuco`.
-
-## [0.2.3]
-- Python bindings: switch to a mixed Rust/Python package layout with private
-  extension module `calib_targets._core` and typed public package sources.
-- Python API: hard reset to a dataclass-first surface with typed-only config
-  inputs and typed detector result objects.
-- Add `to_dict()` / `from_dict(...)` compatibility helpers on public config and
-  result models.
-- Add generated typing artifacts (`_core.pyi`, dictionary literal definitions)
-  and a generator script with `--check` mode for CI.
-- Add Python type-check smoke coverage (Pyright + mypy) in CI.
-
-## [0.2.2]
-- Remove redundant ChArUco board parameter; board spec now lives in params for Rust and Python APIs.
-- `CharucoDetector::new` now takes only `CharucoDetectorParams`.
-- Add typed Python classes for `CharucoBoardSpec`, `MarkerBoardLayout`, and `MarkerCircleSpec`.
-- Make Python config classes mutable via settable attributes.
-- Document authoritative Python output schema in `crates/calib-targets-py/README.md`.
-
-## [0.2.1]
-- Add Python-friendly config/params classes with IDE signatures while keeping dict overrides.
-- Allow partial dict overrides for detector params without specifying full structs.
-- Validate unknown keys in Python config dicts with clearer error paths.
-- Improve Python conversion errors to include parameter paths and accept NumPy scalars.
-
-## [0.2.0]
-- Document the Python bindings across the workspace README, crate readmes, and book.
-- Clarify marker-board `cell_size` usage so `target_position` is populated when alignment succeeds.
-- Fix macOS Python binding linking via a PyO3 build script.
-- Refresh PyO3 bindings to the Bound API to remove deprecation warnings.
-- Bump `chess-corners` dependency to v0.3.
-
-## [0.1.2]
-- Speed up marker circle scoring with LUT-based sampling and a center precheck.
-- Add a fast in-bounds bilinear sampling helper for hot paths.
-
-## [0.1.1]
-- Initial public release of the calib-targets crates.
+## Older releases
+
+The full release history is preserved under
+[`docs/changelog/`](docs/changelog/), grouped by minor-version family:
+
+- [`0.6.x`](docs/changelog/0.6.x.md) — PuzzleBoard crate launch
+- [`0.5.x`](docs/changelog/0.5.x.md) — single-config detector API,
+  multi-component ChArUco, WebAssembly bindings
+- [`0.4.x`](docs/changelog/0.4.x.md) — standalone `projective-grid`
+  crate, hex grids, native C API hardening
+- [`0.3.x`](docs/changelog/0.3.x.md) — printable-target tooling,
+  C ABI / FFI crate, ChArUco recall improvements
+- [`0.2.x`](docs/changelog/0.2.x.md) — Python bindings refresh,
+  ChArUco false-corner fix
+- [`0.1.x`](docs/changelog/0.1.x.md) — initial public releases

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,9 +285,9 @@ dependencies = [
 
 [[package]]
 name = "box-image-pyramid"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b5edf15332ed706ed668d5e1b1e92564c647dd204abec517c1454483c6f746c"
+checksum = "87aa24dde918ca16f7456406a93fe76918ba55cc78fbd7b8aac42cf41810afc5"
 dependencies = [
  "rayon",
 ]
@@ -408,7 +408,6 @@ dependencies = [
  "calib-targets-chessboard",
  "calib-targets-core",
  "chess-corners",
- "chess-corners-core",
  "env_logger",
  "image",
  "log",
@@ -604,9 +603,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chess-corners"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25f9cb585916709874c7f163e50d9c27558120af972fc5baff270a0fc7ea556a"
+checksum = "ec0f69e08802e9ec95a13a51f883c774d999d004fd866a1c4c14655edbd524af"
 dependencies = [
  "box-image-pyramid",
  "chess-corners-core",
@@ -619,9 +618,9 @@ dependencies = [
 
 [[package]]
 name = "chess-corners-core"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8422fd91df635f17da3334e3e8f1d799d78593d777df87d14f21a99428edf473"
+checksum = "c71f1f26caffa180c4574c220746db2655b77825cb8b34aaa6fe2f3a9b87a7b1"
 dependencies = [
  "log",
  "rayon",
@@ -630,9 +629,9 @@ dependencies = [
 
 [[package]]
 name = "chess-corners-ml"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6f75f6a7380faace5fc1f69b0886a84ed036ec9dda6c5d49f017f144fb4c85"
+checksum = "b709a0831849b936ae970515c000cfa0ede4a2410db08263d4402d5aa79156ce"
 dependencies = [
  "anyhow",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -973,23 +973,9 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fax"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05de7d48f37cd6730705cbca900770cab77a89f413d23e100ad7fad7795a0ab"
-dependencies = [
- "fax_derive",
-]
-
-[[package]]
-name = "fax_derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
 
 [[package]]
 name = "fdeflate"
@@ -1054,6 +1040,30 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "generator"
@@ -1439,10 +1449,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -2694,6 +2706,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3323,9 +3341,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3336,9 +3354,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3346,9 +3364,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3359,9 +3377,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ calib-targets-print = { version = "0.8", path = "crates/calib-targets-print" }
 approx = "0.5"
 assert_cmd = "2"
 cbindgen = "0.29"
-chess-corners = "0.7"
+chess-corners = "0.8"
 clap = "4.5"
 criterion = { version = "0.5", default-features = false, features = ["cargo_bench_support", "html_reports"] }
 delaunator = "1.0"

--- a/README.md
+++ b/README.md
@@ -13,15 +13,15 @@ stable C ABI. One grid-first algorithmic core; a single
 
 ![Target gallery — chessboard, ChArUco, PuzzleBoard, marker board](docs/img/target_gallery.png)
 
-> **Status:** feature-complete, heading into a 0.7 release. APIs are
+> **Status:** feature-complete, heading into a 0.8 release. APIs are
 > stabilising but may still change at minor versions.
 
-| Target | When to use |
+| Target | What it is |
 |---|---|
-| **Chessboard** | Simplest option; no markers needed. |
-| **ChArUco** | Partial views OK, unique corner IDs. |
-| **PuzzleBoard** | Self-identifying chessboard with `Full` / `FixedBoard` search, soft-log-likelihood scoring, and per-frame decode diagnostics. Any visible fragment yields the **same absolute corner IDs** a full-view decode would. Multi-camera rigs, heavy occlusion. |
-| **Marker board** | Checkerboard + circle markers; unique origin without a dictionary. |
+| **Chessboard** | Plain checkerboard. Detector returns labelled corner positions with `(0, 0)` rebased to the visual top-left. No markers; corners are not individually identified. |
+| **ChArUco** | Chessboard with ArUco markers in white squares. Each labelled corner gets a globally-unique ID derived from the surrounding markers; partial views decode. |
+| **PuzzleBoard** | Self-identifying chessboard with edge-midpoint dots encoding a 501 × 501 master pattern. Any visible fragment yields the same absolute corner IDs a full-view decode would. `Full` and `FixedBoard` search modes; soft-log-likelihood scoring with `score_margin` / runner-up diagnostics for downstream consistency checks. |
+| **Marker board** | Plain checkerboard with three large circle markers establishing a unique origin without a dictionary. |
 
 Full documentation: [book][book] · [API reference][api] · [getting-started tutorial][getting-started].
 
@@ -35,18 +35,32 @@ Full documentation: [book][book] · [API reference][api] · [getting-started tut
   then decode anchors / dots / circles in rectified cells". The heavy
   lifting lives in [`calib-targets-chessboard`] and
   [`projective-grid`][projective-grid-readme].
+- **Two grid pipelines, one output type.** The default ChessboardV2
+  pipeline is invariant-first seed-and-grow with adaptive local-step
+  prediction, battle-tested across all four target families. The
+  opt-in topological pipeline (Shu / Brunton / Fiala 2009) is image-
+  free Delaunay + edge-classification + flood-fill labelling that runs
+  faster and denser on clean PuzzleBoards. Selectable per call via
+  `DetectorParams::graph_build_algorithm`; ChArUco unconditionally
+  pins ChessboardV2.
 - **Local invariants, not global warps.** Graph construction, seed
-  formation, and validation all work on local neighbourhoods — so
-  moderate perspective and radial distortion degrade gracefully without
-  an explicit distortion model.
+  formation, and validation all work on local neighbourhoods, so
+  moderate perspective and radial distortion degrade gracefully
+  without an explicit distortion model. Stage 6 boundary extension
+  comes in two flavours — global-H over the labelled set (gated on
+  reprojection residuals so it disables itself under heavy distortion)
+  and per-candidate local-H over the K nearest labels (tolerates
+  stronger distortion).
 - **Partial boards supported.** PuzzleBoard gives absolute IDs from a
   single visible fragment; ChArUco / marker boards label whatever is
   visible and the facade `detect_*_all` helpers return every connected
   component.
-- **Consistency diagnostics built in.** PuzzleBoard surfaces both the
-  chosen search/scoring mode and soft-decoder confidence diagnostics
-  (`score_margin`, runner-up origin/transform) so downstream tools can
-  distinguish trusted cross-view matches from weak hypotheses.
+- **Consistency diagnostics built in.** PuzzleBoard surfaces the
+  chosen search / scoring mode and soft-decoder confidence diagnostics
+  (`score_margin`, runner-up origin / transform). The chessboard
+  detector ends in a Stage 9 final-geometry check that drops gross
+  mislabels and isolated false positives before emitting any
+  `Detection`.
 - **Multi-config sweeps.** `detect_*_best` tries three built-in presets
   and keeps the best result — no hand-tuning required for the common
   failure cases.

--- a/book/src/aruco_decoding.md
+++ b/book/src/aruco_decoding.md
@@ -2,9 +2,9 @@
 
 This chapter expands on the marker decoding path in `calib-targets-aruco`. The decoder is grid-first: it samples expected square cells and reads bits in rectified space (or per-cell quads).
 
-## When to use per-cell decoding
+## Per-cell decoding
 
-Use per-cell decoding (`scan_decode_markers_in_cells`) when you already have a grid of square corners and want to avoid warping the full image. It works well with ChArUco detection because you can decode only the valid cells and parallelize across them.
+`scan_decode_markers_in_cells` reads marker bits in their own cells given an existing grid of square corners, without warping the full image. ChArUco detection drives this path: only valid grid cells are decoded, and the per-cell work parallelises trivially.
 
 ## Sampling model
 
@@ -12,8 +12,9 @@ Use per-cell decoding (`scan_decode_markers_in_cells`) when you already have a g
 - The marker area is defined by `marker_size_rel`, with an extra inset from `inset_frac`.
 - A per-marker threshold (Otsu) is computed from sampled intensities.
 
-## Tuning checklist
+## Tuning knobs
 
-- If markers are missing, try reducing `inset_frac` slightly.
-- If false positives appear, raise `min_border_score` or enable `dedup_by_id`.
-- Make sure `marker_size_rel` matches the physical board spec.
+- `inset_frac` controls how far inside the marker area bits are sampled. Lower values capture more of the marker; higher values are more robust to thin black borders bleeding into the bit grid.
+- `min_border_score` is the minimum "frame looks like a marker border" score required to accept a cell. Higher values reject ambiguous cells.
+- `dedup_by_id` collapses repeated decodes of the same dictionary ID across cells.
+- `marker_size_rel` is the marker side relative to the enclosing chessboard cell and must match the physical board spec.

--- a/book/src/projective_grid.md
+++ b/book/src/projective_grid.md
@@ -3,40 +3,90 @@
 > Code: [`projective-grid`](https://github.com/VitalyVorobyev/calib-targets-rs/tree/main/crates/projective-grid).
 
 `projective-grid` is the pattern-agnostic core of the workspace's
-grid detectors. It provides the algorithmic pieces every grid-
-detection pipeline needs — seed-and-grow BFS, boundary extension via
-fitted homography, per-cell rectification, circular-statistics peak
-picking, line / local-homography validation — with no dependency on
+grid detectors. It exposes two grid-construction pipelines (seed-and-
+grow BFS and a topological Delaunay-based finder), boundary-extension
+machinery, per-cell rectification, circular-statistics peak picking,
+and line / local-homography validation — with no dependency on
 calibration-specific types.
 
-You can consume it directly for non-calibration use cases: rectifying
-a photograph of a board game, fitting a locally-planar lattice to a
-laser-dot cloud, extracting a grid from a scanned document, or
-building a new detector for a pattern the workspace doesn't yet ship.
+The crate ships independently on crates.io and is used directly for
+non-calibration tasks: rectifying a photograph of a board game,
+fitting a locally-planar lattice to a laser-dot cloud, extracting a
+grid from a scanned document, or building a new detector for a
+pattern the workspace doesn't yet ship.
 
 ---
 
-## Pipeline
+## Pipelines
 
-The crate centres on a five-stage pipeline. Pattern-specific gates
-(parity, axis-cluster, marker rules, …) plug in via the
-`square::grow::GrowValidator` trait; the geometric machinery is
-generic.
+### Square seed-and-grow (default)
+
+A five-stage pipeline. Pattern-specific gates (parity, axis-cluster,
+marker rules, …) plug in via the `square::grow::GrowValidator` trait;
+the geometric machinery is generic.
 
 | Stage | Entry points | What it does |
 |---|---|---|
 | **Cell-size estimate** | `estimate_global_cell_size`, `estimate_local_steps` | Infer approximate lattice spacing from a raw point cloud. |
 | **Seed-and-grow** | `square::grow::bfs_grow` + `GrowValidator` | BFS from a 2×2 seed quad, predicting each next cell with adaptive per-neighbour local-step. |
-| **Boundary extension** | `square::grow_extension::extend_via_global_homography` | Fit a global H over the BFS-validated set; extend outward into perspective-foreshortened territory. Residual gate disables the pass under heavy lens distortion. |
-| **Validation** | `square::validate` | Line collinearity + local-homography residuals → blacklist of outlier corners; iterate Stages 5–7 until convergence. |
-| **Rectification** | `square::rectify::SquareGridHomography`, `square::mesh::SquareGridHomographyMesh`, hex equivalents | Single global homography or per-cell mesh, depending on distortion regime. |
+| **Boundary extension (global H)** | `square::extension::extend_via_global_homography` | Fit a global H over the BFS-validated set; extend outward into perspective-foreshortened territory. Residual gate disables the pass under heavy lens distortion. |
+| **Boundary extension (local H)** | `square::extension::extend_via_local_homography` | Per-candidate H from the K nearest labelled corners. Tolerates heavy radial distortion and multi-region perspective where a single H breaks. Configured via `LocalExtensionParams`. |
+| **Validation** | `square::validate` | Line collinearity + local-homography residuals → blacklist of outlier corners; iterate the previous stages until convergence. |
+| **Rectification** | `square::rectify::SquareGridHomography`, `square::mesh::SquareGridHomographyMesh`, hex equivalents | Single global homography or per-cell mesh. |
 
-Reusable utilities:
+`square::grow_extension` is a deprecated alias for `square::extension`
+retained for back-compat; new code imports from `square::extension`
+directly.
+
+### Topological grid finder
+
+`projective_grid::build_grid_topological` implements the Shu /
+Brunton / Fiala 2009 grid finder: Delaunay triangulation over the
+corner cloud, edge classification by per-edge axis match, triangle-
+pair → quad merge, and flood-fill `(i, j)` labelling. Image-free —
+the original paper's per-cell colour test is replaced by an axis-
+driven cell predicate so `projective-grid` stays standalone.
+
+```rust,ignore
+use projective_grid::{
+    build_grid_topological, merge_components_local,
+    ComponentInput, LocalMergeParams, TopologicalParams,
+};
+
+let topo = build_grid_topological(&positions, &axes_hints, &TopologicalParams::default())?;
+
+// merge_components_local reunites partial components and is shared
+// with the seed-and-grow pipeline.
+let views: Vec<ComponentInput<'_>> = topo.components.iter()
+    .map(|c| ComponentInput { labelled: &c.labelled, positions: &positions })
+    .collect();
+let merged = merge_components_local(&views, &LocalMergeParams::default());
+```
+
+ChessboardV2 selects between the two pipelines via
+`DetectorParams::graph_build_algorithm`; the default is `ChessboardV2`
+(seed-and-grow). The topological path runs faster and denser on
+clean PuzzleBoards but currently regresses recall on ChArUco-style
+images because marker-internal corners poison the per-cell axis
+test. ChArUco unconditionally pins seed-and-grow inside
+`CharucoDetector::new` regardless of caller choice.
+
+See `crates/projective-grid/docs/TOPOLOGICAL_PIPELINE.md` in the
+workspace for the per-stage algorithm description and known
+limitations.
+
+### Reusable utilities
 
 - **Circular statistics** (`circular_stats`) — plateau-aware peak
   detection and double-angle 2-means for axis-angle histograms.
 - **Homography** (`homography`) — 4-point + DLT solver with Hartley
-  normalisation and a reprojection-quality diagnostic.
+  normalisation and a reprojection-quality diagnostic. The DLT path
+  uses normal equations + 9×9 symmetric eigendecomposition for the
+  null-vector solve.
+- **Component merge** (`component_merge::merge_components_local`) —
+  position-based Hough alignment of `(D4-transform, label-delta)`,
+  shared by both pipelines as the post-stage that reunites partial
+  components.
 
 ---
 
@@ -161,26 +211,28 @@ flip axes so `(0, 0)` sits at the **visual top-left** of the detected
 grid — `+i` points right (+x), `+j` points down (+y). This is not
 enforced by `bfs_grow` itself — it's a pattern-side contract.
 
-### Stage 6 is precision-safe
+### Boundary extension is precision-safe
 
-Boundary extension via global H goes through *every* gate the BFS uses
-— `is_eligible`, `label_of` against `required_label_at`,
+Both extension flavours go through *every* gate the BFS uses —
+`is_eligible`, `label_of` against `required_label_at`,
 `accept_candidate`, and `edge_ok` — plus a tighter ambiguity gate
 (2.5× vs BFS's 1.5×) and a single-claim guarantee (one corner index
-can only be claimed by one cell per pass). Plus the H-residual gate:
-the median / max reprojection residual on the BFS-validated set must
-be small (in pixel units) for the H to be trusted; under heavy lens
-distortion the gate fires and Stage 6 becomes a no-op.
+can only be claimed by one cell per pass). The global-H pass adds an
+H-residual gate on the BFS-validated set: under heavy lens distortion
+the gate fires and the pass becomes a no-op. The local-H pass uses
+a per-candidate worst-residual gate over the K supports instead of a
+single global threshold, so it stays useful where global-H refuses.
 
 ---
 
-## When not to use this
+## Out of scope
 
-- **3D grids.** Coordinates are `nalgebra::Point2<f32>`. There's no
+- **3D grids.** Coordinates are `nalgebra::Point2<f32>`. There is no
   3D support.
-- **Non-planar surfaces.** Stage 6 assumes a single planar
+- **Non-planar surfaces.** Boundary extension assumes a single planar
   homography fits the labelled set. Severely curved surfaces need the
-  mesh variant for rectification, and Stage 6 will refuse to extend.
+  per-cell mesh variant for rectification, and the global-H extension
+  refuses to extend under those conditions.
 - **Dense point clouds without structure.** The seed finder assumes
   the lattice spacing is recoverable from the seed's own edge
-  lengths; pure noise won't yield a stable seed.
+  lengths; pure noise does not yield a stable seed.

--- a/crates/calib-targets-aruco/README.md
+++ b/crates/calib-targets-aruco/README.md
@@ -16,8 +16,8 @@ Most users go through the facade [`calib-targets`][facade] or the
 
 ```toml
 [dependencies]
-calib-targets-aruco = "0.7"
-calib-targets-core = "0.7"
+calib-targets-aruco = "0.8"
+calib-targets-core = "0.8"
 ```
 
 ## Quickstart

--- a/crates/calib-targets-charuco/Cargo.toml
+++ b/crates/calib-targets-charuco/Cargo.toml
@@ -22,7 +22,6 @@ calib-targets-core.workspace = true
 calib-targets-chessboard.workspace = true
 calib-targets-aruco.workspace = true
 chess-corners = { workspace = true, features = ["rayon", "ml-refiner"] }
-chess-corners-core = "0.7"
 projective-grid.workspace = true
 nalgebra.workspace = true
 serde = { workspace = true, features = ["derive"] }

--- a/crates/calib-targets-charuco/README.md
+++ b/crates/calib-targets-charuco/README.md
@@ -23,9 +23,9 @@ and [alignment & refinement chapter][book-alignment].
 
 ```toml
 [dependencies]
-calib-targets-charuco = "0.7"
-calib-targets-core = "0.7"
-calib-targets-aruco = "0.7"
+calib-targets-charuco = "0.8"
+calib-targets-core = "0.8"
+calib-targets-aruco = "0.8"
 ```
 
 ## Quickstart
@@ -89,14 +89,17 @@ marker IDs — rendered by the `overlay_charuco.py` tool.
 
 ## Choosing a dictionary
 
-| Family | Tolerance | When to use |
+| Family | Bit grid | Hamming margin |
 |---|---|---|
-| `DICT_4X4_{50, 100, 250, 1000}` | Tight; only a few bit-errors before confusion. | Small boards with large markers. |
-| `DICT_5X5_*`, `DICT_6X6_*`, `DICT_7X7_*` | Progressively looser; more bits, better Hamming margin. | Medium boards, mild blur. |
-| `DICT_APRILTAG_{16h5, 25h9, 36h10, 36h11}` | Strong error-correcting codes (min. Hamming distance ≥ 10). | Large boards, motion blur, small markers. Combine with the board-level matcher. |
-| `DICT_ARUCO_MIP_36h12` | AprilTag-grade codes in an ArUco layout. | Fine-grained printed targets. |
+| `DICT_4X4_{50, 100, 250, 1000}` | 4×4 payload | Tight; only a few bit-errors before confusion. |
+| `DICT_5X5_*`, `DICT_6X6_*`, `DICT_7X7_*` | 5×5 / 6×6 / 7×7 payload | Progressively looser as bit count grows. |
+| `DICT_APRILTAG_{16h5, 25h9, 36h10, 36h11}` | AprilTag layouts | Strong error-correcting codes (min. Hamming distance ≥ 10). |
+| `DICT_ARUCO_MIP_36h12` | 6×6 payload | AprilTag-grade codes in an ArUco-style layout. |
 
-Match `CharucoBoardSpec::dictionary` exactly to what was printed.
+`CharucoBoardSpec::dictionary` must match the printed dictionary
+exactly. AprilTag families combined with the board-level matcher are
+typical for motion-blurred or distant captures; the smaller 4×4 ArUco
+families fit small boards with large per-marker pixel area.
 
 ## Two matchers
 

--- a/crates/calib-targets-charuco/examples/charuco_detect.rs
+++ b/crates/calib-targets-charuco/examples/charuco_detect.rs
@@ -94,7 +94,7 @@ fn detect_raw_corners(img: &image::GrayImage) -> Vec<CornerDescriptor> {
         "Running ChESS corner scan with threshold={:.3} ({:?}), nms_radius={}",
         chess_cfg.threshold_value, chess_cfg.threshold_mode, chess_cfg.nms_radius
     );
-    find_chess_corners_image(img, &chess_cfg)
+    find_chess_corners_image(img, &chess_cfg).expect("ChESS detection")
 }
 
 fn adapt_corners(raw: &[CornerDescriptor]) -> Vec<Corner> {

--- a/crates/calib-targets-charuco/src/detector/corner_validation.rs
+++ b/crates/calib-targets-charuco/src/detector/corner_validation.rs
@@ -48,11 +48,9 @@ use calib_targets_aruco::MarkerDetection;
 use calib_targets_core::{
     estimate_homography_rect_to_img, GrayImageView, LabeledCorner, TargetDetection, TargetKind,
 };
-use chess_corners_core::{
-    detect::detect_corners_from_response_with_refiner,
-    imageview::ImageView,
-    response::{chess_response_u8_patch, Roi},
-    ChessParams, Refiner,
+use chess_corners::{
+    chess_response_u8_patch, detect_corners_from_response_with_refiner, ChessParams, ImageView,
+    Refiner, Roi,
 };
 use nalgebra::Point2;
 

--- a/crates/calib-targets-charuco/tests/regression.rs
+++ b/crates/calib-targets-charuco/tests/regression.rs
@@ -25,7 +25,7 @@ fn detect_corners(img: &image::GrayImage) -> Vec<CornerDescriptor> {
     chess_cfg.threshold_mode = chess_corners::ThresholdMode::Relative;
     chess_cfg.threshold_value = 0.2;
     chess_cfg.nms_radius = 2;
-    find_chess_corners_image(img, &chess_cfg)
+    find_chess_corners_image(img, &chess_cfg).expect("ChESS detection")
 }
 
 fn adapt_chess_corner(c: &CornerDescriptor) -> TargetCorner {

--- a/crates/calib-targets-core/README.md
+++ b/crates/calib-targets-core/README.md
@@ -14,7 +14,7 @@ writing a new detector or consuming detection results without the facade.
 
 ```toml
 [dependencies]
-calib-targets-core = "0.7"
+calib-targets-core = "0.8"
 nalgebra = "0.34"
 ```
 

--- a/crates/calib-targets-core/src/corner.rs
+++ b/crates/calib-targets-core/src/corner.rs
@@ -5,7 +5,7 @@ pub use projective_grid::GridCoords;
 
 /// One local grid-axis direction at a corner, with its 1σ angular uncertainty.
 ///
-/// Mirrors the upstream `chess_corners_core::AxisEstimate` so that
+/// Mirrors the upstream `chess_corners::AxisEstimate` so that
 /// `calib-targets-core`'s public API does not leak the external detector crate.
 /// The conversion from upstream to this type happens in the single
 /// `adapt_chess_corner` adapter per consumer crate.

--- a/crates/calib-targets-marker/README.md
+++ b/crates/calib-targets-marker/README.md
@@ -19,8 +19,8 @@ Algorithm details: [book chapter][book-chapter].
 
 ```toml
 [dependencies]
-calib-targets-marker = "0.7"
-calib-targets-core = "0.7"
+calib-targets-marker = "0.8"
+calib-targets-core = "0.8"
 ```
 
 ## Quickstart

--- a/crates/calib-targets-marker/examples/marker_detect.rs
+++ b/crates/calib-targets-marker/examples/marker_detect.rs
@@ -45,7 +45,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     let img = ImageReader::open(&cfg.image_path)?.decode()?.to_luma8();
 
     let chess_cfg = make_chess_config();
-    let raw_corners = find_chess_corners_image(&img, &chess_cfg);
+    let raw_corners = find_chess_corners_image(&img, &chess_cfg)?;
     info!("raw ChESS corners: {}", raw_corners.len());
 
     let corners = adapt_corners(&raw_corners);

--- a/crates/calib-targets-print/README.md
+++ b/crates/calib-targets-print/README.md
@@ -14,7 +14,7 @@ Canonical user guide: [printable-targets book chapter][book-chapter].
 
 ```toml
 [dependencies]
-calib-targets-print = "0.7"
+calib-targets-print = "0.8"
 ```
 
 ## Quickstart

--- a/crates/calib-targets-puzzleboard/README.md
+++ b/crates/calib-targets-puzzleboard/README.md
@@ -23,8 +23,8 @@ Algorithm details and bit-layout spec: [book chapter][book-chapter].
 
 ```toml
 [dependencies]
-calib-targets-puzzleboard = "0.7"
-calib-targets-core = "0.7"
+calib-targets-puzzleboard = "0.8"
+calib-targets-core = "0.8"
 ```
 
 ## Quickstart (facade)

--- a/crates/calib-targets-puzzleboard/tests/end_to_end.rs
+++ b/crates/calib-targets-puzzleboard/tests/end_to_end.rs
@@ -65,7 +65,7 @@ fn render_detect_roundtrip_on_small_puzzleboard() {
     cfg.threshold_mode = chess_corners::ThresholdMode::Relative;
     cfg.threshold_value = 0.15;
     cfg.nms_radius = 3;
-    let descriptors = find_chess_corners_image(&gray, &cfg);
+    let descriptors = find_chess_corners_image(&gray, &cfg).expect("ChESS detection");
     assert!(
         descriptors.len() >= 60,
         "expected at least 60 ChESS corners, got {}",
@@ -175,7 +175,7 @@ fn fixed_board_agrees_with_full_on_whole_view() {
     cfg.threshold_mode = chess_corners::ThresholdMode::Relative;
     cfg.threshold_value = 0.15;
     cfg.nms_radius = 3;
-    let descriptors = find_chess_corners_image(&gray, &cfg);
+    let descriptors = find_chess_corners_image(&gray, &cfg).expect("ChESS detection");
     let corners: Vec<TargetCorner> = descriptors.iter().map(adapt).collect();
 
     let board_spec = PuzzleBoardSpec::with_origin(
@@ -258,7 +258,7 @@ fn fixed_board_agrees_across_disjoint_partial_views() {
     cfg.threshold_mode = chess_corners::ThresholdMode::Relative;
     cfg.threshold_value = 0.15;
     cfg.nms_radius = 3;
-    let descriptors = find_chess_corners_image(&gray, &cfg);
+    let descriptors = find_chess_corners_image(&gray, &cfg).expect("ChESS detection");
     let all_corners: Vec<TargetCorner> = descriptors.iter().map(adapt).collect();
 
     let view = GrayImageView {
@@ -440,7 +440,7 @@ fn run_image_rotation_test(upscale: u32, rotation_deg: u32) {
     let detector = PuzzleBoardDetector::new(params).expect("detector");
 
     // Detect on the original image.
-    let descriptors_orig = find_chess_corners_image(&gray_orig, &cfg);
+    let descriptors_orig = find_chess_corners_image(&gray_orig, &cfg).expect("ChESS detection");
     let corners_orig: Vec<TargetCorner> = descriptors_orig.iter().map(adapt).collect();
     let view_orig = GrayImageView {
         width: gray_orig.width() as usize,
@@ -452,7 +452,7 @@ fn run_image_rotation_test(upscale: u32, rotation_deg: u32) {
         .expect("orig decode");
 
     // Detect on the 90° CW rotated image.
-    let descriptors_rot = find_chess_corners_image(&gray_rot, &cfg);
+    let descriptors_rot = find_chess_corners_image(&gray_rot, &cfg).expect("ChESS detection");
     let corners_rot: Vec<TargetCorner> = descriptors_rot.iter().map(adapt).collect();
     let view_rot = GrayImageView {
         width: gray_rot.width() as usize,

--- a/crates/calib-targets-puzzleboard/tests/multi_camera_soft_ll.rs
+++ b/crates/calib-targets-puzzleboard/tests/multi_camera_soft_ll.rs
@@ -80,7 +80,7 @@ fn run_six_views(mode: PuzzleBoardScoringMode) -> SixViewResult {
     cfg.threshold_mode = chess_corners::ThresholdMode::Relative;
     cfg.threshold_value = 0.15;
     cfg.nms_radius = 3;
-    let descriptors = find_chess_corners_image(&gray, &cfg);
+    let descriptors = find_chess_corners_image(&gray, &cfg).expect("ChESS detection");
     let all_corners: Vec<TargetCorner> = descriptors.iter().map(adapt).collect();
 
     let view = GrayImageView {

--- a/crates/calib-targets-wasm/src/lib.rs
+++ b/crates/calib-targets-wasm/src/lib.rs
@@ -58,6 +58,7 @@ fn validate_gray(pixels: &[u8], width: u32, height: u32) -> Result<(), JsError> 
 fn detect_corners_impl(pixels: &[u8], width: u32, height: u32, cfg: &ChessConfig) -> Vec<Corner> {
     let cc_cfg = to_chess_corners_config(cfg);
     find_chess_corners_u8(pixels, width, height, &cc_cfg)
+        .unwrap_or_default()
         .iter()
         .map(adapt_chess_corner)
         .collect()

--- a/crates/calib-targets/src/detect.rs
+++ b/crates/calib-targets/src/detect.rs
@@ -64,6 +64,7 @@ pub fn gray_view(img: &::image::GrayImage) -> core::GrayImageView<'_> {
 pub fn detect_corners(img: &::image::GrayImage, cfg: &ChessConfig) -> Vec<core::Corner> {
     let cfg = to_chess_corners_config(cfg);
     find_chess_corners_image(img, &cfg)
+        .unwrap_or_default()
         .iter()
         .map(adapt_chess_corner)
         .collect()
@@ -508,6 +509,17 @@ mod tests {
 
     #[test]
     fn non_default_conversion_preserves_all_fields() {
+        let forstner = ForstnerConfig {
+            radius: 3,
+            min_trace: 9.0,
+            min_det: 2.0,
+            max_condition_number: 123.0,
+            max_offset: 2.5,
+        };
+        let mut refiner = RefinerConfig::default();
+        refiner.kind = RefinementMethod::Forstner;
+        refiner.forstner = forstner;
+
         let cfg = ChessConfig {
             detector_mode: DetectorMode::Broad,
             descriptor_mode: DescriptorMode::Canonical,
@@ -515,17 +527,7 @@ mod tests {
             threshold_value: 12.5,
             nms_radius: 5,
             min_cluster_size: 7,
-            refiner: RefinerConfig {
-                kind: RefinementMethod::Forstner,
-                forstner: ForstnerConfig {
-                    radius: 3,
-                    min_trace: 9.0,
-                    min_det: 2.0,
-                    max_condition_number: 123.0,
-                    max_offset: 2.5,
-                },
-                ..RefinerConfig::default()
-            },
+            refiner,
             pyramid_levels: 4,
             pyramid_min_size: 96,
             refinement_radius: 6,
@@ -542,19 +544,13 @@ mod tests {
         expected.threshold_value = 12.5;
         expected.nms_radius = 5;
         expected.min_cluster_size = 7;
-        expected.refiner = chess_corners::RefinerConfig {
-            kind: chess_corners::RefinementMethod::Forstner,
-            center_of_mass: chess_corners::CenterOfMassConfig::default(),
-            forstner: chess_corners::ForstnerConfig {
-                radius: 3,
-                min_trace: 9.0,
-                min_det: 2.0,
-                max_condition_number: 123.0,
-                max_offset: 2.5,
-            },
-            saddle_point: chess_corners::SaddlePointConfig::default(),
-            radon_peak: chess_corners::RadonPeakConfig::default(),
-        };
+        expected.refiner = chess_corners::RefinerConfig::build(
+            chess_corners::RefinementMethod::Forstner,
+            chess_corners::CenterOfMassConfig::default(),
+            forstner,
+            chess_corners::SaddlePointConfig::default(),
+            chess_corners::RadonPeakConfig::default(),
+        );
         expected.pyramid_levels = 4;
         expected.pyramid_min_size = 96;
         expected.refinement_radius = 6;
@@ -568,34 +564,30 @@ mod tests {
     fn all_refiner_variants_convert() {
         // Since RefinerConfig is a direct re-export from chess-corners,
         // to_chess_corners_config must pass it through unchanged.
-        let refiners = [
-            RefinerConfig {
-                kind: RefinementMethod::CenterOfMass,
-                center_of_mass: CenterOfMassConfig { radius: 4 },
-                ..RefinerConfig::default()
-            },
-            RefinerConfig {
-                kind: RefinementMethod::Forstner,
-                forstner: ForstnerConfig {
-                    radius: 3,
-                    min_trace: 11.0,
-                    min_det: 0.75,
-                    max_condition_number: 512.0,
-                    max_offset: 1.75,
-                },
-                ..RefinerConfig::default()
-            },
-            RefinerConfig {
-                kind: RefinementMethod::SaddlePoint,
-                saddle_point: SaddlePointConfig {
-                    radius: 5,
-                    det_margin: 0.25,
-                    max_offset: 1.25,
-                    min_abs_det: 0.125,
-                },
-                ..RefinerConfig::default()
-            },
-        ];
+        let mut com = RefinerConfig::default();
+        com.kind = RefinementMethod::CenterOfMass;
+        com.center_of_mass = CenterOfMassConfig { radius: 4 };
+
+        let mut forstner = RefinerConfig::default();
+        forstner.kind = RefinementMethod::Forstner;
+        forstner.forstner = ForstnerConfig {
+            radius: 3,
+            min_trace: 11.0,
+            min_det: 0.75,
+            max_condition_number: 512.0,
+            max_offset: 1.75,
+        };
+
+        let mut saddle = RefinerConfig::default();
+        saddle.kind = RefinementMethod::SaddlePoint;
+        saddle.saddle_point = SaddlePointConfig {
+            radius: 5,
+            det_margin: 0.25,
+            max_offset: 1.25,
+            min_abs_det: 0.125,
+        };
+
+        let refiners = [com, forstner, saddle];
 
         for refiner in refiners.iter() {
             let cfg = ChessConfig {

--- a/crates/calib-targets/tests/rust_api_smoke.rs
+++ b/crates/calib-targets/tests/rust_api_smoke.rs
@@ -36,26 +36,26 @@ image = "0.25"
         &main_path,
         r#"use calib_targets::detect::{
     self, ChessConfig, DetectorMode, DescriptorMode, RefinementMethod, RefinerConfig,
-    SaddlePointConfig, ThresholdMode,
+    ThresholdMode,
 };
 
 fn main() {
     let _named_default: ChessConfig = detect::default_chess_config();
+    // `RefinerConfig` is `#[non_exhaustive]`, so downstream crates must
+    // build it via the preset constructors / `build` rather than a literal.
+    let refiner = RefinerConfig::saddle_point();
     let cfg = ChessConfig {
         detector_mode: DetectorMode::Broad,
         descriptor_mode: DescriptorMode::Canonical,
         threshold_mode: ThresholdMode::Relative,
         threshold_value: 0.15,
         min_cluster_size: 1,
-        refiner: RefinerConfig {
-            kind: RefinementMethod::SaddlePoint,
-            saddle_point: SaddlePointConfig::default(),
-            ..RefinerConfig::default()
-        },
+        refiner,
         pyramid_levels: 2,
         pyramid_min_size: 64,
         ..ChessConfig::default()
     };
+    assert_eq!(cfg.refiner.kind, RefinementMethod::SaddlePoint);
 
     let img = image::GrayImage::new(16, 16);
     let _ = detect::detect_corners(&img, &cfg);

--- a/crates/projective-grid/README.md
+++ b/crates/projective-grid/README.md
@@ -14,21 +14,25 @@ Full API reference: see the [`projective-grid` book chapter][book-chapter].
 
 ```toml
 [dependencies]
-projective-grid = "0.7"
+projective-grid = "0.8"
 nalgebra = "0.34"
 ```
 
 ## Pipeline at a glance
 
-The crate centres on a five-stage pipeline. Pattern-specific gates
-(parity, axis-cluster, marker rules, …) plug into the
-[`square::grow::GrowValidator`] trait; the geometric machinery underneath
-is generic.
+`projective-grid` ships two grid-construction pipelines that produce
+the same `(i, j) → corner_idx` map and share the same downstream
+validation, rectification, and component-merge machinery. Pattern-
+specific gates (parity, axis-cluster, marker rules, …) plug into the
+[`square::grow::GrowValidator`] trait; the geometric machinery
+underneath is generic.
+
+### Square seed-and-grow (default)
 
 ```rust
 use projective_grid::square::{
     grow::{bfs_grow, GrowParams, GrowValidator, Seed},
-    grow_extension::{extend_via_global_homography, ExtensionParams},
+    extension::{extend_via_global_homography, ExtensionParams},
     validate::{validate, LabelledEntry, ValidationParams},
 };
 
@@ -62,22 +66,25 @@ let _result = validate(&entries, cell_size, &ValidationParams::default());
 
 The chessboard / ChArUco / PuzzleBoard detectors in the workspace
 implement their pattern-specific `GrowValidator` and call the same
-machinery; their orchestrators iterate Stage 5–7 with a blacklist until
-the labelled set converges, then run Stage 6, then re-validate.
+machinery. Their orchestrators iterate grow + validate with a
+blacklist until the labelled set converges, then run boundary
+extension, then re-validate.
 
-### Alternative Stage 6: local homography
+### Local-homography boundary extension
 
-`extend_via_local_homography` (in `square::grow_extension`) is an
-opt-in replacement for `extend_via_global_homography`. Instead of
-fitting one global H, it fits a separate H from the K nearest labelled
-corners for each candidate cell. The per-candidate trust gate tolerates
-heavy radial distortion and multi-region perspective where a single H
-breaks. Configure it via `LocalExtensionParams`.
+`square::extension::extend_via_local_homography` is the per-candidate
+counterpart to `extend_via_global_homography`. Instead of fitting one
+global `H`, it fits a separate `H` from the `K` nearest labelled
+corners for each candidate cell. The per-candidate worst-residual
+gate tolerates heavy radial distortion and multi-region perspective
+where a single `H` breaks. Configured via `LocalExtensionParams`.
 
-### Topological pipeline
+### Topological grid finder
 
-For images where corners arrive in a dense, nearly-regular cloud, the
-topological pipeline is an image-free alternative to seed-and-grow:
+`projective_grid::build_grid_topological` is the image-free Shu /
+Brunton / Fiala 2009 grid finder: Delaunay triangulation, edge
+classification by per-edge axis match, triangle-pair → quad merge,
+and flood-fill `(i, j)` labelling.
 
 ```rust
 use projective_grid::{build_grid_topological, merge_components_local,
@@ -93,8 +100,12 @@ let views: Vec<ComponentInput<'_>> = topo.components.iter()
 let merged = merge_components_local(&views, &LocalMergeParams::default());
 ```
 
-See `docs/TOPOLOGICAL_PIPELINE.md` in the workspace for a detailed
-description of the algorithm and known limitations.
+See `docs/TOPOLOGICAL_PIPELINE.md` in the workspace for the per-stage
+algorithm description and known limitations. The chessboard detector
+selects between the two pipelines via
+`DetectorParams::graph_build_algorithm`; ChArUco unconditionally
+pins seed-and-grow because marker-internal corners poison the per-cell
+axis test the topological path relies on.
 
 ## Inputs and outputs
 

--- a/crates/projective-grid/benches/homography.rs
+++ b/crates/projective-grid/benches/homography.rs
@@ -73,5 +73,45 @@ fn bench_dlt(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_4pt, bench_dlt);
+/// K values that match the per-cell hot path in
+/// `extend_via_local_homography`: `min_k=4..8` and `k_nearest=8..12`
+/// from `LocalExtensionParams` defaults and sweep variants. The bench
+/// covers K=8 / 12 / 20 to bracket the realistic range.
+fn bench_dlt_local_extension_sizes(c: &mut Criterion) {
+    let mut group = c.benchmark_group("estimate_homography_local_extension");
+    let h = truth_homography();
+    for &k in &[8usize, 12, 20] {
+        // K points scattered on a grid scale comparable to the labelled
+        // corners that feed the per-candidate fit. Use a fractional-row
+        // grid so non-square K values still place points sanely.
+        let mut src: Vec<Point2<f32>> = Vec::with_capacity(k);
+        let cols = (k as f32).sqrt().ceil() as usize;
+        for idx in 0..k {
+            let i = idx % cols;
+            let j = idx / cols;
+            src.push(Point2::new(i as f32 * 30.0, j as f32 * 30.0));
+        }
+        let dst: Vec<Point2<f32>> = src.iter().map(|&p| h.apply(p)).collect();
+
+        group.bench_function(format!("K={k}"), |b| {
+            b.iter(|| black_box(estimate_homography(black_box(&src), black_box(&dst))));
+        });
+        group.bench_function(format!("K={k}+quality"), |b| {
+            b.iter(|| {
+                black_box(estimate_homography_with_quality(
+                    black_box(&src),
+                    black_box(&dst),
+                ))
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_4pt,
+    bench_dlt,
+    bench_dlt_local_extension_sizes
+);
 criterion_main!(benches);

--- a/crates/projective-grid/src/homography.rs
+++ b/crates/projective-grid/src/homography.rs
@@ -1,6 +1,6 @@
 use crate::float_helpers::lit;
 use crate::Float;
-use nalgebra::{DMatrix, Matrix3, Point2, SMatrix, SVector, Vector3};
+use nalgebra::{Matrix3, Point2, SMatrix, SVector, Vector3};
 
 /// A 3×3 projective homography matrix.
 ///
@@ -260,34 +260,63 @@ pub fn estimate_homography<F: Float>(
     let (im, ti) = normalize_points(dst_pts);
 
     let n = src_pts.len();
-    let rows = 2 * n;
-    let mut a = DMatrix::<F>::zeros(rows, 9);
+    let zero = F::zero();
+    let neg_one = -F::one();
 
+    // Accumulate Aᵀ A directly into a stack 9×9 without ever
+    // materialising the (2N × 9) matrix A. For correspondence
+    // `(x, y) ↦ (u, v)` the two DLT rows are
+    //   row₂ₖ   = [-x, -y, -1,  0,  0,  0, ux, uy, u]
+    //   row₂ₖ₊₁ = [ 0,  0,  0, -x, -y, -1, vx, vy, v]
+    // and Aᵀ A = Σₖ (rowᵀ row) summed over both rows of each pair.
+    let mut m: SMatrix<F, 9, 9> = SMatrix::zeros();
     for k in 0..n {
         let x = r[k].x;
         let y = r[k].y;
         let u = im[k].x;
         let v = im[k].y;
 
-        a[(2 * k, 0)] = -x;
-        a[(2 * k, 1)] = -y;
-        a[(2 * k, 2)] = -F::one();
-        a[(2 * k, 6)] = u * x;
-        a[(2 * k, 7)] = u * y;
-        a[(2 * k, 8)] = u;
-
-        a[(2 * k + 1, 3)] = -x;
-        a[(2 * k + 1, 4)] = -y;
-        a[(2 * k + 1, 5)] = -F::one();
-        a[(2 * k + 1, 6)] = v * x;
-        a[(2 * k + 1, 7)] = v * y;
-        a[(2 * k + 1, 8)] = v;
+        let row1 = SVector::<F, 9>::from_column_slice(&[
+            -x,
+            -y,
+            neg_one,
+            zero,
+            zero,
+            zero,
+            u * x,
+            u * y,
+            u,
+        ]);
+        let row2 = SVector::<F, 9>::from_column_slice(&[
+            zero,
+            zero,
+            zero,
+            -x,
+            -y,
+            neg_one,
+            v * x,
+            v * y,
+            v,
+        ]);
+        m += row1 * row1.transpose();
+        m += row2 * row2.transpose();
     }
 
-    let svd = a.svd(true, true);
-    let vt = svd.v_t?;
-    let last = vt.nrows().checked_sub(1)?;
-    let h = vt.row(last);
+    // The right singular vector of A for σ_min is the eigenvector of
+    // Aᵀ A for the smallest eigenvalue: A = U Σ Vᵀ ⇒ Aᵀ A = V Σ² Vᵀ.
+    // Hartley normalisation keeps cond(A) ≲ 10³, so cond(Aᵀ A) ≲ 10⁶ —
+    // comfortably within f32 precision. Sign is unconstrained here but
+    // pinned downstream by `normalize_homography` dividing by h[(2,2)].
+    let eig = m.symmetric_eigen();
+    let mut min_idx = 0usize;
+    let mut min_val = eig.eigenvalues[0];
+    for k in 1..9 {
+        if eig.eigenvalues[k] < min_val {
+            min_val = eig.eigenvalues[k];
+            min_idx = k;
+        }
+    }
+    let h = eig.eigenvectors.column(min_idx);
 
     let hn = Matrix3::<F>::from_row_slice(&[h[0], h[1], h[2], h[3], h[4], h[5], h[6], h[7], h[8]]);
 
@@ -611,5 +640,171 @@ mod tests {
             assert!((a.x - b.x).abs() < 1e-8);
             assert!((a.y - b.y).abs() < 1e-8);
         }
+    }
+
+    /// Reference DLT path matching the SVD-based implementation that
+    /// existed before the normal-equations + 9×9 sym-eig rewrite. Kept
+    /// inline so the cross-check test below has a frozen baseline that
+    /// the production path can drift away from only within the
+    /// numerical-equivalence contract.
+    fn dlt_via_svd_reference(
+        src_pts: &[Point2<f32>],
+        dst_pts: &[Point2<f32>],
+    ) -> Option<Homography<f32>> {
+        if src_pts.len() != dst_pts.len() || src_pts.len() < 4 {
+            return None;
+        }
+        let (r, tr) = normalize_points(src_pts);
+        let (im, ti) = normalize_points(dst_pts);
+
+        let n = src_pts.len();
+        let rows = 2 * n;
+        let mut a = nalgebra::DMatrix::<f32>::zeros(rows, 9);
+        for k in 0..n {
+            let x = r[k].x;
+            let y = r[k].y;
+            let u = im[k].x;
+            let v = im[k].y;
+            a[(2 * k, 0)] = -x;
+            a[(2 * k, 1)] = -y;
+            a[(2 * k, 2)] = -1.0;
+            a[(2 * k, 6)] = u * x;
+            a[(2 * k, 7)] = u * y;
+            a[(2 * k, 8)] = u;
+
+            a[(2 * k + 1, 3)] = -x;
+            a[(2 * k + 1, 4)] = -y;
+            a[(2 * k + 1, 5)] = -1.0;
+            a[(2 * k + 1, 6)] = v * x;
+            a[(2 * k + 1, 7)] = v * y;
+            a[(2 * k + 1, 8)] = v;
+        }
+        let svd = a.svd(true, true);
+        let vt = svd.v_t?;
+        let last = vt.nrows().checked_sub(1)?;
+        let h = vt.row(last);
+        let hn =
+            Matrix3::<f32>::from_row_slice(&[h[0], h[1], h[2], h[3], h[4], h[5], h[6], h[7], h[8]]);
+        let h_den = denormalize_homography(hn, tr, ti)?;
+        let h_den = normalize_homography(h_den)?;
+        Some(Homography::new(h_den))
+    }
+
+    /// Tiny deterministic xorshift32 PRNG so the random-battery test
+    /// is reproducible without pulling in a `rand` dev-dependency for
+    /// one helper.
+    struct XorShift32(u32);
+    impl XorShift32 {
+        fn new(seed: u32) -> Self {
+            Self(seed.max(1))
+        }
+        fn next_u32(&mut self) -> u32 {
+            let mut x = self.0;
+            x ^= x << 13;
+            x ^= x >> 17;
+            x ^= x << 5;
+            self.0 = x;
+            x
+        }
+        /// Uniform draw in `(-1, 1)`.
+        fn unit(&mut self) -> f32 {
+            (self.next_u32() as f32 / u32::MAX as f32) * 2.0 - 1.0
+        }
+    }
+
+    #[test]
+    fn dlt_matches_old_svd_path_on_random_battery() {
+        // Forward-error contract: for a random battery of well-
+        // conditioned ground-truth homographies, the new
+        // normal-equations + 9×9 sym-eig path produces warped points
+        // that agree with the SVD reference to ≤ 0.01 px on a 100-px
+        // scale (equivalent to ~1e-4 relative). Both paths likewise
+        // agree with the ground-truth H to ≤ 0.01 px. Comparing in
+        // pixel-domain is the contract that actually matters
+        // downstream: H is consumed via `apply(...)` to predict cell
+        // positions, never read entry-by-entry.
+        //
+        // Per-entry relative error on `H` itself can drift up to ~1e-3
+        // because Hartley-normalised cond(A) ≈ 10²-10³ and the
+        // normal-equations route squares it (cond(AᵀA) ≈ 10⁴-10⁶);
+        // in f32 the resulting backward error on the smallest
+        // eigenvector can hit 1e-3 on individual entries. The
+        // pixel-domain test absorbs the gauge-like cancellation that
+        // makes per-entry comparison overly pessimistic.
+        let mut rng = XorShift32::new(42);
+
+        let mut max_fwd_err_new = 0.0f32;
+        let mut max_fwd_err_ref = 0.0f32;
+        let mut max_pair_err = 0.0f32;
+        let mut sample_count = 0usize;
+
+        for _ in 0..1000 {
+            // Random ground-truth H with mild perspective.
+            let gt = Homography::new(Matrix3::new(
+                1.0 + 0.5 * rng.unit(),
+                0.2 * rng.unit(),
+                50.0 * rng.unit(),
+                0.2 * rng.unit(),
+                1.0 + 0.5 * rng.unit(),
+                50.0 * rng.unit(),
+                0.001 * rng.unit(),
+                0.001 * rng.unit(),
+                1.0,
+            ));
+            // 12 source points uniformly on ~cell-grid scale.
+            let src: Vec<Point2<f32>> = (0..12)
+                .map(|_| Point2::new(100.0 * rng.unit(), 100.0 * rng.unit()))
+                .collect();
+            let dst: Vec<Point2<f32>> = src.iter().map(|&p| gt.apply(p)).collect();
+
+            let Some(new_h) = estimate_homography(&src, &dst) else {
+                continue;
+            };
+            let Some(ref_h) = dlt_via_svd_reference(&src, &dst) else {
+                continue;
+            };
+
+            // Forward errors against ground truth at the source points.
+            for &p in &src {
+                let new_p = new_h.apply(p);
+                let ref_p = ref_h.apply(p);
+                let gt_p = gt.apply(p);
+                let new_err = ((new_p.x - gt_p.x).powi(2) + (new_p.y - gt_p.y).powi(2)).sqrt();
+                let ref_err = ((ref_p.x - gt_p.x).powi(2) + (ref_p.y - gt_p.y).powi(2)).sqrt();
+                let pair_err = ((new_p.x - ref_p.x).powi(2) + (new_p.y - ref_p.y).powi(2)).sqrt();
+                if new_err > max_fwd_err_new {
+                    max_fwd_err_new = new_err;
+                }
+                if ref_err > max_fwd_err_ref {
+                    max_fwd_err_ref = ref_err;
+                }
+                if pair_err > max_pair_err {
+                    max_pair_err = pair_err;
+                }
+            }
+
+            sample_count += 1;
+        }
+
+        assert!(
+            sample_count > 900,
+            "expected most random samples to be valid, got {sample_count}"
+        );
+        // Both paths agree with ground truth to well below 0.01 px on
+        // a 100-px scale.
+        assert!(
+            max_fwd_err_new < 1e-2,
+            "new path max forward error {max_fwd_err_new} px exceeds 1e-2"
+        );
+        assert!(
+            max_fwd_err_ref < 1e-2,
+            "reference SVD max forward error {max_fwd_err_ref} px exceeds 1e-2"
+        );
+        // New vs reference: similarly bounded since both are within
+        // their backward-error budget against gt.
+        assert!(
+            max_pair_err < 1e-2,
+            "new vs reference max pixel divergence {max_pair_err} px exceeds 1e-2"
+        );
     }
 }

--- a/crates/projective-grid/src/square/extension/local.rs
+++ b/crates/projective-grid/src/square/extension/local.rs
@@ -10,7 +10,7 @@ use std::collections::{HashMap, HashSet};
 use kiddo::{KdTree, SquaredEuclidean};
 use nalgebra::Point2;
 
-use crate::homography::estimate_homography_with_quality;
+use crate::homography::estimate_homography;
 use crate::square::extension::common::{try_attach_at_cell, TryCellResult};
 use crate::square::extension::{ExtensionStats, LocalExtensionParams};
 use crate::square::grow::{GrowResult, GrowValidator};
@@ -89,7 +89,7 @@ pub fn extend_via_local_homography<V: GrowValidator>(
                 .collect();
             let img_pts: Vec<Point2<f32>> =
                 nearest.iter().map(|&(_, _, idx)| positions[idx]).collect();
-            let Some((h, _)) = estimate_homography_with_quality(&grid_pts, &img_pts) else {
+            let Some(h) = estimate_homography(&grid_pts, &img_pts) else {
                 continue;
             };
 

--- a/docs/changelog/0.1.x.md
+++ b/docs/changelog/0.1.x.md
@@ -1,0 +1,11 @@
+# 0.1.x release notes
+
+Archived release notes for the `0.1.x` series. The active changelog lives in
+[`/CHANGELOG.md`](../../CHANGELOG.md).
+
+## [0.1.2]
+- Speed up marker circle scoring with LUT-based sampling and a center precheck.
+- Add a fast in-bounds bilinear sampling helper for hot paths.
+
+## [0.1.1]
+- Initial public release of the calib-targets crates.

--- a/docs/changelog/0.2.x.md
+++ b/docs/changelog/0.2.x.md
@@ -1,0 +1,51 @@
+# 0.2.x release notes
+
+Archived release notes for the `0.2.x` series. The active changelog lives in
+[`/CHANGELOG.md`](../../CHANGELOG.md).
+
+## [0.2.5]
+- Maintenance release: bump crate versions to `0.2.5`.
+
+## [0.2.4]
+- Fix ChArUco false-corner detection: ArUco marker-interior saddle points
+  could displace true chessboard-grid corners in the graph BFS and produce
+  ChArUco corners with correct IDs but wrong pixel positions.
+- Add marker-constrained corner validation stage in `calib-targets-charuco`:
+  estimates a board-to-image homography from all inlier marker corners and
+  flags corners whose reprojection error exceeds `corner_validation_threshold_rel
+  * px_per_square` (default 8%). Flagged corners are re-detected via a local
+  ChESS patch search seeded at the projected position.
+- Add `corner_validation_threshold_rel` and `corner_redetect_params` to
+  `CharucoDetectorParams`.
+- Add `chess-corners-core` as a production dependency of `calib-targets-charuco`.
+
+## [0.2.3]
+- Python bindings: switch to a mixed Rust/Python package layout with private
+  extension module `calib_targets._core` and typed public package sources.
+- Python API: hard reset to a dataclass-first surface with typed-only config
+  inputs and typed detector result objects.
+- Add `to_dict()` / `from_dict(...)` compatibility helpers on public config and
+  result models.
+- Add generated typing artifacts (`_core.pyi`, dictionary literal definitions)
+  and a generator script with `--check` mode for CI.
+- Add Python type-check smoke coverage (Pyright + mypy) in CI.
+
+## [0.2.2]
+- Remove redundant ChArUco board parameter; board spec now lives in params for Rust and Python APIs.
+- `CharucoDetector::new` now takes only `CharucoDetectorParams`.
+- Add typed Python classes for `CharucoBoardSpec`, `MarkerBoardLayout`, and `MarkerCircleSpec`.
+- Make Python config classes mutable via settable attributes.
+- Document authoritative Python output schema in `crates/calib-targets-py/README.md`.
+
+## [0.2.1]
+- Add Python-friendly config/params classes with IDE signatures while keeping dict overrides.
+- Allow partial dict overrides for detector params without specifying full structs.
+- Validate unknown keys in Python config dicts with clearer error paths.
+- Improve Python conversion errors to include parameter paths and accept NumPy scalars.
+
+## [0.2.0]
+- Document the Python bindings across the workspace README, crate readmes, and book.
+- Clarify marker-board `cell_size` usage so `target_position` is populated when alignment succeeds.
+- Fix macOS Python binding linking via a PyO3 build script.
+- Refresh PyO3 bindings to the Bound API to remove deprecation warnings.
+- Bump `chess-corners` dependency to v0.3.

--- a/docs/changelog/0.3.x.md
+++ b/docs/changelog/0.3.x.md
@@ -1,0 +1,127 @@
+# 0.3.x release notes
+
+Archived release notes for the `0.3.x` series. The active changelog lives in
+[`/CHANGELOG.md`](../../CHANGELOG.md).
+
+## [0.3.2]
+
+### ChArUco — local grid smoothness pre-filter
+
+- **New `grid_smoothness` module** in `calib-targets-charuco`: runs between
+  `build_corner_map` and `build_marker_cells` to detect corners whose pixel
+  position is inconsistent with their grid neighbors (midpoint prediction).
+  This catches false corners from ArUco marker internal features picked up by
+  ChESS under a loose orientation tolerance (e.g. 22.5°).  Flagged corners are
+  re-detected locally via `redetect_corner_in_roi`; if re-detection fails, the
+  corner is snapped to the predicted position (never removed) so that marker
+  cell completeness — and thus marker detection recall — is preserved.
+- **New `grid_smoothness_threshold_rel` parameter** on
+  `CharucoDetectorParams` (default `0.05`, i.e. 3 px at 60 px/sq).
+  Set to `f32::INFINITY` to disable.  Also exposed in the FFI
+  (`ct_charuco_detector_params_t`) with the same default.
+- Promote `redetect_corner_in_roi` from private to `pub(crate)` in
+  `corner_validation.rs` so the grid smoothness module can reuse it.
+
+## [0.3.1]
+
+### Chessboard grid graph — perspective-invariant neighbor direction fix
+
+- **Fix direction symmetry in `is_good_neighbor_with_orientation`**: the old
+  code indexed diagonal directions by the source/neighbor cluster index
+  (`grid_diagonals[ci]` / `grid_diagonals[cj]`), so the sign of `v_minus = oi
+  - oj` depended on which corner was the "source" and which was the "neighbor".
+  This broke the A→B Right ↔ B→A Left invariant the BFS relies on, causing
+  spurious disconnected components and missing grid edges on rotated or
+  perspective-distorted boards.
+- **Canonical reference frame**: switch to `grid_diagonals[0]` and
+  `grid_diagonals[1]` (independent of edge direction) so all edges in the graph
+  share the same `v_plus`/`v_minus` axes. Canonicalize the sign of `v_minus`
+  via the cross-product determinant so that `(v_minus, v_plus)` always form a
+  right-handed frame in image coordinates, regardless of the arbitrary order
+  produced by orientation clustering.
+- **Perspective-invariant direction classification**: replace the image-space
+  `direction_quadrant` heuristic (which broke for rotated boards) with signed
+  dot products against the local grid axes. The resulting Right/Left/Down/Up
+  labels are now consistent with the local grid geometry under perspective, not
+  just when the board is nearly axis-aligned.
+- Add a `rotated_grid_forms_single_component` unit test that constructs a 4×4
+  corner grid at an arbitrary 40° rotation and verifies the graph BFS produces
+  a single connected component with correct grid coordinates.
+
+### ChArUco marker detection — improved recall on blurry images
+
+- **Multi-threshold binarization**: the marker decode step now tries multiple
+  binarization thresholds per cell (Otsu, Otsu±10, Otsu±15, two percentile
+  thresholds, and a border-guided midpoint) and selects the one that yields a
+  valid dictionary match with hamming=0. This recovers markers that were
+  previously lost on blurry or unevenly-lit images because a single Otsu
+  threshold flipped one or two border or payload bits. Controlled by the new
+  `ScanDecodeConfig::multi_threshold` field (default `true`); exposed as
+  `ArucoScanConfig::multi_threshold` for JSON-level overrides.
+- **Lower default `min_border_score` for ChArUco**: the per-cell border-black
+  ratio threshold is now `0.75` (was `0.85`) in `CharucoDetectorParams::for_board`.
+  The downstream alignment and corner-validation stages already act as
+  false-positive guards, so the looser scan-stage bar improves recall without
+  introducing spurious detections.
+- Add `percentile_threshold`, `border_guided_threshold`, and
+  `compute_threshold_candidates` helper functions to `calib-targets-aruco`
+  (crate-private).
+- Move `log` from a dev-dependency to a regular dependency in
+  `calib-targets-aruco` to support debug logging in production builds.
+
+### Diagnostic logging across the detection pipeline
+
+- **`calib-targets-chessboard`**: add `log::debug!` at every significant
+  rejection point in the chessboard detector — early corner count check,
+  post-orientation-filter count, per-component BFS/grid-fit/completeness
+  rejections, and the accepted-candidate summary. Add `log_graph_summary`
+  helper that logs grid-graph component sizes and node-degree distribution.
+- **`calib-targets-charuco` pipeline**: add `log::debug!` / `log::warn!` at
+  each stage — chessboard success/failure (with config details on failure),
+  marker sampling cell counts, scan result count, alignment result (transform +
+  inlier count), pre- and post-validation corner counts. Failed-cell details
+  (border-score, observed code) now logged at `debug` level from
+  `scan_decode_markers_in_cells`.
+- **`charuco_detect` example**: switch default log level to `debug`; add
+  config-echo logging on startup.
+
+## [0.3.0]
+
+### Printable targets
+
+- Add the dedicated `calib-targets-print` crates.io crate to the coordinated
+  Rust release flow and document it as a first-class published printable-target
+  entry point alongside `calib_targets::printable`.
+- Add a canonical printable-target guide with JSON, Rust, CLI, and Python
+  flows, output-bundle expectations, and print-at-100%-scale guidance.
+- Productize the repo-local `calib-targets-cli` workflow with
+  `list-dictionaries` and `validate`, clearer help text, and integration
+  coverage for discover/init/validate/generate flows.
+- Add explicit millimeter-aware conversions from `CharucoBoardSpec` and
+  `MarkerBoardLayout` into printable target specs and printable documents.
+
+### Native C API
+
+- Add the repo-local `calib-targets-ffi` crate and generated public C header
+  for native consumers. The FFI crate remains `publish = false` and is built
+  from the workspace rather than distributed on crates.io.
+- Add fixed-struct C detector APIs for chessboard, ChArUco, and checkerboard
+  marker-board detection over 8-bit grayscale images, with opaque handles,
+  explicit status codes, caller-owned query/fill buffers, full ChESS
+  configuration, and built-in dictionary names only.
+- Add repo-owned native validation for the C API: generated-header drift
+  checks, a plain C smoke example, a thin header-only C++17 RAII
+  wrapper/example, and a Cargo-driven smoke test that compiles and runs
+  external C and C++ consumers against the built shared library.
+- Add repo-local ergonomic C++/CMake consumer packaging: stage Cargo-built
+  artifacts into a deterministic CMake package prefix, export
+  `calib_targets_ffi::c` and `calib_targets_ffi::cpp` targets, and validate a
+  repo-owned `find_package(...)` consumer example in CI.
+- Add tagged native release assets for `calib-targets-ffi`: supported GitHub
+  releases now attach per-platform archives containing the staged `include/`,
+  `lib/`, and `lib/cmake/` prefix so downstream C/C++ consumers can integrate
+  without building Rust from source.
+- Clarify current native-consumer boundaries: the release archives are the
+  supported distribution format for Linux, macOS, and Windows tags, but there
+  is still no crates.io/package-manager distribution, installer flow, or signed
+  native package.

--- a/docs/changelog/0.4.x.md
+++ b/docs/changelog/0.4.x.md
@@ -1,0 +1,78 @@
+# 0.4.x release notes
+
+Archived release notes for the `0.4.x` series. The active changelog lives in
+[`/CHANGELOG.md`](../../CHANGELOG.md).
+
+## [0.4.2]
+
+### Release engineering
+
+- Technical release: bump coordinated crate versions to `0.4.2` after
+  publish-workflow fixes.
+
+## [0.4.1]
+
+### Release engineering
+
+- Technical release: bump coordinated crate versions to `0.4.1` to fix
+  publication issues.
+
+## [0.4.0]
+
+### Standalone `projective-grid` crate
+
+- Add the new publishable [`projective-grid`](https://crates.io/crates/projective-grid)
+  crate for pattern-agnostic 2D grid tooling: pluggable `NeighborValidator`
+  traits, grid graph construction, connected-component traversal, BFS grid
+  coordinate assignment, homography estimation, global rectification, per-cell
+  mesh rectification, and grid smoothness prediction.
+- Extract the generic square-grid geometry and homography machinery from
+  `calib-targets-core` into `projective-grid`. `calib-targets-core` keeps the
+  image-space pieces (`GrayImage*`, sampling, `warp_perspective_gray`) and
+  re-exports `Homography`, `GridCoords` (`GridIndex` alias), `GridAlignment`,
+  `GridTransform`, and homography-estimation helpers for downstream
+  compatibility.
+- Refactor `calib-targets-chessboard` to delegate grid-graph construction and
+  traversal to `projective-grid`, while keeping chessboard-specific neighbor
+  validation in-crate. Switch ChArUco grid smoothness to the shared
+  `projective_grid::predict_grid_position` helper instead of maintaining a
+  separate midpoint-prediction implementation.
+
+### Hex grids and built-in validators
+
+- Add `projective_grid::hex` with pointy-top axial-coordinate support for
+  6-connected graph construction, BFS coordinate assignment, grid smoothness
+  prediction, `D6` alignment transforms, `HexGridHomography`, and
+  `HexGridHomographyMesh` for per-triangle affine/projective rectification.
+- Add ready-to-use validator implementations in
+  `projective_grid::validators`:
+  `XJunctionValidator` for ChESS-like oriented square-grid corners,
+  `SpatialSquareValidator` for unoriented square lattices, and
+  `SpatialHexValidator` for unoriented hex lattices such as ringgrids.
+
+### Native C API and bindings
+
+- Expose `ScanDecodeConfig::multi_threshold` in the FFI as
+  `ct_scan_decode_config_t::multi_threshold` so native callers can control the
+  multi-threshold marker decode path instead of being forced to the Rust
+  default.
+- Add native test coverage that verifies `ct_scan_decode_config_t` preserves
+  the `multi_threshold` flag when converting into the Rust
+  `ScanDecodeConfig`.
+- Make the Python typing-artifact generator robust to multiline
+  `#[pyclass(...)]` attributes so generated `_core.pyi` stubs stay in sync
+  after adding `skip_from_py_object` to config-heavy binding classes.
+
+### Workspace and release engineering
+
+- Centralize shared crate metadata and dependency versions in the workspace
+  root via `[workspace.package]` and `[workspace.dependencies]` so the Rust
+  crates inherit coordinated `0.4` versioning and one dependency set.
+- Raise the documented MSRV to Rust `1.88` and surface it in the workspace
+  metadata and top-level README badge.
+- Update docs and packaging references from `0.3` to `0.4`, including the
+  getting-started dependency snippets and the coordinated Rust/Python/native
+  release metadata.
+- Include `projective-grid` in the coordinated crates.io release flow and add
+  CI validation that the publish order matches inter-crate dependencies before
+  attempting the tagged publish job.

--- a/docs/changelog/0.5.x.md
+++ b/docs/changelog/0.5.x.md
@@ -1,0 +1,120 @@
+# 0.5.x release notes
+
+Archived release notes for the `0.5.x` series. The active changelog lives in
+[`/CHANGELOG.md`](../../CHANGELOG.md).
+
+## [0.5.3]
+
+### Fixes
+
+- **Python bindings:** fix `MarkerDetection.gc` deserialization. Rust emits
+  `{"i","j"}` (from `GridCoords`), but the Python wrapper was typed as a
+  separate `GridCell` dataclass requiring `{"gx","gy"}`, so every
+  `detect_charuco` call with markers crashed in `from_dict`. Dropped the
+  redundant `GridCell` type; `MarkerDetection.gc` now uses `GridCoords`,
+  matching `LabeledCorner.grid` and `CircleCandidate.cell`.
+- Added `python_tests/test_detect_roundtrip.py` that runs the real extension
+  on repo test images and round-trips result dicts, so Rust/Python dict-key
+  drift fails loudly instead of being masked by hand-written fixtures.
+
+## [0.5.2]
+
+### Changed
+
+- **`projective-grid`:** all public types and functions are now generic over
+  floating-point type (`f32` / `f64`). All types default to `f32`, so existing
+  code compiles unchanged. New `Float` trait alias (`RealField + Copy`) is
+  re-exported from the crate root.
+- `Homography` internal matrix is now `Matrix3<F>` (previously always `f64`).
+  For `f32` users this means slightly less internal precision but no
+  cross-type conversions; `f64` users get full double-precision throughout.
+
+## [0.5.1]
+
+### Fixes
+
+- Fix FFI C++ consumer examples: `config.graph.*` → `config.chessboard.graph.*`
+  after API redesign nested `GridGraphParams` inside `ChessboardParams`.
+- Fix broken intra-doc links (`detect_from_corners`, `min_marker_inliers`).
+- Fix `cargo doc` binary name collision by adding `doc = false` to CLI bin.
+- Regenerate FFI header and Python typing stubs after `#[non_exhaustive]` changes.
+- Add `detect_*_best` sweep functions to Python and WASM bindings.
+- Document pre-release quality gates in CLAUDE.md.
+
+## [0.5.0]
+
+### API redesign
+
+- **Breaking:** `ChessConfig` is now embedded inside each detector's params struct.
+  Facade `detect_*` functions take a single `&Params` argument instead of
+  separate `(&ChessConfig, Params)`. Removed `detect_charuco_default` and
+  `detect_marker_board_default`.
+- **Breaking:** `CharucoDetectorParams` renamed to `CharucoParams`.
+- **Breaking:** `CharucoParams.charuco` field renamed to `.board`.
+- **Breaking:** `MarkerBoardLayout` renamed to `MarkerBoardSpec`.
+- **Breaking:** `GridCell` replaced with `GridCoords` in aruco crate.
+  `BoardCell` removed.
+- Add multi-config sweep API: `detect_chessboard_best`, `detect_charuco_best`,
+  `detect_marker_board_best` try multiple parameter configs and return the best
+  result (most markers, then most corners).
+- Add `CharucoParams::sweep_for_board()` and `ChessboardParams::sweep_default()`
+  presets for common multi-threshold sweep scenarios.
+- Extract shared `calib_targets_core::io::{load_json, write_json, IoError}` to
+  replace duplicated IO boilerplate across crates.
+- Python and WASM bindings accept the new single-config API. The `chess_cfg`
+  parameter is still accepted for backward compatibility (overrides
+  `params.chess` or `params.chessboard.chess` when provided).
+- Python: `CharucoParams` and `MarkerBoardSpec` are the canonical names;
+  `CharucoDetectorParams` and `MarkerBoardLayout` remain as aliases.
+
+### Multi-component ChArUco detection
+
+- Merge disconnected grid components for 30-50% more corners on challenging
+  images (Scheimpflug optics, narrow focus strips). Each component is aligned
+  independently via marker-based D4 rotation, then merged.
+
+### AprilTag max_hamming fix
+
+- `CharucoParams::for_board()` now sets `max_hamming` to
+  `min(2, dictionary.max_correction_bits)` instead of 0, improving recall for
+  AprilTag-based ChArUco boards (e.g. `DICT_APRILTAG_36h10`).
+
+### WebAssembly bindings and browser demo
+
+- Add the new `calib-targets-wasm` crate (`crates/calib-targets-wasm/`) with
+  `wasm-bindgen` exports for all detection pipelines: `detect_corners`,
+  `detect_chessboard`, `detect_charuco`, and `detect_marker_board`. The crate
+  depends directly on the detector crates and `chess-corners` (without `rayon`
+  or `ml-refiner`) so it compiles cleanly for `wasm32-unknown-unknown`.
+- Expose `rgba_to_gray` for browser canvas RGBA-to-grayscale conversion and
+  `default_chess_config` / `default_chessboard_params` /
+  `default_marker_board_params` helpers for populating UI defaults from Rust.
+- Config and result objects are passed as plain JS objects via
+  `serde-wasm-bindgen` (no JSON string round-trips).
+- WASM binary: ~436 KB raw, ~195 KB gzipped.
+- Add a React/TypeScript demo app at `demo/` (Vite 6, React 19) with:
+  image upload (drag-and-drop), detection mode selector (Corners / Chessboard /
+  ChArUco / Marker Board), interactive parameter sliders, canvas overlay with
+  colored corners and grid edges, and a results panel with timing and JSON view.
+- Add `wasm` CI job to `.github/workflows/ci.yml`: builds WASM with
+  `wasm-pack`, verifies output artifacts, and builds the demo app with
+  TypeScript checking.
+- Add `scripts/build-wasm.sh` helper to build WASM into `demo/pkg/`.
+- Add `default-members` to the root workspace manifest so `cargo test` excludes
+  the WASM crate by default.
+
+### Python bindings API refactoring
+
+- Flatten `ChessConfig` in Python: remove nested `ChessCornerParams`,
+  `CoarseToFineParams`, `PyramidParams`; all fields are now top-level with
+  concrete defaults. Add `RefinerConfig`, `CenterOfMassConfig`,
+  `ForstnerConfig`, `SaddlePointConfig`.
+- Fold `GridGraphParams` into `ChessboardParams` as `chessboard.graph` across
+  all Rust crates, Python bindings, FFI, and JSON configs.
+- Add `ChessboardDetectConfig` / `ChessboardDetectReport` and
+  `MarkerBoardDetectConfig` / `MarkerBoardDetectReport` for JSON-driven
+  detection workflows.
+- Rewrite `calib-targets-py/src/lib.rs` from ~3600 lines to ~290 lines using a
+  dict-based JSON bridge (Python dataclass `to_dict()` -> `serde_json` ->
+  Rust type). Remove all `*Source` enums, `*Overrides` structs, and manual
+  extraction functions.

--- a/docs/changelog/0.6.x.md
+++ b/docs/changelog/0.6.x.md
@@ -1,0 +1,80 @@
+# 0.6.x release notes
+
+Archived release notes for the `0.6.x` series. The active changelog lives in
+[`/CHANGELOG.md`](../../CHANGELOG.md).
+
+## [0.6.0]
+
+Coordinated workspace release that ships the new
+`calib-targets-puzzleboard` crate. `calib-targets-core` adds the
+`TargetKind::PuzzleBoard` variant, which is a non-additive change to a
+`#[non_exhaustive]` enum but bumps the workspace minor version anyway so
+all crates publish in lockstep at `0.6.0`.
+
+### Added
+
+- Add first-class PuzzleBoard support with a new
+  `calib-targets-puzzleboard` crate. The detector samples edge-midpoint code
+  dots on a chessboard grid, decodes the embedded 501 x 501 master pattern,
+  and returns absolute corner IDs plus target-space positions.
+- Add `TargetKind::PuzzleBoard` variant in `calib-targets-core` so the new
+  detector can populate `TargetDetection.kind`.
+- Add committed PuzzleBoard code-map blobs, generation/verification tools,
+  synthetic and real-image regression tests, and generated PuzzleBoard
+  testdata.
+- Ship the PStelldinger/PuzzleBoard author-canonical `code1`/`code2` maps
+  (`map_a.bin` / `map_b.bin`) and a new `import_author_maps.rs` tool so the
+  shipped maps match the upstream reference implementation; add
+  `tests/interop_authors.rs` to keep the maps byte-compatible.
+- Add PuzzleBoard printable target generation through `calib-targets-print`,
+  including JSON/SVG/PNG output bundles and Python printable dataclasses.
+- Add PuzzleBoard facade helpers, Rust examples, Python bindings, WASM
+  bindings, FFI C ABI structs/functions, and regenerated native headers.
+- Add PuzzleBoard documentation in the crate README, workspace README,
+  mdBook, and release/development command references.
+- Add `PuzzleBoardSearchMode::FixedBoard`. Matches observations directly
+  against the declared board's own bit pattern (derived from
+  `PuzzleBoardSpec` at decode time) under `8 × (rows+1)²` candidate
+  shifts, so any partial view of that specific board decodes to the same
+  master IDs a full-view decode would produce. Cheaper than `Full` for
+  small boards and fast enough for the large ones. Default stays `Full`;
+  opt in via `params.decode.search_mode = PuzzleBoardSearchMode::FixedBoard`.
+  Mirrored in the Python dataclass and WASM TypeScript types; FFI stays
+  on `Full`.
+- Add `cargo bench -p calib-targets --bench puzzleboard_sizes` (criterion
+  comparison of `Full` vs `FixedBoard` across sizes 6, 8, 10, 12, 13, 16,
+  20, 30) and `cargo run --release -p calib-targets --example
+  puzzleboard_size_sweep` (per-stage success/failure/timing table used to
+  pinpoint which pipeline stage a given board size fails at).
+- Overlay every decoded PuzzleBoard edge-bit dot in the WASM demo: sky-blue
+  ring around `bit=1` (white puzzle dot), orange ring around `bit=0` (black
+  puzzle dot), opacity scaled by per-bit confidence.
+
+### Fixed
+
+- Filter PuzzleBoard decode candidates by bit-error rate before selecting the
+  best weighted score, avoiding false negatives when a higher-score candidate
+  exceeds the configured error budget.
+- Re-check the PuzzleBoard minimum edge count after confidence filtering so
+  weak edge samples cannot pass into the decoder as an undersized window.
+- Demo dev server no longer 404s on `calib_targets_wasm_bg.wasm` — Vite's
+  esbuild pre-bundler was rewriting the JS into `.vite/deps/` without
+  copying the sibling `.wasm`, so the `new URL(..., import.meta.url)` fetch
+  hit the SPA fallback. Fixed by adding `calib-targets-wasm` to
+  `optimizeDeps.exclude`.
+- Demo `ResultsPanel` grid readout now reports `max − min + 1` instead of
+  `max + 1`, so a 10 × 10 PuzzleBoard no longer displays as "177 × 177"
+  (master-grid indices start near 167).
+- Demo PuzzleBoard edge-bit overlay now maps `observed_edges` from local to
+  master coordinates via the alignment's D4 + translation before looking up
+  corners, fixing the previously empty overlay.
+- Fix `GridAlignment.transform` TypeScript type in the WASM demo (was
+  `string`; actual serde shape is `{a, b, c, d}`).
+
+### Changed
+
+- Demo toolchain switched from `npm` to `bun` (`demo/bun.lock` is the
+  committed lockfile; `demo/package-lock.json` removed). CI wasm job now
+  uses `oven-sh/setup-bun` + `bun install --frozen-lockfile`.
+- `.claude/CLAUDE.md` gains the new bench + diagnostic example commands
+  and documents the `bun` switch.


### PR DESCRIPTION
## Summary

- **Commit A** drops a wasted 3×3 quality SVD in `extend_via_local_homography` — the call site already discarded `HomographyQuality` (`let Some((h, _)) = ...`) and trust-gates on manual residuals.
- **Commit B** replaces `estimate_homography`'s `(2N × 9)` DLT SVD with normal-equations + a 9×9 symmetric eigendecomposition of `AᵀA`. Hartley stays. The 4-point fast path stays. No public API change.
- On a 12 MP chessboard frame, `extend_via_local_homography` sum-of-passes drops from **1.11 s → 142 ms** and full `detect_chessboard` from **1163 ms → 232 ms** (~5×). Microbench shows **1.8×–3.3×** on `estimate_homography` across N, scaling with N because the old path was O(N²) in SVD bidiagonalisation and the new path is O(N) in the `AᵀA` accumulation.

The trade is the textbook f32 cond² penalty: per-entry H drift can hit ~1e-3 relative. Downstream is safe because consumers feed H through `apply(...)` to predict cell positions, never read entries — a 30-60 px cell × 1e-3 H drift → sub-1e-3 px prediction shift, well below the KD-tree search radius and the `pos=` regression budget. `HomographyQuality::from_homography` is intentionally left on the 3×3 SVD path: same penalty would apply there too, and the consumer is no longer in the per-cell hot loop after Commit A.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo doc --workspace --no-deps` (zero warnings)
- [x] `cargo test --workspace`
- [x] `cargo test --workspace --all-features`
- [x] New `dlt_matches_old_svd_path_on_random_battery` test: 1000-sample random homography battery (deterministic xorshift32 seed), agrees with an inlined SVD reference to ≤ 0.01 px in pixel-domain
- [x] Microbench: `cargo bench -p projective-grid --bench homography` — 1.8-3.3× speedup at the existing N=9/25/100/225 cases, plus new K=8/12/20 cases mirroring the production `LocalExtensionParams` defaults
- [x] `bench check --algorithm chessboard-v2 --dataset private` — 12/12 PASS, `miss=0 extra=0 pos=0 id=0 dup=0` on every frame (zero precision regression)
- [x] `bench check --algorithm topological --dataset private` — `pos=0 id=0` everywhere (pre-existing recall gap unchanged)
- [x] `cargo run --release --example detect_chessboard testdata/large.png` → 371 corners (matches baseline)
- [x] `cargo run --release --features tracing --example detect_chessboard testdata/puzzleboard_reference/example4.png` → 723 corners, `detect` time 232 ms (was ~1163 ms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)