### PR TITLE
docs: fix broken intra-doc links in marker diagnostics

### DIFF
--- a/crates/calib-targets-marker/src/diagnostics.rs
+++ b/crates/calib-targets-marker/src/diagnostics.rs
@@ -11,7 +11,7 @@
 //! ([`crate::MarkerBoardDetectionResult`]).
 //!
 //! A consumer that only needs to *use* a marker-board detection wants the
-//! labelled corners ([`crate::MarkerBoardDetectionResult::detection`]) and the
+//! labelled corners ([`crate::MarkerBoardDetectionResult::corners`]) and the
 //! grid alignment ([`crate::MarkerBoardDetectionResult::alignment`]) — never
 //! the contents of this module. The fields here exist only to *understand* or
 //! debug a detection.
@@ -38,7 +38,7 @@ use crate::types::CircleMatch;
 #[derive(Clone, Debug, Default, Serialize)]
 pub struct MarkerBoardDiagnostics {
     /// Per-corner provenance: for labelled corner `k` in
-    /// [`crate::MarkerBoardDetectionResult::detection`], `inliers[k]` is the
+    /// [`crate::MarkerBoardDetectionResult::corners`], `inliers[k]` is the
     /// index of the source ChESS corner in the detector's input slice.
     pub inliers: Vec<usize>,
     /// Every circle hypothesis scored in image space, before matching.


### PR DESCRIPTION
## Summary

`cargo doc --workspace --no-deps` emitted two `rustdoc::broken_intra_doc_links` warnings:

```
warning: unresolved link to `crate::MarkerBoardDetectionResult::detection`
  --> crates/calib-targets-marker/src/diagnostics.rs:14
  --> crates/calib-targets-marker/src/diagnostics.rs:41
```

`MarkerBoardDetectionResult` has no `detection` field — its labelled corners
live in the `corners` field. Both links are repointed to
`crate::MarkerBoardDetectionResult::corners`.

## Verification

`cargo doc --workspace --no-deps` now produces zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)