### PR TITLE
docs(architecture): detection-stack knowledge base + consolidation backlog

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,20 @@ guides, and release history.
 
 ## Map
 
+### `architecture/` — start here: how the whole stack fits together
+A cross-cutting map of the detection stack — the algorithm atlas, per-detector
+pipeline maps, the crate-layering view, a critical review, and a ranked cleanup
+backlog. The best entry point when onboarding or auditing the detector crates.
+
+| File | What it covers |
+|---|---|
+| [`architecture/README.md`](architecture/README.md) | Entry map + the one-screen verdict + the keep-it-current rule. |
+| [`architecture/algorithm-atlas.md`](architecture/algorithm-atlas.md) | Every atomic algorithm + the algorithm×pipeline matrix. |
+| [`architecture/pipeline-maps.md`](architecture/pipeline-maps.md) | Each detector stage-by-stage (algorithm, local vs delegated). |
+| [`architecture/dependency-and-layering.md`](architecture/dependency-and-layering.md) | Crate DAG, layering, the library-only surface. |
+| [`architecture/critique.md`](architecture/critique.md) | Critical review: duplication/debt findings + the from-scratch verdict. |
+| [`architecture/chore-backlog.md`](architecture/chore-backlog.md) | Ranked, effort/risk-tagged consolidation backlog. |
+
 ### `development/` — developer guides
 The everyday gates and conventions. These are the guides linked from the
 project [`CLAUDE.md`](../.claude/CLAUDE.md).

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,73 @@
+# Architecture knowledge base
+
+A cross-cutting map of the **detection stack** — every atomic algorithm, how the
+algorithms compose into each detector's pipeline, how the crates layer, and an
+honest critique of the redundancy/debt with a ranked cleanup backlog.
+
+This complements the existing docs: [`../algorithms/`](../algorithms/) holds
+per-algorithm *deep-dives*; this tree holds the *atlas + wiring + critique* that ties
+them together. Scope is the algorithm-implementing crates (L0–L3):
+`projective-grid`, `calib-targets-core`, `-aruco`, `-chessboard`, `-charuco`,
+`-puzzleboard`, `-marker`.
+
+## The one-screen answer
+
+If you only read one paragraph: the stack is **not overengineered at the crate
+level** — the dependency graph is a clean DAG, the four detectors share one grid
+spine by *embedding* `chessboard` (not by copy-paste), and the decode layers
+(`aruco`, `puzzle`, `marker`) are cohesive and duplication-free. What makes it *feel*
+tangled is **debt, not design**: a homography solver forked verbatim between `core`
+and `projective-grid`, a half-finished `GridCoords → Coord` coordinate migration
+frozen behind `*_to_next` shims, a few same-named-but-different modules (`recovery`
+×2, "validation" ×2), and one dead single-variant enum. The big crate
+(`projective-grid`, 3× the next) is big mostly on purpose — it is a **published
+standalone library** whose hex / dot-grid / orientation-free breadth is intended
+product that no in-workspace detector uses. Would I rebuild it this way? The
+structure, ~80% yes; the within-crate debris, no — and it is a *consolidation* job,
+not a rewrite. Full reasoning in [`critique.md`](critique.md).
+
+## Map
+
+| Doc | What it answers |
+|---|---|
+| [`algorithm-atlas.md`](algorithm-atlas.md) | **What** — every atomic algorithm (home, signature, one-liner, used-by) + the algorithm×pipeline matrix. |
+| [`pipeline-maps.md`](pipeline-maps.md) | **How they compose** — each detector stage-by-stage; which algorithm runs, local vs delegated. |
+| [`dependency-and-layering.md`](dependency-and-layering.md) | **Who depends on whom** — the crate DAG, the layering, why the big crate is big, the library-only surface. |
+| [`critique.md`](critique.md) | **Is it any good** — what's solid, the findings (with `file:line` evidence + severity), and the from-scratch verdict. |
+| [`chore-backlog.md`](chore-backlog.md) | **What to do** — ranked, effort/risk/API-tagged consolidation items (C-1 … C-9). |
+
+**Suggested reading order for onboarding:** this page → `pipeline-maps.md` (trace one
+detector end-to-end) → `algorithm-atlas.md` (look up any stage's algorithm) →
+`critique.md` → `chore-backlog.md`.
+
+## <a id="keeping-this-current"></a>Keeping this current
+
+This is a **hand-maintained snapshot**, not generated. It drifts the moment the code
+moves, so it carries a lightweight refresh rule (wired into
+[`../development/release-gates.md`](../development/release-gates.md)):
+
+> **When a PR adds, removes, renames, or relocates an atomic algorithm, or changes a
+> detector's pipeline stages, update [`algorithm-atlas.md`](algorithm-atlas.md) and
+> [`pipeline-maps.md`](pipeline-maps.md) in the same PR.** When it changes a crate's
+> internal dependencies or public tiers, update
+> [`dependency-and-layering.md`](dependency-and-layering.md).
+
+Practical guidance:
+
+- **Anchors are `file.rs::fn`, not line numbers** — function names survive edits, so a
+  rename is the only thing that breaks a link. Line numbers in prose are pinned
+  reference points, not load-bearing.
+- **The status column is the perishable part.** When a `📚` library-only path gains a
+  workspace-detector caller (e.g. a new dot-grid detector), flip it to `✅` in the
+  atlas and add its row to the matrix.
+- **When you close a backlog item**, strike it in [`chore-backlog.md`](chore-backlog.md)
+  and update the `critique.md` finding it resolves (don't silently delete — the trail
+  is the observability).
+- **Spot-check before release:** resolve ~10 atlas `file.rs::fn` anchors and confirm
+  the matrix still matches reality (no `✅` row with no production caller). This is the
+  cheap version of the [evidence-driven](../development/debugging.md) discipline
+  applied to docs.
+
+These docs follow the same rules as the rest of the tree: no private-dataset
+specifics ([policy](../development/private-dataset-policy.md)), and split any file past
+~800–1000 lines.

--- a/docs/architecture/algorithm-atlas.md
+++ b/docs/architecture/algorithm-atlas.md
@@ -1,0 +1,250 @@
+# Algorithm Atlas
+
+> The **what** of the detection stack: every atomic algorithm in the workspace,
+> named once, with its home, its signature, and which pipelines use it.
+> For the **how-they-compose** view see [`pipeline-maps.md`](pipeline-maps.md);
+> for the **why-it-looks-like-this** view see [`critique.md`](critique.md).
+
+This is a hand-maintained snapshot. When you add, remove, or move an atomic
+algorithm, update this file and [`pipeline-maps.md`](pipeline-maps.md) in the same
+PR (see [`README.md`](README.md#keeping-this-current)).
+
+## How to read a node
+
+Each row is one *atomic algorithm* — a self-contained computation with a clear
+input→output, not glue. Anchors are written `file.rs::fn` (the function name is the
+durable anchor; line numbers drift and are omitted except where pinned in prose).
+
+**Crate shorthand:** `pg` = `projective-grid`, `core` = `calib-targets-core`,
+`aruco` / `chess` / `charuco` / `puzzle` / `marker` = the matching `calib-targets-*`.
+
+**Status key** (this is the load-bearing column — read it carefully):
+
+| Badge | Meaning |
+|---|---|
+| ✅ **exercised** | On a shipping in-workspace detector's production path. |
+| 📚 **library-only** | Reachable only through `projective-grid`'s *public API* — its intended external product surface (hex lattices, dot-grid / orientation-free evidence, the geometry-only recovery schedule). **No workspace detector calls it.** This is *not* dead code; it is library scope. See [`dependency-and-layering.md`](dependency-and-layering.md#the-library-only-surface). |
+| 🧪 **diagnostic** | Trace/debug path only. |
+
+The `📚` rows are the single biggest reason `projective-grid` is ~3× the size of
+any other crate. They are deliberately kept (the crate is a published standalone
+grid library); they are flagged here only so a reader of *this workspace* knows
+the in-workspace detectors never reach them.
+
+---
+
+## 1. Geometry primitives
+
+The numerical bedrock: homography / projective fits and warps.
+
+| Algorithm | Home | In → Out | Computes | Status |
+|---|---|---|---|---|
+| Normalized DLT homography (N≥4) | `pg geometry/homography.rs::estimate_homography` | src/dst point pairs → `Homography<F>` | Hartley-normalize → accumulate `AᵀA` → smallest-eigenvector → denormalize → scale-fix. | ✅ (via `shared::fit`) |
+| 4-point homography | `pg geometry/homography.rs::homography_from_4pt` | 4 src + 4 dst → `Homography<F>` | Direct 8×8 LU solve on normalized points. | ✅ |
+| Homography quality | `pg geometry/homography.rs::HomographyQuality::from_homography` | `Homography` → (cond, det, σ) | SVD condition number + determinant; **diagnostic only, scale-dependent**. | ✅ |
+| 8-DOF projective DLT | `pg geometry/mod.rs::estimate_projective` | src/dst → `Projective2<F>` | Generic-`F` plain DLT (no Hartley); used where a `Projective2` is wanted. | ✅ |
+| **Image-aware DLT homography (N≥4)** | `core homography.rs::estimate_homography_rect_to_img` | src/dst → `Homography` | **Byte-for-byte the same DLT as `pg`'s** + image-domain extras. See [duplication finding D-1](critique.md#d-1-homography-is-forked-verbatim). | ✅ (detectors) |
+| Perspective warp (gray) | `core homography.rs::warp_perspective_gray` | image + H + size → rectified image | Per-output-pixel inverse-map + bilinear sample. | ✅ |
+| `Homography`↔`Projective2` bridge | `core homography.rs::homography_to_next` / `homography_from_next` | one matrix type ↔ the other | Migration shim between core's `Homography` and pg's `Projective2`. | ✅ (debt) |
+| Grid-line curvature predict | `core grid_smoothness.rs::square_predict_grid_position` | model pt + params → predicted px | Second-order spacing prediction under smooth distortion. | ✅ |
+
+Deep dive: homography conventions are documented inline in both files; the
+duplication is analysed in [`critique.md` §D-1](critique.md#d-1-homography-is-forked-verbatim).
+
+## 2. Corner ingestion & feature prep
+
+Turning raw ChESS corners into the generic features the grid engine consumes.
+
+| Algorithm | Home | In → Out | Computes | Status |
+|---|---|---|---|---|
+| ChESS strength / fit prefilter | `chess pipeline/inputs.rs::topological_inputs` | `&[ChessCorner]` + thresholds → mask + `PointFeature`s | Drop weak / poor-fit corners; convert to pg features. | ✅ |
+| Per-corner axis cache | `pg topological/axis.rs` | corner axes → cached unit dirs + informative flag | Precompute the two axis families per corner for cell-test. | ✅ |
+
+## 3. Axis clustering (global direction prior)
+
+| Algorithm | Home | In → Out | Computes | Status |
+|---|---|---|---|---|
+| Global axis clustering | `pg cluster/mod.rs::cluster_axes` | weighted edge dirs → 2 centres + assignments | Undirected circular 2-means → the two dominant board axes. | ✅ |
+| Undirected circular mean | `pg cluster/circular.rs::circular_mean` | angles → mean (mod π) | Accumulate `(cos2θ, sin2θ)`; the axes-only contract. | ✅ |
+| Domain cluster adapter | `chess pipeline/cluster.rs` | corners → clustered corners + centres | Thin map between pg cluster output and chess stage/label enums. | ✅ (wrapper) |
+
+## 4. Grid assembly — the topological builder
+
+The sole grid builder (Shu/Brunton/Fiala axis-driven). Square is the shipped path;
+hex is library-only. Canonical deep-dive:
+[`algorithms/topological-grid-detection.md`](../algorithms/topological-grid-detection.md)
+and [`chessboard/docs/PIPELINE.md`](../../crates/calib-targets-chessboard/docs/PIPELINE.md).
+
+| Algorithm | Home | In → Out | Computes | Status |
+|---|---|---|---|---|
+| Delaunay triangulation | `pg topological/delaunay.rs::triangulate` | points → half-edge mesh | `delaunator` wrapper (f64 internally for robustness). | ✅ |
+| Axis-driven edge classification | `pg topological/classify.rs` | mesh + axis caches → Grid/Diagonal/Spurious per half-edge | Does an edge align with a corner axis family? | ✅ |
+| Triangle-pair → quad | `pg topological/quads.rs` | triangles + classified edges → quads | Merge diagonal-sharing pairs into grid cells. | ✅ |
+| Quad filter | `pg topological/filter.rs::apply_topological_quad_filter` | quads + degrees → filtered quads | Reject degree>4, extreme parallelograms, out-of-band cell sizes. | ✅ |
+| Integer component labelling (walk) | `pg topological/walk.rs::label_components` | quads + seed → `(i,j)→index` per component | Flood-fill integer labels, rebase min→(0,0). | ✅ |
+| Square orchestrator | `pg topological/mod.rs::detect_square_oriented2_topological_all` | oriented features + params → labelled components | Drives delaunay→classify→quads→filter→walk. | ✅ |
+| Hex cell classification | `pg topological/hex.rs::classify_hex_cells` | mesh + hex axis caches → valid cells | Three-direction alignment + equilateral test. | 📚 |
+| Hex axial labelling | `pg topological/hex.rs::label_components` | hex cells + seed → axial labels | Axial flood-fill with parallelogram completion (no quad merge). | 📚 |
+| Hex orchestrator | `pg topological/hex_detect.rs::detect_hex_oriented3_topological_all` | features → labelled hex components | Hex analogue of the square orchestrator + D6 merge. | 📚 |
+| Trace-mode walk | `pg topological/trace.rs::build_grid_topological_trace` | quads → labels + trace | Alternate labeller for diagnostics. | 🧪 |
+
+## 5. Orientation synthesis
+
+Recover per-corner axes when the input has 0 or 1 trusted directions (dot grids,
+circle grids, orientation-free chessboards). All **library-only** — every workspace
+detector feeds native ChESS dual axes (`Oriented2`). Deep dive:
+[`projective-grid/docs/ORIENTATION.md`](../../crates/projective-grid/docs/ORIENTATION.md).
+
+| Algorithm | Home | In → Out | Computes | Status |
+|---|---|---|---|---|
+| Synthesize dual axes (from positions) | `pg orient.rs::synthesize_oriented2` | `&[PointFeature]` → `OrientedFeature<2>` | Perspective-invariant mod-π 2-means per corner from neighbour geometry. | 📚 |
+| Synthesize 2nd axis (from 1) | `pg orient.rs::synthesize_oriented2_from_oriented1` | `OrientedFeature<1>` → `<2>` | Keep the trusted axis, recover the orthogonal. | 📚 |
+| Synthesize triple axes (hex) | `pg orient.rs::synthesize_oriented3` | `&[PointFeature]` → `OrientedFeature<3>` | Three-family generalisation for hex. | 📚 |
+
+## 6. Component merge
+
+| Algorithm | Home | In → Out | Computes | Status |
+|---|---|---|---|---|
+| Local geometric merge | `pg shared/merge.rs::merge_components_local` | labelled components → merged | Reunite components under D4 symmetry via shortest label-space edge. | ✅ |
+| Shared-corner-index merge | `chess pipeline/recover.rs::merge_components_with_shared_corners` | two label maps → merged | Merge by shared *corner indices* under D4 (runs after the geometric merge; needs core's `GRID_TRANSFORMS_D4`). | ✅ (chess-local) |
+
+## 7. Growth & recovery — the geometry-only engine
+
+`projective-grid`'s grow/fill/extend/recover machinery. Chessboard composes the
+`grow` + `fill` primitives in its own boosters; it runs `RecoverySchedule::Off`
+(`chess pipeline/mod.rs:116`) and never touches `extension`, `grow_extend`, or the
+`recovery` schedule — those drive the library-only orientation-free path.
+
+| Algorithm | Home | In → Out | Computes | Status |
+|---|---|---|---|---|
+| BFS candidate search | `pg shared/grow/mod.rs::collect_candidates` | KD-tree + prediction + policy → ranked candidates | Radius search filtered by attach policy. | ✅ |
+| Per-neighbour prediction | `pg shared/grow/predict.rs::predict_from_neighbours` | labelled neighbours → predicted px | Weighted average from K nearest labelled corners. | ✅ |
+| Interior hole fill | `pg shared/fill.rs::fill_grid_holes` | labelled + bbox + policy → attached count | Enumerate empty cells in bbox+skirt, attach via the grow ladder. | ✅ |
+| Chessboard boosters | `chess pipeline/boosters.rs::apply_boosters_with_directional_edge_scale` | component + policy → grown component | Wrap `fill_grid_holes` with a weak-cluster-rescue `SquareAttachPolicy`. | ✅ (chess-local) |
+| Directional edge scale | `chess pipeline/recover.rs::directional_edge_lengths` | component + positions → per-axis medians | Anisotropy-tolerant edge-length gate for boosters. | ✅ (chess-local) |
+| Local-H boundary extension | `pg shared/extension/local.rs::extend_via_local_homography` | candidate + K-nearest → attached | Per-candidate local homography, project + revalidate. | 📚 |
+| Global-H extension fallback | `pg shared/extension/global.rs::extend_via_global_homography` | candidates + global H → attached | Manifold-fit fallback when local fails. | 📚 |
+| Recovery schedule | `pg shared/recovery.rs::run_schedule` | labelled + params → recovered (fixed point) | Iterate extend→fill→validate→drop until stable. Opt-in via `RecoverySchedule`. | 📚 |
+
+## 8. Validation & wrong-label filters
+
+The precision firewall: every check here is *drop-only* (a corner is removed, never
+relabelled), upholding the "no false positives" contract.
+
+| Algorithm | Home | In → Out | Computes | Status |
+|---|---|---|---|---|
+| Validation pipeline | `pg shared/validate/mod.rs::validate` | labelled + params → rejections | Compose the checks below into one pass. | ✅ |
+| Line collinearity | `pg shared/validate/lines.rs::check_line_collinearity` | labelled → rejected idx | Flag 3-point grid-line sets failing collinearity. | ✅ |
+| Per-corner local-H residual | `pg shared/validate/local_h.rs::validate_local_homographies` | labelled → rejected idx | Fit local H from K nearest, reject high relative residual. | ✅ |
+| Wrong-label edge drops | `pg shared/validate/recovery.rs::topological_wrong_label_drops` | labelled + params → dropped | Drop overlong / off-axis / duplicate-pixel edges. | ✅ |
+| Frontier-kink smoothness | `pg shared/validate/recovery.rs` (frontier filter) | labelled + lines → dropped | Second-order line-spacing kink past the true boundary (Gap-15 fix). | ✅ |
+| Largest-component filter | `pg shared/validate/recovery.rs::largest_cardinally_connected_component` | labelled → subset | Keep only the largest cardinally-connected component. | ✅ |
+| Chessboard geometry check | `chess pipeline/geometry_check.rs::run_geometry_check` | labelled → validated | Sequence the pg validators on the chess output. | ✅ |
+| Output normalize / rebase | `chess pipeline/output.rs::build_detection` + `pg result.rs::LabelledGrid::normalize` | labelled → `ChessboardDetection` | Rebase to non-negative, canonicalise image-axis orientation. | ✅ |
+| Post-build consistency check | `pg check/mod.rs::check_consistency` | solution → report | Standalone post-detection validation (public task). | 📚 |
+
+## 9. Marker decode (ArUco)
+
+The codec layer: no quad/grid detection of its own — it decodes within a grid it is
+handed. `aruco/src/scan.rs` (969 LOC) is one cohesive scanner.
+
+| Algorithm | Home | In → Out | Computes | Status |
+|---|---|---|---|---|
+| Dictionary lookup | `aruco dictionary.rs` | dict id → code + metadata | Embedded ArUco/AprilTag code tables. | ✅ |
+| Cell warp + bit sample | `aruco scan.rs::sample_cell` | cell quad + image → grid samples | Homography-warp the cell, sample a mean grid. | ✅ |
+| Otsu threshold (+ multi-threshold) | `aruco threshold.rs` | samples → binary bits | Otsu binarisation with multi-threshold fallback. | ✅ |
+| Hamming match | `aruco matcher.rs::match_code` | observed code → (id, rotation, hamming) | Brute-force XOR+popcount over all 4 rotations of all codes. | ✅ |
+| Border score + detection build | `aruco scan.rs::build_detection` | samples + match → `MarkerDetection` | Border-ring confidence + assemble typed detection. | ✅ |
+
+## 10. ChArUco matching & corner ID
+
+Grid is delegated to `chess`; markers are decoded by `aruco`. This crate owns the
+*alignment* (which marker sits where) and corner-ID assignment. **The board-level
+soft-LL matcher is the default** (`charuco detector/params.rs:306`,
+`use_board_level_matcher: true`); the legacy vote matcher is an off-by-default
+opt-in fallback. Deep dive:
+[`algorithms/charuco_concept.md`](../algorithms/charuco_concept.md).
+
+| Algorithm | Home | In → Out | Computes | Status |
+|---|---|---|---|---|
+| Board-level hypothesis matcher (soft-LL) | `charuco detector/board_match.rs::match_board_diag` | cells + image → markers + alignment | Dense (cell×id×rotation) soft-bit log-likelihood; enumerate D4×translation; pick max-score with margin gate. | ✅ **default** |
+| Legacy rotation+translation vote | `charuco alignment.rs::solve_alignment` | markers → alignment | Histogram dominant rotation, vote best translation by inliers. | ⚠️ opt-in fallback |
+| Inlier filter | `charuco detector/alignment_select.rs` | markers + alignment → inliers | Keep markers whose aligned position is a valid board cell. | ✅ |
+| Marker-cell enumeration | `charuco detector/marker_sampling.rs::build_marker_cells` | corner map → 4-corner cells | Enumerate complete grid squares to decode. | ✅ |
+| Grid smoothing (opt) | `charuco detector/grid_smoothness.rs::smooth_grid_corners` | corners + image → refined | Per-corner ChESS re-detect to tighten the grid. | ✅ |
+| Corner-ID assignment | `charuco detector/corner_mapping.rs::map_charuco_corners` | corners + alignment → `CharucoCorner`s | Map grid→board coords, look up charuco id, dedup per cell. | ✅ |
+| Homography corner refit | `charuco detector/corner_validation.rs::validate_and_fix_corners` | corners + inlier markers → refined | Global board→image H; flag deviating corners, re-detect via ChESS ROI. | ✅ |
+| Marker-corner linkage check | `charuco validation.rs::validate_marker_corner_links` | reported links + spec → violations | **Public** post-hoc check that a result matches the board definition. | ✅ (API) |
+| Multi-component merge | `charuco detector/merge.rs::merge_charuco_results` | per-component results → union | Dedup + union across grid components. | ✅ |
+
+## 11. PuzzleBoard decode
+
+Grid delegated to `chess`; everything below is local. Master pattern is 501×501
+(= 3×167 cyclic periods). Deep dive:
+[`algorithms/puzzle_detection_spec.md`](../algorithms/puzzle_detection_spec.md).
+
+| Algorithm | Home | In → Out | Computes | Status |
+|---|---|---|---|---|
+| Edge-bit sampling | `puzzle detector/edge_sampling.rs` | image + edge endpoints + refs → (bit, confidence) | Sample intensity at the edge midpoint, classify vs bright/dark refs. | ✅ |
+| Cell reference estimation | `puzzle detector/edge_sampling.rs` | image + adjacent cells → (bright, dark) | Local bright/dark levels for bit classification. | ✅ |
+| CRT master row/col | `puzzle detector/decode/mod.rs::crt_master_row` / `crt_master_col` | cyclic residues (mod 3, mod 167) → master coord [0,501) | Chinese-Remainder recovery of absolute master index. | ✅ |
+| Hard-weighted decode | `puzzle detector/decode/hard.rs::decode` | observed edges + max-BER → outcome | Precompute H/V contribution tables, scan master origins, rank by (matched, weighted score). | ✅ |
+| Soft-LL decode | `puzzle detector/decode/soft.rs::decode_soft` | edges + soft config → outcome | Per-bit log-likelihood scan with best-vs-runner-up margin gate. | ✅ |
+| Master-origin scan (CRT collapse) | `puzzle detector/decode/hard.rs` | contribution tables → best origin | Optimised O(8·501) origin walk (was O(8·501²)) via CRT collapse. | ✅ |
+| Master-ID encode + wrap | `puzzle detector/pipeline.rs::master_ij_to_id` / `wrap_master` | (i,j)+transform+origin → flat id | Flat id = `j·501+i`; preserves `target_position` invariant. | ✅ |
+| Component decode ranking | `puzzle detector/pipeline.rs::is_better_component_decode` | two decodes → better | Lexicographic: edges matched, BER, then margin/confidence. | ✅ |
+
+## 12. Circle-marker detection (marker board)
+
+Grid delegated to `chess`; circles are the pose anchor, not decoded markers.
+
+| Algorithm | Home | In → Out | Computes | Status |
+|---|---|---|---|---|
+| Circle scoring | `marker circle_score.rs::score_circle_in_square` | warped cell + params → (center, contrast, polarity) | Fit a circle to cell contrast, report center + polarity. | ✅ |
+| Circle detection via warp | `marker detect.rs::detect_circles_via_square_warp` | image + corner map → candidates | Warp each cell, score circles, rank by polarity. | ✅ |
+| Circle matching | `marker match_circles.rs::match_expected_circles` | expected + candidates → matches | Permutation search minimising total distance with polarity + offset consistency. | ✅ |
+| Grid-alignment from circles | `marker match_circles.rs::estimate_grid_alignment` | matched circles → alignment | Offset-consensus rotation + translation. | ✅ |
+
+---
+
+## Algorithm × pipeline matrix
+
+Rows = atomic algorithms (collapsed to families); columns = the four shipping
+detectors plus the standalone grid library. `●` = on this pipeline's production
+path; `○` = available to it but not default; blank = unused by it.
+
+| Algorithm family | Chess | ChArUco | Puzzle | Marker | Grid-lib (pg public API) |
+|---|:--:|:--:|:--:|:--:|:--:|
+| Homography / projective fit (§1) | ● | ● | ●¹ | ● | ● |
+| Image warp + curvature predict (§1) | ● | ● | ● | ● | |
+| ChESS prefilter + axis cache (§2) | ● | ●² | ●² | ●² | |
+| Axis clustering (§3) | ● | ●² | ●² | ●² | ● |
+| Topological **square** assembly (§4) | ● | ●² | ●² | ●² | ● |
+| Topological **hex** assembly (§4) | | | | | ● 📚 |
+| Orientation synthesis (§5) | | | | | ● 📚 |
+| Component merge — geometric (§6) | ● | ●² | ●² | ●² | ● |
+| Component merge — shared-index (§6) | ● | ●² | ●² | ●² | |
+| Grow + interior fill (§7) | ● | ●² | ●² | ●² | ● |
+| Local/global-H extension + recovery schedule (§7) | | | | | ● 📚 |
+| Validation + wrong-label drops (§8) | ● | ●² | ●² | ●² | ● |
+| ArUco decode (§9) | | ● | | | |
+| ChArUco board-level matcher (§10) | | ● | | | |
+| ChArUco legacy vote matcher (§10) | | ○ | | | |
+| ChArUco corner-id + refit + linkage (§10) | | ● | | | |
+| PuzzleBoard edge decode + CRT (§11) | | | ● | | |
+| Circle scoring + matching (§12) | | | | ● | |
+
+¹ Puzzle reaches §1 only transitively through its embedded chess detector.
+² ChArUco / Puzzle / Marker reach §2–§8 **through** their embedded `chess`
+detector, not by calling `pg` directly — `chess` is the only in-workspace crate
+that depends on `projective-grid` (see [`dependency-and-layering.md`](dependency-and-layering.md)).
+
+### The one-paragraph takeaway
+
+Every shipping detector funnels through **one** grid path: ChESS corners →
+axis-cluster → **topological square** assembly → geometric merge → grow/fill →
+validate. The marker family (`charuco`, `puzzle`, `marker`) then bolts a *decode*
+stage on top, and those decode stages (§9–§12) are clean, cohesive, and share
+nothing they shouldn't. The breadth lives entirely in `pg`'s `📚` rows (hex,
+orientation-free, recovery schedule) — intended library surface, exercised by no
+detector here.

--- a/docs/architecture/chore-backlog.md
+++ b/docs/architecture/chore-backlog.md
@@ -1,0 +1,178 @@
+# Chore Backlog — Detection Stack Consolidation
+
+> The actionable output of the [critique](critique.md): a ranked ledger of
+> evidence-backed cleanup items. **Doc-only as of this snapshot — nothing here is
+> executed yet.** Each item is tagged with effort, regression risk, blast radius,
+> and **API impact** (because `projective-grid`, `core`, and the detectors are
+> published — semver matters).
+
+Legend — **Effort:** S (<½ day) · M (1–3 days) · L (multi-PR). **Risk:** regression
+risk. **API:** `internal-safe` (no published-surface change) · `semver` (breaking,
+stage with deprecations) · `additive` (new items only) · `feature` (new cfg flag).
+
+## Recommended execution order
+
+Legibility quick-wins first, then the one high-value structural fix, then the large
+migration once the surface is clearer. Optional/strategic last.
+
+| Order | Item | What | Sev | Effort | Risk | API |
+|---|---|---|---|---|---|---|
+| 1 | [C-8](#c-8) | Sanitize private-dataset specifics in source comments | P3 | S | Low | none |
+| 2 | [C-3](#c-3) | Rename `recovery`/`validation` modules by role | P2 | S | Low | internal-safe¹ |
+| 3 | [C-6](#c-6) | Share one `build_corner_map` | P2 | S | Low | additive |
+| 4 | [C-4](#c-4) | Delete the single-variant `SquareAlgorithm` seam | P3 | S | Low | semver² |
+| 5 | [C-1](#c-1) | Unify the forked homography (single source of truth) | **P1** | M | Med | internal-safe |
+| 6 | [C-5](#c-5) | Decide what `pg`'s advanced tier *is* | P2 | M | Low | semver/doc |
+| 7 | [C-7](#c-7) | Retire or justify the legacy ChArUco matcher | P3 | M | Med | semver |
+| 8 | [C-2](#c-2) | Finish the `GridCoords → Coord` migration | **P1** | L | Med-High | semver |
+| 9 | [C-9](#c-9) | Feature-gate the library-only breadth (optional) | — | M | Med | feature |
+
+¹ The `pg shared/*` renames touch the *advanced tier*, which `lib.rs` declares
+semver-exempt; the one public rename (`charuco validation.rs`) needs a deprecation
+alias. ² Removes a `pub enum` — trivially breaking; deprecate one release first.
+
+---
+
+## <a id="c-1"></a>C-1 · Unify the forked homography
+**Severity P1 · Effort M · Risk Med · API internal-safe (if names preserved)**
+
+- **Problem:** [D-1](critique.md#d-1-homography-is-forked-verbatim). The DLT solver in
+  `pg geometry/homography.rs::estimate_homography` is a verbatim copy of
+  `core homography.rs::estimate_homography_rect_to_img` (~250 LOC, identical body).
+  Two hand-maintained copies of numerically-sensitive code that will drift silently.
+- **Fix:** make the lowest crate canonical. Keep the pure solver in `pg geometry`;
+  in `core`, delete the duplicated body and re-implement
+  `estimate_homography_rect_to_img` as a thin wrapper over `pg`'s solver, retaining
+  *only* the image-domain extras (`warp_perspective_gray`, the `Projective2` bridges).
+  Preserve every existing public name so callers don't change.
+- **Blast radius:** `core homography.rs`, `pg geometry/homography.rs`; all detector
+  callers recompile unchanged.
+- **Risk control:** the existing homography unit tests in both files + both private
+  regression sets must stay green; assert pixel-level parity of the two solvers on a
+  fixed correspondence set before deleting the `core` body.
+- **Deps:** none. Do before [C-2](#c-2) (shrinks the `core` public surface in flux).
+
+## <a id="c-2"></a>C-2 · Finish the `GridCoords → Coord` migration
+**Severity P1 · Effort L · Risk Med-High · API semver**
+
+- **Problem:** [D-2](critique.md#d-2-the-gridcoords--coord-migration-is-frozen-mid-flight).
+  Dual coordinate models (`core GridCoords{i,j}` vs `pg Coord{u,v}`) bridged by
+  `grid_alignment_to_next`/`_from_next` shims. The single biggest "what's canonical?"
+  tax in the stack.
+- **Fix:** adopt `pg Coord` as canonical. Migrate `core` adapters and `chessboard`
+  (and any `charuco`/`puzzle`/`marker` use of `core` grid types) onto it; delete the
+  `*_to_next`/`*_from_next` shims. Provide `#[deprecated]` aliases for the removed
+  public `core` types for one minor release.
+- **Blast radius:** `core grid_alignment.rs` (public), `chessboard`, transitively the
+  L3 detectors. Largest item here.
+- **Risk control:** stage in two PRs — (a) internal migration behind deprecated
+  aliases, (b) alias removal next minor. Full regression matrix each step.
+- **Deps:** after [C-1](#c-1); coordinate the deprecation window with [C-4](#c-4).
+
+## <a id="c-3"></a>C-3 · Rename `recovery`/`validation` modules by role
+**Severity P2 · Effort S · Risk Low · API internal-safe¹**
+
+- **Problem:** [D-3](critique.md#d-3-two-validations-two-corner-maps). Two `recovery.rs`
+  in `pg shared/` (schedule vs drop-filters); two "validation" concepts in `charuco`.
+- **Fix:** `pg shared/recovery.rs` → `recovery_schedule.rs`;
+  `pg shared/validate/recovery.rs` → `wrong_label_filters.rs`;
+  `charuco detector/corner_validation.rs` → `corner_refit.rs`;
+  `charuco validation.rs` → `link_check.rs` (public — add a deprecation re-export).
+- **Blast radius:** internal `pg`/`charuco` paths (compiler-checked); `chessboard`'s
+  advanced-tier import paths update (semver-exempt tier).
+- **Risk control:** pure renames; `cargo build` + `cargo doc` (zero-warning gate)
+  catch every miss.
+
+## <a id="c-4"></a>C-4 · Delete the single-variant `SquareAlgorithm` seam
+**Severity P3 · Effort S · Risk Low · API semver (trivial)**
+
+- **Problem:** [D-4](critique.md#d-4-deadspeculative-seams-kept-for-later).
+  `pg detect.rs::SquareAlgorithm` has one variant; the `with_algorithm` builder and
+  the bench `AlgorithmReq` seam scaffold a builder that doesn't exist.
+- **Fix:** remove the enum + builder + the `match` with one arm; inline the
+  topological path. Keep `DetectionParams` `#[non_exhaustive]` for headroom. Update
+  `bench/compare.rs` to drop the synthetic second-builder slug.
+- **Blast radius:** `pg detect.rs` (removes a `pub enum`), `chessboard` (one call
+  site), `bench`.
+- **Judgment call:** legitimate to *keep* as semver headroom on a library. Recommend
+  deleting (deprecate one release) — re-add when a real second builder lands.
+
+## <a id="c-5"></a>C-5 · Decide what `pg`'s advanced tier *is*
+**Severity P2 · Effort M · Risk Low · API semver/doc**
+
+- **Problem:** [D-5](critique.md#d-5-the-advanced-tier-is-a-private-api-wearing-a-pub-badge).
+  `pub mod shared` / `pub mod topological` are "semver-exempt" yet published — both a
+  public API and chessboard's private engine.
+- **Fix (pick one):** (a) **embrace it as public** — document the composition
+  contract (the `SquareAttachPolicy` a consumer supplies, the recovery-schedule
+  guarantees), drop the "private" framing; or (b) **make it private** — move the
+  engine to a non-published `*-engine` crate (or `pub(crate)` + workspace path),
+  leaving only the facade public.
+- **Blast radius:** `pg lib.rs` + docs (option a), or a new crate + `chessboard`
+  import paths (option b).
+- **Recommendation:** option (a) doc-first (cheaper, keeps external composability);
+  revisit (b) only if no external consumer composes the engine.
+
+## <a id="c-6"></a>C-6 · Share one `build_corner_map`
+**Severity P2 · Effort S · Risk Low · API additive**
+
+- **Problem:** [D-3](critique.md#d-3-two-validations-two-corner-maps).
+  `charuco detector/marker_sampling.rs` and `marker detector.rs` each implement
+  "chessboard grid → grid→pixel map" in parallel.
+- **Fix:** add a `build_corner_map` helper to `chessboard` (it owns
+  `ChessboardDetection`) and have both `charuco` and `marker` call it.
+- **Blast radius:** `chessboard` (new `pub` helper), `charuco`, `marker`.
+- **Risk control:** assert the shared helper reproduces both current maps on a fixed
+  detection before deleting the locals.
+
+## <a id="c-7"></a>C-7 · Retire or justify the legacy ChArUco matcher
+**Severity P3 · Effort M · Risk Med · API semver**
+
+- **Problem:** [D-6](critique.md#d-6-a-superseded-legacy-fallback-and-private-dataset-specifics-in-source).
+  The board-level soft-LL matcher is the default; the legacy vote matcher
+  (`alignment.rs` + `alignment_select.rs`, ~300 LOC + the `use_board_level_matcher`
+  flag) is an off-by-default fallback.
+- **Fix:** **decision first** — does the legacy matcher ever beat the default on any
+  frame in the regression sets? If no → delete it (+ the flag/types, deprecated one
+  release). If yes → keep it but add a one-line "why we still ship this" rationale at
+  the flag definition.
+- **Blast radius:** `charuco` only.
+- **Risk control:** the data check *is* the gate; don't delete a fallback on a hunch.
+
+## <a id="c-8"></a>C-8 · Sanitize private-dataset specifics in source comments
+**Severity P3 · Effort S · Risk Low · API none**
+
+- **Problem:** [D-6](critique.md#d-6-a-superseded-legacy-fallback-and-private-dataset-specifics-in-source).
+  `charuco detector/params.rs` default-constant comments cite concrete private-dataset
+  board sizes and frame counts, against
+  [`private-dataset-policy.md`](../development/private-dataset-policy.md).
+- **Fix:** rewrite those comments as general statements ("tuned on internal ArUco/
+  AprilTag regression sets; κ is the minimum that clears them with zero wrong-ids");
+  move any concrete figures to a local-only note. Grep the workspace for the same
+  pattern elsewhere while here.
+- **Blast radius:** comments only — zero behaviour change.
+- **Why early:** it's a policy-compliance item and trivially safe.
+
+## <a id="c-9"></a>C-9 · Feature-gate the library-only breadth (optional / strategic)
+**Severity — · Effort M · Risk Med · API feature**
+
+- **Problem:** [What the breadth costs](critique.md#what-the-breadth-costs). Hex and
+  orientation-free paths are always compiled though no workspace detector uses them.
+- **Fix:** gate them behind `feature = "hex"` and `feature = "orientation-free"`.
+  Keep current defaults *on* to avoid a breaking change, or flip defaults *off* in the
+  next minor (semver-sensitive) so the minimal engine is the default mental model.
+- **Blast radius:** `pg` cfg matrix + CI (must build all feature combinations).
+- **Note:** strategic, not urgent. Only worthwhile if compile time / surface size is
+  a felt cost; the breadth itself is intended product and stays either way.
+
+---
+
+## What this backlog deliberately does **not** propose
+
+- **No rewrite, no rearchitecture.** The crate DAG stays
+  ([critique: what's good](critique.md#what-is-genuinely-good-dont-fix-these)).
+- **No deletion of hex / dot-grid / orientation-free** algorithms — they are intended
+  published library scope ([layering](dependency-and-layering.md#the-library-only-surface)).
+- **No detector-decode changes** — `aruco`/`puzzle`/`marker` decode layers are clean.
+- **No tuning of constants to examples** — any constant touched (e.g. in C-7/C-8) is
+  reasoned from principle, per the workspace anti-overfitting rule.

--- a/docs/architecture/critique.md
+++ b/docs/architecture/critique.md
@@ -1,0 +1,229 @@
+# Architecture Critique
+
+> A critical, evidence-anchored review of the detection stack — where the
+> redundancy, duplication, overengineering, and naming debt actually are, and
+> whether the structure is worth keeping. Each finding cites `file.rs::symbol`.
+> Actionable items are tracked in [`chore-backlog.md`](chore-backlog.md).
+
+**Framing decision (from the owner):** `projective-grid` is a **standalone
+published library**. Its hex / dot-grid / orientation-free breadth is *intended
+product surface for external users*, not bloat to delete. That reframes this whole
+review: the question is **not** "is the scope too big?" (it is deliberately big) but
+"is the workspace carrying *avoidable* duplication, frozen migrations, and naming
+debt on top of that scope?" It is — and that, not the breadth, is what makes the
+stack hard to grasp.
+
+---
+
+## What is genuinely good (don't "fix" these)
+
+A critical review has to start by protecting what works, so cleanup doesn't damage it.
+
+- **The crate DAG is clean.** No cycles; sensible layering (L0 `projective-grid` →
+  L1 `core` → L2 `aruco`/`chessboard` → L3 composed detectors). See
+  [`dependency-and-layering.md`](dependency-and-layering.md). Almost every problem
+  below is *within* a crate, not in the boundaries.
+- **One grid spine, shared by embedding — not copy-paste.** `charuco`/`puzzle`/
+  `marker` get the grid by embedding `chessboard`, not by reimplementing it
+  ([pipeline-maps](pipeline-maps.md)). That is the *right* kind of reuse.
+- **The decode layers are cohesive and duplication-free.** `aruco/src/scan.rs`
+  (the codec), `puzzle` hard/soft+CRT decode, and `marker` circle scoring are each
+  self-contained, single-responsibility, and share nothing they shouldn't.
+- **The precision contract is enforced structurally.** Every check in
+  `pg shared/validate/*` is *drop-only* (a corner is removed, never relabelled),
+  which is exactly how you honour "misses are OK, false positives are not".
+- **API hygiene is consistently high.** `#[non_exhaustive]` + named constructors on
+  public types; no `todo!()`/`unimplemented!()` debris; clean clippy under
+  `-D warnings`. The detector public surfaces (`charuco`/`marker`/`aruco` `lib.rs`,
+  ~44–64 LOC each) are tight.
+
+This is *not* a codebase that needs a rewrite. It needs **consolidation**.
+
+---
+
+## Findings
+
+Severity: **P1** worth doing soon · **P2** worth doing · **P3** judgment / nice-to-have.
+
+### <a id="d-1-homography-is-forked-verbatim"></a>D-1 Homography is forked verbatim
+**Severity: P1 · the top finding.**
+
+`pg geometry/homography.rs::estimate_homography` and
+`core homography.rs::estimate_homography_rect_to_img` are the **same algorithm,
+copied**: identical Hartley normalization → `AᵀA` accumulation → `symmetric_eigen`
+→ denormalize → scale-fix, down to the variable names and the 4-point LU variant.
+The differences are cosmetic: the numeric bound (`Float` vs `RealField`), the
+function name, and the image-domain extras `core` adds (`warp_perspective_gray`,
+`homography_to_next`/`from_next`). ~250 LOC of numerically-sensitive code maintained
+in two places.
+
+- **Why it exists:** `core → projective-grid` in the DAG, so `pg` (below `core`)
+  cannot reuse `core`'s solver without a cycle. It forked instead.
+- **Who uses which:** *every detector* uses `core`'s copy (`charuco
+  corner_validation.rs`, `chess rectified_view.rs` + `mesh_warp.rs`); only `pg`'s own
+  `shared::fit` uses `pg`'s copy.
+- **Why it's debt, not duplication-by-design:** two hand-maintained copies of a DLT
+  *will* drift (one gets a conditioning fix, the other doesn't), and that drift is
+  silent and numerical — the worst kind.
+- **Fix (direction fixed by the DAG):** make the lowest crate the single source of
+  truth — keep the pure solver in `pg geometry`, have `core` re-export it and add
+  only its image-coupled helpers on top. Internal-safe on the `pg` side; the `core`
+  re-export must preserve the existing public names (`estimate_homography_rect_to_img`)
+  to stay non-breaking. → [backlog C-1](chore-backlog.md#c-1).
+
+### <a id="d-2-the-gridcoords--coord-migration-is-frozen-mid-flight"></a>D-2 The `GridCoords → Coord` migration is frozen mid-flight
+**Severity: P1 · the biggest comprehension tax.**
+
+Two grid-coordinate models coexist: `core grid_alignment.rs::GridCoords{i,j}` /
+`GridAlignment` (legacy) and `pg lattice::Coord{u,v}` (current), bridged by adapters
+literally named `grid_alignment_to_next` / `grid_alignment_from_next` — and the same
+`*_to_next`/`*_from_next` idiom appears for homography
+(`core homography.rs::homography_to_next`). "The next crate's representation" is
+migration vocabulary frozen into the public API; a reader cannot tell which model is
+canonical, which is why the stack "can't be grasped".
+
+- **Why it's debt:** a half-finished migration is strictly worse than either
+  endpoint — every consumer must understand *both* models and the shims between them.
+- **Fix:** pick `Coord` as canonical, migrate `core` + `chessboard` onto it, delete
+  the `*_to_next`/`*_from_next` shims. Larger and partly semver-breaking (public
+  `core` types change) — stage it. → [backlog C-2](chore-backlog.md#c-2).
+
+### <a id="d-3-two-validations-two-corner-maps"></a>D-3 Two validations, two corner maps, two `recovery.rs`
+**Severity: P2 · naming/observability tax (each is small; together they confuse).**
+
+Genuinely-distinct logic given near-identical names — the reader pays to
+disambiguate every time:
+
+- **Two `recovery.rs` in one crate:** `pg shared/recovery.rs` (the *schedule* —
+  orchestrates extend→fill→validate→drop) vs `pg shared/validate/recovery.rs` (the
+  *drop-filters* it calls). Not duplication — but two files named `recovery` one
+  directory apart is a comprehension trap.
+- **Two "validation" in charuco:** `charuco detector/corner_validation.rs`
+  (`validate_and_fix_corners` — internal homography refit + ROI re-detect) vs
+  `charuco validation.rs` (`validate_marker_corner_links` — *public* post-hoc check
+  against the board spec). Different inputs, different audience, same word.
+- **Two `build_corner_map`:** `charuco detector/marker_sampling.rs` and
+  `marker detector.rs` each implement "chessboard grid → grid→pixel map" in parallel.
+  Real (if small) duplication of the same concept.
+
+- **Fix:** rename by role (`recovery_schedule.rs` vs `wrong_label_filters.rs`;
+  `corner_refit.rs` vs `link_check.rs`); lift one `build_corner_map` into
+  `chessboard` (or `core`) and share it. Mostly internal-safe renames; the public
+  `charuco validation.rs` name needs a deprecation alias if changed. →
+  [backlog C-3](chore-backlog.md#c-3), [C-6](chore-backlog.md#c-6).
+
+### <a id="d-4-deadspeculative-seams-kept-for-later"></a>D-4 Dead/speculative seams kept "for later"
+**Severity: P3 · low cost, but pure comprehension drag.**
+
+- `pg detect.rs::SquareAlgorithm` is a **single-variant `#[non_exhaustive]` enum**
+  (`Topological`). Every call site passes that one value; the
+  `with_algorithm(...)` builder, the bench's `AlgorithmReq` seam
+  (`bench/compare.rs:281` — "reserve a seam for a future alternative builder"), and a
+  `match` with one real arm all exist for a builder that was removed (seed-and-grow)
+  and a hypothetical future one.
+- **Judgment, not a slam-dunk:** for a *published library* a reserved
+  `#[non_exhaustive]` enum is a legitimate semver-headroom choice. But today it costs
+  every reader a "wait, where are the other algorithms?" detour for zero behaviour.
+  Recommend deleting and re-introducing when a second builder actually lands; the
+  `#[non_exhaustive]` on the request struct already preserves headroom. →
+  [backlog C-4](chore-backlog.md#c-4).
+
+### <a id="d-5-the-advanced-tier-is-a-private-api-wearing-a-pub-badge"></a>D-5 The advanced tier is a private API wearing a `pub` badge
+**Severity: P2 · library-design clarity.**
+
+`pg lib.rs` exposes `pub mod shared` and `pub mod topological` as a "semver-exempt
+pre-1.0" advanced tier "for in-workspace consumers (the chessboard detector)"
+(lib.rs:37–45). The deep reach from `chessboard` into `pg shared::{grow,fill,
+validate,merge}` is therefore *sanctioned*, not a leak — but on a **published** crate
+a `pub mod` is still public: it lands on docs.rs and external users can build on it,
+semver-exempt or not.
+
+- **The tension:** it is simultaneously "chessboard's private engine" and "part of
+  the published API". Pick one. Either (a) it is a supported composition API — then
+  document the contract (what `SquareAttachPolicy` a consumer must supply, what the
+  recovery schedule guarantees) and stop calling it private; or (b) it is
+  chessboard-private — then it wants a workspace-internal seam (a `pub(crate)` +
+  in-repo path, or a non-published `-engine` crate), not a `pub mod` on the published
+  crate. → [backlog C-5](chore-backlog.md#c-5).
+
+### <a id="d-6-a-superseded-legacy-fallback-and-private-dataset-specifics-in-source"></a>D-6 A superseded legacy fallback, and private-dataset specifics in source
+**Severity: P3.**
+
+- **Legacy matcher:** `charuco` ships two marker matchers. The board-level soft-LL
+  matcher (`detector/board_match.rs`) is the **default** (`params.rs:306`,
+  `use_board_level_matcher: true`); the legacy rotation+translation vote
+  (`alignment.rs` + `alignment_select.rs`, ~300 LOC) is an off-by-default documented
+  fallback. This is *mild* debt — a kept-for-safety fallback, not "the good one is
+  off" (an earlier inventory pass got this backwards; corrected here). Decide:
+  retire it, or keep it with a one-line "why we still ship this" rationale.
+- **Hygiene:** `charuco detector/params.rs` default-constant comments cite concrete
+  private-dataset board sizes and frame counts to justify tuned constants. Per
+  [`private-dataset-policy.md`](../development/private-dataset-policy.md) concrete
+  numbers belong in local-only surfaces; source comments compiled into the published
+  crate are borderline. Sanitize to general statements (this doc deliberately does
+  **not** repeat the numbers). → [backlog C-7](chore-backlog.md#c-7),
+  [C-8](chore-backlog.md#c-8).
+
+### Watch-list (not findings yet)
+
+- **Large files that are still cohesive:** `pg orient.rs` (~1.08K), `aruco scan.rs`
+  (969), `puzzle detector/pipeline.rs` (807). Each is *one* algorithm family today,
+  so they pass the "no giant grab-bag files" rule — but they sit at the threshold;
+  if a second responsibility lands in any of them, split then.
+- **Param-struct surface:** `chess params/` (~583 LOC across `mod.rs` +
+  `advanced.rs`) is large but deliberately split into a 3-knob stable core and an
+  opt-in `#[non_exhaustive]` `AdvancedTuning`. Acceptable; just keep new knobs out of
+  the stable struct.
+
+---
+
+## <a id="what-the-breadth-costs"></a>What the breadth costs (accepted, not a bug)
+
+Per the owner's decision the library breadth stays. Stating its cost honestly so the
+decision is made with open eyes:
+
+- ~1.08K LOC of orientation synthesis (`orient.rs`), ~0.88K of hex
+  (`topological/hex*.rs` + `lattice/hex.rs`), plus the extension + recovery-schedule
+  engine, are carried by the workspace but exercised here only by `pg`'s own tests.
+- Every refactor of the shared back-half (e.g. C-1, C-5) must keep all `📚` paths
+  green, not just the chessboard path — the test matrix is wider than the shipped
+  surface.
+- **Mitigation, not removal:** keep it, but make the cost legible — feature-gate the
+  hex and orientation-free paths (`feature = "hex"`, `feature = "orientation-free"`)
+  so external users opt in and in-workspace builds can compile the minimal engine.
+  This preserves the product while shrinking the default surface a reader/`chessboard`
+  sees. → [backlog C-9](chore-backlog.md#c-9) (optional).
+
+---
+
+## Would I build it this way from scratch?
+
+**The crate structure: ~80% yes. The within-crate state: no.**
+
+Given the same goal — a published generic grid library *plus* a family of target
+detectors — I would keep the layering almost exactly (it is a clean DAG, the decode
+layers are well-isolated, the grid spine is shared by embedding). What I would *not*
+reproduce is the accumulated debris. Six concrete changes turn the current stack into
+the one I'd design:
+
+1. **One source of truth for geometry.** Pure homography/projective DLT lives in the
+   lowest crate (`pg`); `core` re-exports and adds image-domain helpers. Kill the
+   fork. *(D-1 / C-1)*
+2. **Finish the coordinate migration.** `Coord` is canonical; `GridCoords` and the
+   `*_to_next`/`*_from_next` shims are deleted. This single change removes most of the
+   "I can't tell what's canonical" tax. *(D-2 / C-2)*
+3. **Name by role, not by history.** `recovery_schedule` vs `wrong_label_filters`;
+   `corner_refit` vs `link_check`; one shared `build_corner_map`. *(D-3 / C-3, C-6)*
+4. **Decide what the engine *is*.** Either a documented public composition API or a
+   workspace-internal seam — not a "semver-exempt `pub mod`" that is both. *(D-5 / C-5)*
+5. **Delete dead seams.** No single-variant `SquareAlgorithm`; re-introduce a
+   strategy enum only when a second strategy exists. *(D-4 / C-4)*
+6. **Gate the breadth, don't carry it always-on.** Hex and orientation-free behind
+   features so the default build and the mental model are the shipped spine. *(C-9)*
+
+None of these is a rearchitecture. They are consolidation + finishing one migration +
+renaming — which is exactly why the stack *feels* overengineered while being, at the
+crate level, basically sound. The complexity you are feeling is **debt, not design**.
+
+See [`chore-backlog.md`](chore-backlog.md) for the ranked, effort-and-risk-tagged
+execution list.

--- a/docs/architecture/dependency-and-layering.md
+++ b/docs/architecture/dependency-and-layering.md
@@ -1,0 +1,125 @@
+# Dependency & Layering
+
+> Who depends on whom, and why the big crate is big. Pairs with the
+> [Algorithm Atlas](algorithm-atlas.md) and [Pipeline Maps](pipeline-maps.md).
+
+## The dependency DAG (production deps only)
+
+Extracted from the crate `Cargo.toml` manifests. `chess-corners` is the external
+upstream ChESS corner detector; every detector depends on it. Internal edges only:
+
+```
+ L0  projective-grid            (no internal deps — the foundation; published standalone)
+        ▲
+ L1  calib-targets-core         → projective-grid
+        ▲                ▲
+ L2  aruco → core        chessboard → core, projective-grid      (the only DETECTOR on pg)
+                ▲              ▲           ▲
+ L3       charuco ────────────┘           │     → core, chessboard, aruco
+          puzzleboard ────────────────────┤     → core, chessboard
+          marker ─────────────────────────┘     → core, chessboard
+                ▲
+ L4  print → core, aruco, charuco, marker, puzzleboard
+     calib-targets (facade) → all detectors + print
+                ▲
+ L5  ffi → facade      py → facade      wasm → all detectors + print
+     bench → facade, chessboard, core, projective-grid      studio → facade, bench, chessboard
+```
+
+It is a **clean acyclic graph with no cycles** — the crate boundaries are
+sound. This matters for the [critique](critique.md): nearly every problem found is
+*within* a crate (duplication, naming, dead seams), **not** in the dependency
+structure. The lone exception is the [homography fork](#why-projective-grid-is-big-and-duplicated),
+which is a *consequence* of the layering.
+
+| Crate | Layer | Internal prod deps | Role |
+|---|---|---|---|
+| `projective-grid` | L0 | *(none)* | Generic grid recovery; **published standalone**. |
+| `calib-targets-core` | L1 | projective-grid | Shared types (`Corner`, `LabeledCorner`, image views), homography, the legacy `GridCoords` model + adapters. |
+| `calib-targets-aruco` | L2 | core | ArUco/AprilTag dictionaries + decode codec. |
+| `calib-targets-chessboard` | L2 | core, projective-grid | The base detector; **the only in-workspace detector that drives `projective-grid`**. |
+| `calib-targets-charuco` | L3 | core, chessboard, aruco | ChArUco fusion. |
+| `calib-targets-puzzleboard` | L3 | core, chessboard | Self-identifying chessboard. |
+| `calib-targets-marker` | L3 | core, chessboard | Checkerboard + 3-circle board. |
+| `calib-targets-print` | L4 | core, aruco, charuco, marker, puzzleboard | Printable-target generation (not a detector). |
+| `calib-targets` | L4 | all detectors + print | Facade + CLI. |
+| `ffi` / `py` / `wasm` | L5 | facade / all detectors | Bindings (C ABI, PyO3, wasm). |
+| `bench` / `studio` | L5 | facade, chessboard, core, projective-grid | Harness + GUI (local tooling). |
+
+**Atlas scope** ([Algorithm Atlas](algorithm-atlas.md)) is L0–L3: the crates that
+*implement detection algorithms*. The **rim** — `print`, `ffi`, `py`, `wasm`,
+`bench`, `studio` — generates, exposes, or measures those algorithms but implements
+none of its own, so it is documented here (this table) and not atlased.
+
+## The "one real consumer" reality
+
+`projective-grid` has two production consumers inside the workspace:
+
+- **`calib-targets-core`** consumes its *type model* (`Coord`, `Projective2`,
+  transforms) to build adapters.
+- **`calib-targets-chessboard`** consumes its *engine* — the topological assembler
+  plus the `shared::{merge, grow, fill, validate}` primitives.
+
+`charuco`, `puzzleboard`, and `marker` do **not** depend on `projective-grid` in
+production at all — they list it only as a *dev*-dependency (tests) and reach the
+grid through their embedded `chessboard` detector. So within this workspace, the
+17.3K-LOC engine has exactly **one detector driving it**.
+
+That is not a criticism by itself — `projective-grid` is published for *external*
+consumers too. But it explains the shape: the crate is co-designed with one
+in-workspace client, and its public surface reflects that.
+
+## The two public tiers (and the coupling note)
+
+`projective-grid/src/lib.rs` declares two tiers explicitly:
+
+- **Stable facade** — `detect_grid`, `detect_grid_all`, `check_consistency`, the
+  `Evidence` / `DetectionParams` / result model, the `Lattice` model, the
+  `orient::synthesize_*` helpers, `cluster_axes`. Normal semver intent.
+- **Advanced tier** — `pub mod shared` and `pub mod topological`: the assembly
+  engine, **declared semver-exempt pre-1.0**, "for in-workspace consumers (the
+  chessboard detector) that compose the engine directly with their own policies"
+  (lib.rs:37–45).
+
+So the deep reach from `chessboard` into `pg shared::{grow, fill, validate, merge}`
+is **sanctioned by design**, not an encapsulation leak. The honest critique
+([§D-5](critique.md#d-5-the-advanced-tier-is-a-private-api-wearing-a-pub-badge)) is
+narrower: a *semver-exempt `pub` module is still a `pub` module* on a published
+crate — it appears in docs.rs and external users can depend on it. Either it is a
+supported composition API (then document the contract and the policies a consumer
+must supply) or it is chessboard-private (then it wants a workspace-internal seam,
+not a published `pub mod`).
+
+## <a id="the-library-only-surface"></a>The library-only surface
+
+The `📚` rows in the [atlas](algorithm-atlas.md) — hex assembly, orientation
+synthesis, local/global-H extension, the recovery schedule — are reachable only
+through the L0 public facade and are exercised in-workspace **only by
+`projective-grid`'s own tests/benches/examples**. By line count this is a large
+slice of L0 (orientation synthesis alone is `orient.rs` at ~1.08K LOC; hex is
+~0.88K across three files; the recovery schedule + extension add more).
+
+Per the owner's decision, this is **intended product** for external users (dot
+grids, circle grids, hex targets), **not** dead code, and is kept. It is called out
+so a reader of *this workspace* is not misled into thinking the detectors use it.
+The maintenance cost it carries is real and is reflected in the
+[critique](critique.md#what-the-breadth-costs) — but the cost is accepted, not a
+bug to fix.
+
+## <a id="why-projective-grid-is-big-and-duplicated"></a>Why `projective-grid` is big — and duplicated
+
+Two structural facts, both downstream of the layering:
+
+1. **Breadth (intended).** L0 ships two lattice families × three evidence kinds ×
+   an optional recovery schedule. Only `(Square, Oriented2)` is on a workspace
+   detector path; the rest is external library scope.
+2. **The homography fork (debt).** L0 needs a homography for its internal fit, but
+   it sits *below* `core`, so it **cannot** call `core`'s homography (that would be
+   a cycle, `core → pg → core`). The result:
+   `pg geometry/homography.rs::estimate_homography` is a **verbatim copy** of
+   `core homography.rs::estimate_homography_rect_to_img` (identical Hartley-DLT
+   body; differs only in the `Float` vs `RealField` bound and a name). Every
+   *detector* calls `core`'s copy; only `pg`'s internal `shared::fit` calls `pg`'s.
+   The fix direction is fixed by the DAG: the canonical home for the pure DLT is the
+   lowest crate (`pg`), with `core` re-exporting + adding its image-domain extras.
+   Full analysis: [critique §D-1](critique.md#d-1-homography-is-forked-verbatim).

--- a/docs/architecture/pipeline-maps.md
+++ b/docs/architecture/pipeline-maps.md
@@ -1,0 +1,150 @@
+# Pipeline Maps
+
+> The **how-they-compose** view: each detector as an ordered stage list, every
+> stage naming the [atomic algorithm](algorithm-atlas.md) it runs and whether that
+> algorithm lives **locally** in the detector crate or is **delegated** to a lower
+> crate (`projective-grid` or `calib-targets-core`).
+
+Read alongside the [Algorithm Atlas](algorithm-atlas.md) (the *what*) and the
+[layering doc](dependency-and-layering.md) (the *who-depends-on-whom*).
+
+**The shared spine.** All four detectors share one front-half — the grid build —
+and differ only in the back-half they bolt on top:
+
+```
+                     ┌─────────────────────── SHARED GRID SPINE ───────────────────────┐
+ChESS corners ──▶ prefilter ──▶ axis-cluster ──▶ topological square ──▶ merge ──▶ grow/fill ──▶ validate ──▶ labelled (i,j) grid
+                     └──────────────────────────────────────────────────────────────────┘
+                                                                                         │
+                          ┌──────────────────────────────────────────────┬──────────────┴───────────────┐
+                          ▼                                               ▼                              ▼
+                  chessboard: ship grid              charuco / marker: decode features        puzzle: decode edge dots
+                                                     inside warped cells, assign IDs           on the master pattern, assign IDs
+```
+
+Only **`chessboard`** owns that spine (it is the sole in-workspace consumer of
+`projective-grid`); **`charuco`, `puzzle`, `marker` get the spine by embedding the
+`chessboard` detector**, then run their own decode back-half.
+
+---
+
+## 1. Chessboard — `chess Detector::detect` → `ChessboardDetection`
+
+The reference pipeline. Entry: `chess detector.rs::Detector::detect` →
+`chess pipeline/mod.rs::detect_all_topological`. Canonical stage table:
+[`chessboard/docs/PIPELINE.md`](../../crates/calib-targets-chessboard/docs/PIPELINE.md).
+
+| # | Stage | Entry | Algorithm (atlas §) | Local / Delegated |
+|---|---|---|---|---|
+| 1 | Prefilter | `chess pipeline/inputs.rs::topological_inputs` | ChESS strength/fit prefilter (§2) | **Local** |
+| 2 | Axis cluster | `chess pipeline/cluster.rs` | Global axis clustering (§3) | **Delegated** → `pg cluster_axes` |
+| 3 | Topological grid | `pg ...::detect_square_oriented2_topological_all` via `pipeline/mod.rs:112` | Delaunay → classify → quads → filter → walk (§4) | **Delegated** → `pg` (`SquareAlgorithm::Topological`, `RecoverySchedule::Off`) |
+| 4 | Merge + recover | `chess pipeline/recover.rs::recover_topological_components` | Geometric merge (§6) + shared-index merge (§6) + boosters fill (§7) | **Mixed**: `pg merge_components_local` + `pg fill_grid_holes`; merge-by-index + directional scale **local** |
+| 5 | Geometry check | `chess pipeline/geometry_check.rs::run_geometry_check` | Line collinearity + local-H + wrong-label drops + largest-component (§8) | **Delegated** → `pg shared::validate` |
+| 6 | Output | `chess pipeline/output.rs::build_detection` | Normalize + rebase to non-negative (§8) | **Delegated** → `pg LabelledGrid::normalize` |
+
+**Notes.** Stage 3 hands `pg` native dual axes (`Evidence::Oriented2`) and turns the
+facade's own validate/fit/recovery **off** — chessboard owns stages 4–6 itself.
+This is why `pg`'s recovery *schedule* (`run_schedule`) and `extension` modules are
+[library-only](algorithm-atlas.md): the shipped chessboard path never enters them.
+
+Auxiliary (not on the detection path, but public): `chess mesh_warp.rs` +
+`chess rectified_view.rs` produce rectified views for downstream calibration tooling.
+
+## 2. PuzzleBoard — `puzzle PuzzleBoardDetector::detect` → `PuzzleBoardDetectionResult`
+
+Self-identifying chessboard: a binary dot at each interior edge midpoint encodes an
+absolute position on a 501×501 master. Entry:
+`puzzle detector/pipeline.rs::PuzzleBoardDetector::detect`. Zero direct dependency
+on `pg` — the grid arrives via the embedded `chess` detector.
+
+| # | Stage | Entry | Algorithm (atlas §) | Local / Delegated |
+|---|---|---|---|---|
+| 1 | Chessboard grid | `puzzle pipeline.rs` → `chess Detector::detect_all` | Full chess spine (§1) | **Delegated** → `chess` |
+| 2 | Edge sampling | `puzzle detector/pipeline.rs::sample_all_edges` | Edge-bit sampling + cell-reference estimation (§11) | **Local** |
+| 3 | Edge filter | `puzzle pipeline.rs` (confidence gate) | min-confidence threshold | **Local** |
+| 4 | Decode select | `puzzle pipeline.rs` | choose hard/soft × full/fixed-board | **Local** |
+| 5 | Decode | `puzzle decode/hard.rs::decode` · `decode/soft.rs::decode_soft` (+ fixed variants) | Hard-weighted / soft-LL decode + master-origin scan (§11) | **Local** |
+| 6 | CRT origin recovery | `puzzle decode/mod.rs::crt_master_row` / `crt_master_col` | CRT master row/col (§11) | **Local** |
+| 7 | Corner-ID assignment | `puzzle pipeline.rs::master_ij_to_id` / `wrap_master` | Master-ID encode + wrap (§11) | **Local** |
+| 8 | Component ranking | `puzzle pipeline.rs::is_better_component_decode` | Component decode ranking (§11) | **Local** |
+
+**Notes.** Steps 5–8 are pure decode — no grid logic reimplemented. The four decode
+paths (hard/soft × full/fixed) are a *multiplex over one algorithm family*, not four
+algorithms. See the [decoder-precision note](algorithm-atlas.md) and the standing
+decision not to rewrite the decoder absent a precision gap.
+
+## 3. ChArUco — `charuco CharucoDetector::detect` → `CharucoDetectionResult`
+
+Grid-first fusion: chessboard grid + per-cell ArUco decode + board-level alignment +
+corner IDs. Entry: `charuco detector/pipeline.rs::CharucoDetector::detect`.
+
+| # | Stage | Entry | Algorithm (atlas §) | Local / Delegated |
+|---|---|---|---|---|
+| 1 | Chessboard grid | `charuco pipeline.rs` → `chess Detector::detect` | Full chess spine (§1) | **Delegated** → `chess` |
+| 2 | Grid smoothing (opt) | `charuco detector/grid_smoothness.rs::smooth_grid_corners` | Per-corner ChESS refine (§10) | **Local** |
+| 3 | Cell enumeration | `charuco detector/marker_sampling.rs::build_marker_cells` | Marker-cell enumeration (§10) | **Local** |
+| 4a | **Decode + align (default)** | `charuco detector/board_match.rs::match_board_diag` | Board-level soft-LL matcher (§10) | **Local** (decode bits via `aruco`) |
+| 4b | Decode + align (fallback) | `charuco detector/alignment_select.rs` → `alignment.rs::solve_alignment` | Legacy rotation+translation vote (§10) | **Local**; **opt-in** (`use_board_level_matcher = false`) |
+| 5 | Inlier filter | `charuco detector/alignment_select.rs` | Inlier filter (§10) | **Local** |
+| 6 | Corner-ID assignment | `charuco detector/corner_mapping.rs::map_charuco_corners` | Corner-ID assignment (§10) | **Local** |
+| 7 | Corner refit | `charuco detector/corner_validation.rs::validate_and_fix_corners` | Homography corner refit (§10) | **Mixed**: H fit **delegated** → `core estimate_homography_rect_to_img`; ROI re-detect local |
+| 8 | Output (+ merge) | `charuco detector/merge.rs::merge_charuco_results` | Multi-component merge (§10) | **Local** |
+
+**Public, off-path:** `charuco validation.rs::validate_marker_corner_links` lets a
+caller validate a finished result against the board spec — distinct from the internal
+stage-7 `corner_validation` (see [critique §D-3](critique.md#d-3-two-validations-two-corner-maps)).
+
+**Default matters:** stage **4a** is the default (`detector/params.rs:306`). 4b is a
+documented fallback, not the default — the atlas and critique correct an earlier
+mis-reading on this point.
+
+## 4. Marker board — `marker MarkerBoardDetector::detect_*` → `MarkerBoardDetectionResult`
+
+Checkerboard + 3 circles; circles anchor the pose, chessboard corners are the grid
+truth. Entry: `marker detector.rs::MarkerBoardDetector`.
+
+| # | Stage | Entry | Algorithm (atlas §) | Local / Delegated |
+|---|---|---|---|---|
+| 1 | Chessboard grid | `marker detector.rs` → `chess Detector::detect` | Full chess spine (§1) | **Delegated** → `chess` |
+| 2 | Corner map | `marker detector.rs::build_corner_map` | grid→pixel map | **Local** (duplicate of charuco's; see [critique §D-3](critique.md#d-3-two-validations-two-corner-maps)) |
+| 3 | Circle scoring | `marker detect.rs::detect_circles_via_square_warp` → `circle_score.rs::score_circle_in_square` | Circle scoring + detection (§12) | **Local** |
+| 4 | Circle matching | `marker match_circles.rs::match_expected_circles` | Circle matching (§12) | **Local** |
+| 5 | Alignment | `marker match_circles.rs::estimate_grid_alignment` | Grid-alignment from circles (§12) | **Local** |
+
+## 5. Standalone grid library — `pg detect_grid` / `detect_grid_all`
+
+`projective-grid` is a published crate with its own public detection entry point,
+used by external consumers (and exercised by `pg`'s own tests/benches/examples). Its
+breadth is the part no in-workspace detector reaches. Entry:
+`pg detect.rs::detect_grid_all`. Deep dive:
+[`projective-grid/docs/DESIGN.md`](../../crates/projective-grid/docs/DESIGN.md).
+
+| Evidence × lattice | Path | Status in this workspace |
+|---|---|---|
+| `(Square, Oriented2)` | topological square assembly (the spine chess uses) | ✅ exercised (via chess) |
+| `(Square, Oriented1)` | `synthesize_oriented2_from_oriented1` → square assembly + recovery schedule | 📚 library-only |
+| `(Square, Positions)` | `synthesize_oriented2` → square assembly + recovery schedule | 📚 library-only |
+| `(Hex, Oriented3)` | hex assembly (`detect_hex_oriented3_topological_all`) | 📚 library-only |
+| `(Hex, Positions)` | `synthesize_oriented3` → hex assembly | 📚 library-only |
+| anything else | `GridError::UnsupportedCombination` | — |
+
+The `Oriented1` / `Positions` / `Hex` rows are where the orientation-synthesis
+(§5), local/global-H extension, and recovery-schedule (§7) algorithms live. They are
+genuine library features (dot grids, circle grids, hex targets for external users),
+simply not on any path a `calib-targets-*` detector takes.
+
+---
+
+## Cross-cutting observations (feed the critique)
+
+- **One spine, four back-halves.** The structure is cleaner than it looks: §1's spine
+  is shared via crate embedding, not copy-paste. The decode back-halves (§9–§12)
+  are well-isolated.
+- **The delegation arrows almost all point down** (`charuco/puzzle/marker → chess →
+  pg/core`), which is correct layering. The only *up-ish* smell is the homography:
+  detectors call `core`'s copy while the identical solver also sits in `pg` below
+  them — see [critique §D-1](critique.md#d-1-homography-is-forked-verbatim).
+- **Two corner-map builders and two "validation" concepts** ride along stages
+  marked *Local* above; they are small but are genuine duplication —
+  [critique §D-3](critique.md#d-3-two-validations-two-corner-maps).

--- a/docs/development/release-gates.md
+++ b/docs/development/release-gates.md
@@ -35,5 +35,12 @@ mdbook build book
 `#[non_exhaustive]`) invalidates both the FFI header and Python typing stubs.
 Always regenerate both after such changes.
 
+**Architecture docs (hand-maintained, not generated).** When a change adds,
+removes, renames, or relocates an atomic algorithm, or alters a detector's pipeline
+stages or a crate's internal dependencies, update the matching files under
+[`../architecture/`](../architecture/README.md#keeping-this-current) in the same PR
+(algorithm atlas + pipeline maps for algorithm/stage changes; the layering doc for
+dependency changes). Spot-check ~10 `file.rs::fn` anchors before tagging.
+
 See [conventions.md](conventions.md#binding--cli-parity) for the binding /
 CLI / dict-key parity rules that these generated artifacts enforce.


### PR DESCRIPTION
Adds docs/architecture/ -- a hand-maintained knowledge base for the detection stack, answering "is this overengineered, and can the structure be grasped".

- algorithm-atlas.md -- every atomic algorithm + an algorithm x pipeline matrix
- pipeline-maps.md -- each detector stage-by-stage (algorithm, local vs delegated)
- dependency-and-layering.md -- the crate DAG + the library-only surface
- critique.md -- evidence-anchored findings (D-1..D-6) + the from-scratch verdict
- chore-backlog.md -- ranked consolidation items (C-1..C-9)

Cross-linked from docs/README.md; a keep-it-current rule is wired into docs/development/release-gates.md.

## Verdict

The crate structure is a clean DAG, ~80% what I would build from scratch. The pain is debt, not design: a verbatim-forked homography (core vs projective-grid), a frozen GridCoords -> Coord migration, same-named modules, and a dead single-variant enum. projective-grid is large mostly because of intended published-library breadth (hex / dot-grid / orientation-free) that no in-workspace detector uses.

Docs-only -- no code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)