### PR TITLE
chore: consolidation round 2 — unify forked homography (C-1) + share cell enumeration (C-6)

### DIFF
--- a/crates/calib-targets-charuco/src/detector/grid_smoothness.rs
+++ b/crates/calib-targets-charuco/src/detector/grid_smoothness.rs
@@ -9,8 +9,7 @@
 //! the prediction are re-detected locally or snapped to the predicted position.
 
 use super::corner_refit::redetect_corner_in_roi;
-use super::marker_sampling::CornerMap;
-use calib_targets_core::{square_predict_grid_position, GrayImageView, GridCoords};
+use calib_targets_core::{square_predict_grid_position, CornerMap, GrayImageView, GridCoords};
 use chess_corners::low_level::ChessParams;
 use log::debug;
 use nalgebra::Point2;

--- a/crates/calib-targets-charuco/src/detector/marker_sampling.rs
+++ b/crates/calib-targets-charuco/src/detector/marker_sampling.rs
@@ -1,17 +1,15 @@
 use calib_targets_aruco::MarkerCell;
-use calib_targets_core::{GridCoords, LabeledCorner};
-use nalgebra::Point2;
-use std::collections::HashMap;
+use calib_targets_core::{
+    complete_cell_corners, corner_map_bounds, CornerMap, GridCoords, LabeledCorner,
+};
 
 #[cfg(feature = "tracing")]
 use tracing::instrument;
 
-pub(crate) type CornerMap = HashMap<GridCoords, Point2<f32>>;
-
 /// Build a grid -> image map from inlier chessboard corners.
 #[cfg_attr(feature = "tracing", instrument(level = "info", skip(corners, inliers), fields(corners=inliers.len())))]
 pub(crate) fn build_corner_map(corners: &[LabeledCorner], inliers: &[usize]) -> CornerMap {
-    let mut map = HashMap::new();
+    let mut map = CornerMap::new();
     for &idx in inliers {
         if let Some(c) = corners.get(idx) {
             if let Some(g) = c.grid {
@@ -23,43 +21,28 @@ pub(crate) fn build_corner_map(corners: &[LabeledCorner], inliers: &[usize]) -> 
 }
 
 /// Enumerate complete square cells (TL, TR, BR, BL) from a corner map.
+///
+/// The bounds scan and per-cell corner lookup (including the canonical
+/// TL, TR, BR, BL quad order) are the shared [`corner_map_bounds`] /
+/// [`complete_cell_corners`] primitives; this only wraps each complete cell as
+/// a [`MarkerCell`].
 #[cfg_attr(feature = "tracing", instrument(level = "info", skip(map), fields(corners=map.len())))]
 pub(crate) fn build_marker_cells(map: &CornerMap) -> Vec<MarkerCell> {
-    let mut min_i = i32::MAX;
-    let mut min_j = i32::MAX;
-    let mut max_i = i32::MIN;
-    let mut max_j = i32::MIN;
-
-    for g in map.keys() {
-        min_i = min_i.min(g.i);
-        min_j = min_j.min(g.j);
-        max_i = max_i.max(g.i);
-        max_j = max_j.max(g.j);
-    }
-
-    if min_i == i32::MAX || min_j == i32::MAX {
+    let Some((min_i, min_j, max_i, max_j)) = corner_map_bounds(map) else {
         return Vec::new();
-    }
+    };
 
     let cells_x = (max_i - min_i).max(0) as usize;
     let cells_y = (max_j - min_j).max(0) as usize;
     let mut out = Vec::with_capacity(cells_x * cells_y);
     for j in min_j..max_j {
         for i in min_i..max_i {
-            let g00 = GridCoords { i, j };
-            let g10 = GridCoords { i: i + 1, j };
-            let g11 = GridCoords { i: i + 1, j: j + 1 };
-            let g01 = GridCoords { i, j: j + 1 };
-
-            let (Some(&p00), Some(&p10), Some(&p11), Some(&p01)) =
-                (map.get(&g00), map.get(&g10), map.get(&g11), map.get(&g01))
-            else {
+            let Some(corners_img) = complete_cell_corners(map, i, j) else {
                 continue;
             };
-
             out.push(MarkerCell {
                 gc: GridCoords { i, j },
-                corners_img: [p00, p10, p11, p01],
+                corners_img,
             });
         }
     }
@@ -70,6 +53,7 @@ pub(crate) fn build_marker_cells(map: &CornerMap) -> Vec<MarkerCell> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use nalgebra::Point2;
 
     #[test]
     fn build_corner_map_filters_inliers() {

--- a/crates/calib-targets-core/src/corner_map.rs
+++ b/crates/calib-targets-core/src/corner_map.rs
@@ -1,0 +1,94 @@
+//! Grid → image corner maps and complete-cell enumeration.
+//!
+//! A [`CornerMap`] associates integer grid intersections ([`GridCoords`]) with
+//! their sub-pixel image positions. The marker and ChArUco detectors both warp
+//! the unit square cells of such a map to read out circles / ArUco bits, so the
+//! per-cell corner lookup — and the canonical **TL, TR, BR, BL** quad order it
+//! encodes — lives here once instead of being re-derived in each detector.
+
+use std::collections::HashMap;
+
+use nalgebra::Point2;
+
+use crate::corner::GridCoords;
+
+/// A grid → image corner map: integer grid intersections to their sub-pixel
+/// image positions. The shared currency of the marker / ChArUco square-cell
+/// warp paths.
+pub type CornerMap = HashMap<GridCoords, Point2<f32>>;
+
+/// Inclusive grid-coordinate bounds `(min_i, min_j, max_i, max_j)` over a
+/// corner map's keys, or `None` when the map is empty.
+///
+/// Callers derive their own cell-index scan range from these corner bounds: the
+/// complete cells of the map span lower-left corners `min_i ..= max_i - 1` by
+/// `min_j ..= max_j - 1`.
+pub fn corner_map_bounds(map: &CornerMap) -> Option<(i32, i32, i32, i32)> {
+    let mut keys = map.keys();
+    let first = keys.next()?;
+    let (mut min_i, mut min_j, mut max_i, mut max_j) = (first.i, first.j, first.i, first.j);
+    for g in keys {
+        min_i = min_i.min(g.i);
+        min_j = min_j.min(g.j);
+        max_i = max_i.max(g.i);
+        max_j = max_j.max(g.j);
+    }
+    Some((min_i, min_j, max_i, max_j))
+}
+
+/// The four image corners of the unit cell whose top-left intersection is grid
+/// `(i, j)`, in **TL, TR, BR, BL** order (clockwise — the canonical quad order
+/// used for every homography fit in the workspace). Returns `None` if any of
+/// the cell's four grid intersections is absent from the map.
+pub fn complete_cell_corners(map: &CornerMap, i: i32, j: i32) -> Option<[Point2<f32>; 4]> {
+    let tl = *map.get(&GridCoords { i, j })?;
+    let tr = *map.get(&GridCoords { i: i + 1, j })?;
+    let br = *map.get(&GridCoords { i: i + 1, j: j + 1 })?;
+    let bl = *map.get(&GridCoords { i, j: j + 1 })?;
+    Some([tl, tr, br, bl])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// 2×2 intersections forming a single complete unit cell at lower-left
+    /// grid `(0, 0)`.
+    fn unit_grid() -> CornerMap {
+        let mut map = CornerMap::new();
+        map.insert(GridCoords { i: 0, j: 0 }, Point2::new(0.0, 0.0));
+        map.insert(GridCoords { i: 1, j: 0 }, Point2::new(10.0, 0.0));
+        map.insert(GridCoords { i: 1, j: 1 }, Point2::new(10.0, 10.0));
+        map.insert(GridCoords { i: 0, j: 1 }, Point2::new(0.0, 10.0));
+        map
+    }
+
+    #[test]
+    fn bounds_none_when_empty() {
+        assert_eq!(corner_map_bounds(&CornerMap::new()), None);
+    }
+
+    #[test]
+    fn bounds_span_all_keys() {
+        let mut map = unit_grid();
+        map.insert(GridCoords { i: 3, j: -2 }, Point2::new(1.0, 1.0));
+        assert_eq!(corner_map_bounds(&map), Some((0, -2, 3, 1)));
+    }
+
+    #[test]
+    fn complete_cell_returns_tl_tr_br_bl() {
+        let map = unit_grid();
+        let c = complete_cell_corners(&map, 0, 0).expect("complete cell");
+        assert_eq!(c[0], Point2::new(0.0, 0.0)); // TL = (i, j)
+        assert_eq!(c[1], Point2::new(10.0, 0.0)); // TR = (i + 1, j)
+        assert_eq!(c[2], Point2::new(10.0, 10.0)); // BR = (i + 1, j + 1)
+        assert_eq!(c[3], Point2::new(0.0, 10.0)); // BL = (i, j + 1)
+    }
+
+    #[test]
+    fn incomplete_cell_is_none() {
+        let mut map = unit_grid();
+        map.remove(&GridCoords { i: 1, j: 1 }); // drop BR
+        assert_eq!(complete_cell_corners(&map, 0, 0), None);
+    }
+}

--- a/crates/calib-targets-core/src/homography.rs
+++ b/crates/calib-targets-core/src/homography.rs
@@ -1,268 +1,31 @@
-//! Projective homography type and estimators.
+//! Projective homography: image-warp and `nalgebra::Projective2` bridges over
+//! the workspace's single-source homography estimator.
 //!
-//! Homographies in this crate map source-frame points to destination-frame
-//! points as `p_dst ~ H * p_src`. Detector code uses this for rectified-grid
-//! to image-frame mappings; residuals are measured in image pixels.
+//! The [`Homography`] type, [`HomographyQuality`] metrics, and the
+//! Hartley-normalised DLT estimators live in the lowest crate,
+//! [`projective_grid::geometry`], so the algorithm has exactly one
+//! implementation. This module re-exports them and adds only the pieces that
+//! need core-level image types ([`warp_perspective_gray`]) or the
+//! `nalgebra::Projective2` representation used by the grid-alignment bridge
+//! ([`homography_to_next`] / [`homography_from_next`]).
+//!
+//! Homographies map source-frame points to destination-frame points as
+//! `p_dst ~ H * p_src`. Detector code uses this for rectified-grid to
+//! image-frame mappings; residuals are measured in image pixels.
 
 use crate::{sample_bilinear_u8, GrayImage, GrayImageView};
-use nalgebra::{Matrix3, Point2, Projective2, RealField, SMatrix, SVector, Vector3};
+use nalgebra::{Point2, Projective2};
 
-fn lit<F: RealField + Copy>(val: f64) -> F {
-    F::from_subset(&val)
-}
-
-/// A 3×3 projective homography matrix.
-///
-/// Maps 2D points between two projective planes: `p_dst ~ H * p_src`.
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct Homography<F = f32> {
-    /// The raw 3×3 matrix. Defined up to an overall scale; estimators in this
-    /// module normalize it so the bottom-right entry is `1`.
-    pub h: Matrix3<F>,
-}
-
-/// Numerical quality of a homography matrix.
-///
-/// **Diagnostic only — not a scale-stable stability gate.** The
-/// absolute-magnitude fields (`min_singular_value`, `determinant`) depend on
-/// the coordinate scale of the points `H` was fit from, so a single absolute
-/// threshold is not portable across image scales. Use for inspection and
-/// relative comparison; for production gating prefer a pixel-unit re-projection
-/// residual.
-#[non_exhaustive]
-#[derive(Clone, Copy, Debug)]
-pub struct HomographyQuality<F = f32> {
-    /// Largest singular value of `H`.
-    pub max_singular_value: F,
-    /// Smallest singular value of `H`.
-    pub min_singular_value: F,
-    /// Condition number `max_singular_value / min_singular_value`.
-    pub condition: F,
-    /// Determinant of `H`.
-    pub determinant: F,
-}
-
-impl<F: RealField + Copy> HomographyQuality<F> {
-    /// Compute quality from a homography matrix.
-    pub fn from_homography(h: &Homography<F>) -> Self {
-        let svd = h.h.svd(false, false);
-        let mut s_max = F::zero();
-        let mut s_min = lit(1e30);
-        for k in 0..3 {
-            let s = svd.singular_values[k];
-            if s > s_max {
-                s_max = s;
-            }
-            if s < s_min {
-                s_min = s;
-            }
-        }
-        let condition = if s_min > F::default_epsilon() {
-            s_max / s_min
-        } else {
-            lit(1e30)
-        };
-        Self {
-            max_singular_value: s_max,
-            min_singular_value: s_min,
-            condition,
-            determinant: h.h.determinant(),
-        }
-    }
-
-    /// `true` when `min_singular_value < threshold`.
-    ///
-    /// **Diagnostic only**: `min_singular_value` scales with the coordinate
-    /// magnitudes of `H`, so a single threshold is not portable across image
-    /// scales. Not a production stability gate.
-    pub fn is_ill_conditioned(&self, min_singular_value_threshold: F) -> bool {
-        self.min_singular_value < min_singular_value_threshold
-    }
-}
-
-impl<F: RealField + Copy> Homography<F> {
-    /// Wrap an existing 3×3 matrix as a homography. The matrix is taken as-is;
-    /// no normalization is applied.
-    pub fn new(h: Matrix3<F>) -> Self {
-        Self { h }
-    }
-
-    /// Build a homography from a row-major `[[row0], [row1], [row2]]` array.
-    pub fn from_array(rows: [[F; 3]; 3]) -> Self {
-        Self::new(Matrix3::from_row_slice(&[
-            rows[0][0], rows[0][1], rows[0][2], rows[1][0], rows[1][1], rows[1][2], rows[2][0],
-            rows[2][1], rows[2][2],
-        ]))
-    }
-
-    /// Return the matrix as a row-major `[[row0], [row1], [row2]]` array.
-    pub fn to_array(&self) -> [[F; 3]; 3] {
-        [
-            [self.h[(0, 0)], self.h[(0, 1)], self.h[(0, 2)]],
-            [self.h[(1, 0)], self.h[(1, 1)], self.h[(1, 2)]],
-            [self.h[(2, 0)], self.h[(2, 1)], self.h[(2, 2)]],
-        ]
-    }
-
-    /// A homography backed by the all-zeros matrix. Not invertible; used only
-    /// as a placeholder before a real estimate is available.
-    pub fn zero() -> Self {
-        Self {
-            h: Matrix3::zeros(),
-        }
-    }
-
-    /// Apply the homography to a 2D point.
-    #[inline]
-    pub fn apply(&self, p: Point2<F>) -> Point2<F> {
-        let v = self.h * Vector3::new(p.x, p.y, F::one());
-        let w = v[2];
-        Point2::new(v[0] / w, v[1] / w)
-    }
-
-    /// Compute the inverse homography, if the matrix is invertible.
-    pub fn inverse(&self) -> Option<Self> {
-        self.h.try_inverse().map(Self::new)
-    }
-}
-
-/// Estimate H such that `p_dst ~ H * p_src` from N >= 4 point
-/// correspondences.
-///
-/// Uses Hartley normalization + DLT for N > 4 and a direct 4-point solver for
-/// N == 4.
-pub fn estimate_homography_rect_to_img<F: RealField + Copy>(
-    src_pts: &[Point2<F>],
-    dst_pts: &[Point2<F>],
-) -> Option<Homography<F>> {
-    if src_pts.len() != dst_pts.len() || src_pts.len() < 4 {
-        return None;
-    }
-
-    if src_pts.len() == 4 {
-        let src: &[Point2<F>; 4] = src_pts.try_into().ok()?;
-        let dst: &[Point2<F>; 4] = dst_pts.try_into().ok()?;
-        return homography_from_4pt(src, dst);
-    }
-
-    let (r, tr) = normalize_points(src_pts);
-    let (im, ti) = normalize_points(dst_pts);
-
-    let mut m: SMatrix<F, 9, 9> = SMatrix::zeros();
-    let zero = F::zero();
-    let neg_one = -F::one();
-    for k in 0..src_pts.len() {
-        let x = r[k].x;
-        let y = r[k].y;
-        let u = im[k].x;
-        let v = im[k].y;
-
-        let row1 = SVector::<F, 9>::from_column_slice(&[
-            -x,
-            -y,
-            neg_one,
-            zero,
-            zero,
-            zero,
-            u * x,
-            u * y,
-            u,
-        ]);
-        let row2 = SVector::<F, 9>::from_column_slice(&[
-            zero,
-            zero,
-            zero,
-            -x,
-            -y,
-            neg_one,
-            v * x,
-            v * y,
-            v,
-        ]);
-        m += row1 * row1.transpose();
-        m += row2 * row2.transpose();
-    }
-
-    let eig = m.symmetric_eigen();
-    let mut min_idx = 0usize;
-    let mut min_val = eig.eigenvalues[0];
-    for k in 1..9 {
-        if eig.eigenvalues[k] < min_val {
-            min_val = eig.eigenvalues[k];
-            min_idx = k;
-        }
-    }
-    let h = eig.eigenvectors.column(min_idx);
-    let hn = Matrix3::<F>::from_row_slice(&[h[0], h[1], h[2], h[3], h[4], h[5], h[6], h[7], h[8]]);
-    let h_den = denormalize_homography(hn, tr, ti)?;
-    let h_den = normalize_homography(h_den)?;
-    Some(Homography::new(h_den))
-}
-
-/// Estimate H such that `p_dst ~ H * p_src` and return numerical quality
-/// metrics.
-pub fn estimate_homography_with_quality<F: RealField + Copy>(
-    src_pts: &[Point2<F>],
-    dst_pts: &[Point2<F>],
-) -> Option<(Homography<F>, HomographyQuality<F>)> {
-    let h = estimate_homography_rect_to_img(src_pts, dst_pts)?;
-    let q = HomographyQuality::from_homography(&h);
-    Some((h, q))
-}
-
-/// Compute H from exactly 4 point correspondences: `dst ~ H * src`.
-///
-/// Uses Hartley normalization for numerical stability.
-pub fn homography_from_4pt<F: RealField + Copy>(
-    src: &[Point2<F>; 4],
-    dst: &[Point2<F>; 4],
-) -> Option<Homography<F>> {
-    let (src_n, t_src) = normalize_points4(src);
-    let (dst_n, t_dst) = normalize_points4(dst);
-
-    let mut a = SMatrix::<F, 8, 8>::zeros();
-    let mut b = SVector::<F, 8>::zeros();
-
-    for k in 0..4 {
-        let x = src_n[k].x;
-        let y = src_n[k].y;
-        let u = dst_n[k].x;
-        let v = dst_n[k].y;
-
-        let r0 = 2 * k;
-        a[(r0, 0)] = x;
-        a[(r0, 1)] = y;
-        a[(r0, 2)] = F::one();
-        a[(r0, 6)] = -u * x;
-        a[(r0, 7)] = -u * y;
-        b[r0] = u;
-
-        let r1 = 2 * k + 1;
-        a[(r1, 3)] = x;
-        a[(r1, 4)] = y;
-        a[(r1, 5)] = F::one();
-        a[(r1, 6)] = -v * x;
-        a[(r1, 7)] = -v * y;
-        b[r1] = v;
-    }
-
-    let x = a.lu().solve(&b)?;
-    let hn = Matrix3::<F>::new(x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], F::one());
-
-    let h_den = denormalize_homography(hn, t_src, t_dst)?;
-    let h_den = normalize_homography(h_den)?;
-    Some(Homography::new(h_den))
-}
-
-/// 4-point variant of [`estimate_homography_with_quality`].
-pub fn homography_from_4pt_with_quality<F: RealField + Copy>(
-    src: &[Point2<F>; 4],
-    dst: &[Point2<F>; 4],
-) -> Option<(Homography<F>, HomographyQuality<F>)> {
-    let h = homography_from_4pt(src, dst)?;
-    let q = HomographyQuality::from_homography(&h);
-    Some((h, q))
-}
+// Single source of truth for the homography type, quality metrics, and the
+// Hartley-normalised DLT estimators: defined in `projective_grid::geometry` and
+// re-exported here so detectors keep importing them from `calib_targets_core`.
+// `estimate_homography_rect_to_img` is core's descriptive alias for the generic
+// `estimate_homography` — source points are the rectified board, destination
+// points are image pixels, so the returned `H` maps board → image.
+pub use projective_grid::geometry::{
+    estimate_homography as estimate_homography_rect_to_img, estimate_homography_with_quality,
+    homography_from_4pt, homography_from_4pt_with_quality, Homography, HomographyQuality,
+};
 
 /// Convert [`Homography`] into the next crate's projective transform
 /// representation. The underlying 3×3 matrix is copied directly.
@@ -303,102 +66,10 @@ pub fn warp_perspective_gray(
     }
 }
 
-fn hartley_normalization<F: RealField + Copy>(cx: F, cy: F, mean_dist: F) -> Matrix3<F> {
-    let s = if mean_dist > lit(1e-12) {
-        lit::<F>(2.0).sqrt() / mean_dist
-    } else {
-        F::one()
-    };
-
-    Matrix3::new(
-        s,
-        F::zero(),
-        -s * cx,
-        F::zero(),
-        s,
-        -s * cy,
-        F::zero(),
-        F::zero(),
-        F::one(),
-    )
-}
-
-fn normalize_points<F: RealField + Copy>(pts: &[Point2<F>]) -> (Vec<Point2<F>>, Matrix3<F>) {
-    let n = lit(pts.len() as f64);
-    let mut cx = F::zero();
-    let mut cy = F::zero();
-    for p in pts {
-        cx += p.x;
-        cy += p.y;
-    }
-    cx /= n;
-    cy /= n;
-
-    let mut mean_dist = F::zero();
-    for p in pts {
-        let dx = p.x - cx;
-        let dy = p.y - cy;
-        mean_dist += (dx * dx + dy * dy).sqrt();
-    }
-    mean_dist /= n;
-
-    let t = hartley_normalization(cx, cy, mean_dist);
-    let mut out = Vec::with_capacity(pts.len());
-    for p in pts {
-        let v = t * Vector3::new(p.x, p.y, F::one());
-        out.push(Point2::new(v[0], v[1]));
-    }
-    (out, t)
-}
-
-fn normalize_points4<F: RealField + Copy>(pts: &[Point2<F>; 4]) -> ([Point2<F>; 4], Matrix3<F>) {
-    let n = lit(4.0);
-    let mut cx = F::zero();
-    let mut cy = F::zero();
-    for p in pts {
-        cx += p.x;
-        cy += p.y;
-    }
-    cx /= n;
-    cy /= n;
-
-    let mut mean_dist = F::zero();
-    for p in pts {
-        let dx = p.x - cx;
-        let dy = p.y - cy;
-        mean_dist += (dx * dx + dy * dy).sqrt();
-    }
-    mean_dist /= n;
-
-    let t = hartley_normalization(cx, cy, mean_dist);
-    let mut out = [Point2::new(F::zero(), F::zero()); 4];
-    for (i, p) in pts.iter().enumerate() {
-        let v = t * Vector3::new(p.x, p.y, F::one());
-        out[i] = Point2::new(v[0], v[1]);
-    }
-    (out, t)
-}
-
-fn normalize_homography<F: RealField + Copy>(h: Matrix3<F>) -> Option<Matrix3<F>> {
-    let s = h[(2, 2)];
-    if s.abs() < lit(1e-12) {
-        return None;
-    }
-    Some(h / s)
-}
-
-fn denormalize_homography<F: RealField + Copy>(
-    hn: Matrix3<F>,
-    t_src: Matrix3<F>,
-    t_dst: Matrix3<F>,
-) -> Option<Matrix3<F>> {
-    let t_dst_inv = t_dst.try_inverse()?;
-    Some(t_dst_inv * hn * t_src)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use nalgebra::Matrix3;
 
     fn assert_close(a: Point2<f32>, b: Point2<f32>, tol: f32) {
         let dx = (a.x - b.x).abs();
@@ -414,29 +85,13 @@ mod tests {
         );
     }
 
+    /// Smoke-test that the re-exported `estimate_homography_rect_to_img` alias
+    /// resolves from `calib_targets_core` and recovers a clean grid. The
+    /// estimator itself is exhaustively tested in `projective_grid::geometry`
+    /// (4-point, overdetermined, f64, and a random reference-SVD battery); this
+    /// only guards the core-level re-export alias.
     #[test]
-    fn four_point_fit_maps_tl_tr_br_bl() {
-        let rect = [
-            Point2::new(0.0_f32, 0.0),
-            Point2::new(100.0, 0.0),
-            Point2::new(100.0, 80.0),
-            Point2::new(0.0, 80.0),
-        ];
-        let image = [
-            Point2::new(20.0_f32, 30.0),
-            Point2::new(130.0, 25.0),
-            Point2::new(140.0, 120.0),
-            Point2::new(15.0, 115.0),
-        ];
-
-        let h = homography_from_4pt(&rect, &image).expect("fit");
-        for (src, dst) in rect.into_iter().zip(image) {
-            assert_close(h.apply(src), dst, 1e-3);
-        }
-    }
-
-    #[test]
-    fn overdetermined_estimate_recovers_clean_grid() {
+    fn reexported_estimate_alias_recovers_clean_grid() {
         let ground_truth = Homography::new(Matrix3::new(
             1.0, 0.2, 12.0, -0.1, 0.9, 6.0, 0.0006, 0.0004, 1.0,
         ));
@@ -455,6 +110,8 @@ mod tests {
         }
     }
 
+    /// Core-specific: the `nalgebra::Projective2` bridge round-trips the matrix
+    /// exactly (this pair lives in core because it needs `Projective2`).
     #[test]
     fn projective2_bridge_round_trips() {
         let h = Homography::new(Matrix3::new(
@@ -466,26 +123,5 @@ mod tests {
                 assert_eq!(bridged.h[(r, c)], h.h[(r, c)]);
             }
         }
-    }
-
-    #[test]
-    fn quality_reports_finite_metrics_for_clean_homography() {
-        let rect = [
-            Point2::new(0.0_f32, 0.0),
-            Point2::new(100.0, 0.0),
-            Point2::new(100.0, 100.0),
-            Point2::new(0.0, 100.0),
-        ];
-        let dst = [
-            Point2::new(50.0_f32, 50.0),
-            Point2::new(150.0, 60.0),
-            Point2::new(140.0, 160.0),
-            Point2::new(40.0, 150.0),
-        ];
-        let (_, q) = homography_from_4pt_with_quality(&rect, &dst).expect("h");
-        assert!(q.max_singular_value.is_finite() && q.max_singular_value > 0.0);
-        assert!(q.min_singular_value > 0.0);
-        assert!(q.condition.is_finite());
-        assert!(q.determinant.abs() > 1e-3);
     }
 }

--- a/crates/calib-targets-core/src/lib.rs
+++ b/crates/calib-targets-core/src/lib.rs
@@ -26,6 +26,7 @@
 mod bit_likelihood;
 mod chess;
 mod corner;
+mod corner_map;
 mod grid_alignment;
 mod grid_smoothness;
 mod homography;
@@ -57,6 +58,7 @@ pub use corner::{
     axis_estimate_from_next, axis_estimate_to_next, AxisEstimate, GridCoords, LabeledCorner,
     TargetDetection, TargetKind,
 };
+pub use corner_map::{complete_cell_corners, corner_map_bounds, CornerMap};
 pub use grid_alignment::{
     cell_rect_corners_at, grid_alignment_from_next, grid_alignment_to_next, grid_coords_from_next,
     grid_coords_to_next, grid_transform_from_next, grid_transform_to_next, GridAlignment,

--- a/crates/calib-targets-marker/src/detect.rs
+++ b/crates/calib-targets-marker/src/detect.rs
@@ -2,10 +2,7 @@ use crate::circle_score::{
     score_circle_in_square, CircleCandidate, CirclePolarity, CircleScoreParams,
 };
 use crate::coords::CellCoords;
-use calib_targets_core::{GrayImageView, GridCoords};
-
-use nalgebra::Point2;
-use std::collections::HashMap;
+use calib_targets_core::{complete_cell_corners, corner_map_bounds, CornerMap, GrayImageView};
 
 #[cfg(feature = "tracing")]
 use tracing::instrument;
@@ -16,29 +13,15 @@ use tracing::instrument;
 )]
 pub(crate) fn detect_circles_via_square_warp(
     img: &GrayImageView<'_>,
-    map: &HashMap<GridCoords, Point2<f32>>, // (i,j)->pixel corner
+    map: &CornerMap, // (i,j) -> pixel corner
     score_params: &CircleScoreParams,
     // optional ROI in grid cell coords to avoid scanning whole board:
     roi: Option<(i32, i32, i32, i32)>, // (i_min, j_min, i_max, j_max) on CELL indices
 ) -> Vec<CircleCandidate> {
-    if map.is_empty() {
+    // Corner bounds → cell-index range: cells span [min .. max-1] on each axis.
+    let Some((min_i, min_j, max_i, max_j)) = corner_map_bounds(map) else {
         return Vec::new();
-    }
-
-    // Determine scan bounds from map
-    let mut min_i = i32::MAX;
-    let mut min_j = i32::MAX;
-    let mut max_i = i32::MIN;
-    let mut max_j = i32::MIN;
-
-    for g in map.keys() {
-        min_i = min_i.min(g.i);
-        min_j = min_j.min(g.j);
-        max_i = max_i.max(g.i);
-        max_j = max_j.max(g.j);
-    }
-
-    // cell indices range: i in [min_i .. max_i-1], j in [min_j .. max_j-1]
+    };
     let cell_min_i = min_i;
     let cell_min_j = min_j;
     let cell_max_i = max_i - 1;
@@ -62,19 +45,10 @@ pub(crate) fn detect_circles_via_square_warp(
 
     for j in scan_j0..=scan_j1 {
         for i in scan_i0..=scan_i1 {
-            // corners TL,TR,BR,BL in image space
-            let g00 = GridCoords { i, j };
-            let g10 = GridCoords { i: i + 1, j };
-            let g11 = GridCoords { i: i + 1, j: j + 1 };
-            let g01 = GridCoords { i, j: j + 1 };
-
-            let (Some(&p00), Some(&p10), Some(&p11), Some(&p01)) =
-                (map.get(&g00), map.get(&g10), map.get(&g11), map.get(&g01))
-            else {
+            // corners_img is [TL, TR, BR, BL] in image space
+            let Some(corners_img) = complete_cell_corners(map, i, j) else {
                 continue;
             };
-
-            let corners_img = [p00, p10, p11, p01]; // TL,TR,BR,BL
 
             let cell = CellCoords { i, j };
             if let Some(c) = score_circle_in_square(img, &corners_img, cell, score_params) {
@@ -119,7 +93,8 @@ pub(crate) fn top_k_by_polarity(
 mod tests {
     use super::*;
     use crate::circle_score::CircleScoreParams;
-    use calib_targets_core::GrayImageView;
+    use calib_targets_core::{GrayImageView, GridCoords};
+    use nalgebra::Point2;
 
     fn dummy_image() -> GrayImageView<'static> {
         GrayImageView {
@@ -132,7 +107,7 @@ mod tests {
     #[test]
     fn detect_circles_empty_map_returns_empty() {
         let img = dummy_image();
-        let map = HashMap::new();
+        let map = CornerMap::new();
         let out = detect_circles_via_square_warp(&img, &map, &CircleScoreParams::default(), None);
         assert!(out.is_empty());
     }
@@ -140,7 +115,7 @@ mod tests {
     #[test]
     fn detect_circles_insufficient_corners_returns_empty() {
         let img = dummy_image();
-        let mut map = HashMap::new();
+        let mut map = CornerMap::new();
         map.insert(GridCoords { i: 0, j: 0 }, Point2::new(0.0, 0.0));
         map.insert(GridCoords { i: 1, j: 0 }, Point2::new(1.0, 0.0));
 

--- a/crates/calib-targets-marker/src/detector.rs
+++ b/crates/calib-targets-marker/src/detector.rs
@@ -4,8 +4,6 @@ use crate::diagnostics::MarkerBoardDiagnostics;
 use crate::match_circles::{estimate_grid_alignment, match_expected_circles};
 use crate::types::{CircleMatch, MarkerBoardDetectionResult, MarkerBoardParams};
 
-use std::collections::HashMap;
-
 use nalgebra::Point2;
 
 use calib_targets_chessboard::ChessCorner;
@@ -13,7 +11,7 @@ use calib_targets_chessboard::{
     ChessboardDetection, ChessboardParamsError, Detector as ChessDetector,
 };
 use calib_targets_core::{
-    GrayImageView, GridAlignment, GridCoords, LabeledCorner, TargetDetection, TargetKind,
+    CornerMap, GrayImageView, GridAlignment, LabeledCorner, TargetDetection, TargetKind,
 };
 
 /// Marker board detector: chessboard + three circle markers.
@@ -230,6 +228,6 @@ fn relabel_as_marker(mut detection: TargetDetection) -> TargetDetection {
     detection
 }
 
-fn build_corner_map(det: &ChessboardDetection) -> HashMap<GridCoords, Point2<f32>> {
+fn build_corner_map(det: &ChessboardDetection) -> CornerMap {
     det.corners.iter().map(|c| (c.grid, c.position)).collect()
 }


### PR DESCRIPTION
Executes two items from the consolidation backlog (`docs/architecture/chore-backlog.md`). Both are **behavior-preserving** — the focus was eliminating duplication without any recall/precision change. Validated on the full workspace test (chessboard regression + charuco public-image reprojection gates + projective-grid).

## C-1 — unify the verbatim-forked homography solver (top P1 finding, D-1)

The Hartley-normalised DLT homography estimator existed as **two byte-identical copies**: `calib-targets-core/src/homography.rs` and `projective-grid/src/geometry/homography.rs`. The fork existed only because `projective-grid` sits below `core` in the crate DAG and won't depend on it, so the algorithm was copied down.

- **Single source of truth** now lives in `projective-grid::geometry` (the lowest crate; `core` already depends on it). `core` re-exports the type, quality metrics, and estimators.
- `core` keeps only the three helpers that genuinely need core-level deps `projective-grid` lacks: `warp_perspective_gray` (image types) and the `homography_to_next` / `homography_from_next` `nalgebra::Projective2` bridges.
- `estimate_homography_rect_to_img` becomes a descriptive re-export alias for `projective_grid::geometry::estimate_homography`.
- **~364 LOC** of duplicated numeric code deleted; one implementation, one test battery (projective-grid's 4-point / overdetermined / f64 / random reference-SVD suite). `core::Homography` is now literally the same type as `projective_grid::geometry::Homography`, removing a latent type-bridge.

**API note (0.10.0 window):** the public generic bound on core's homography surface tightens from `RealField + Copy` to projective-grid's sealed `Float` (= `RealField + Copy + From<f32> + 'static`). `f32`/`f64` — the only real instantiations — satisfy both, so no production caller is affected.

## C-6 — share the complete-square-cell enumeration

The backlog framed this as "share one `build_corner_map`", but the two `build_corner_map` functions are **genuinely different operations** (marker's trivial `&ChessboardDetection` map vs charuco's inlier-filtered `&[LabeledCorner]` builder) — merging them would be a *worse* abstraction, so they stay separate.

The real duplication was the **complete-square-cell enumeration**, verbatim-identical between charuco's `build_marker_cells` and marker's `detect_circles_via_square_warp`: bbox-fold the corner-map keys, then per cell form `g00/g10/g11/g01`, look all four up, skip if any missing, assemble `[p00,p10,p11,p01]` in TL,TR,BR,BL order.

Extracted into a new `calib-targets-core::corner_map` module:
- `CornerMap` — the shared grid→image map type (was a `pub(crate)` alias in charuco; marker spelled it out as a raw `HashMap`).
- `corner_map_bounds` — the bbox fold.
- `complete_cell_corners` — the four-corner lookup, which now **centralises the canonical TL,TR,BR,BL quad-order invariant in exactly one place** (a correctness win — wrong order ⇒ self-crossing quad).

## Validation

- `cargo fmt --all --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅ (no new `#[allow]`)
- `cargo doc --workspace --no-deps` ✅ zero warnings
- `cargo test --workspace` ✅ **0 failures** — chessboard regression, charuco public-image (`small`/`small2`/`mid`/`large`) reprojection gates, projective-grid (139), and the 4 new `corner_map` unit tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)