### PR TITLE
chore: roadmap follow-ups — Gap 18 resolved (#61) + drop bench AlgorithmArg dead seam (C-4)

### DIFF
--- a/crates/calib-targets-bench/src/bin/bench/cli.rs
+++ b/crates/calib-targets-bench/src/bin/bench/cli.rs
@@ -2,7 +2,6 @@
 //! the value-enum knobs and their conversions into detector types, and the
 //! small param-loading helpers shared by the subcommands.
 
-use calib_targets::chessboard::DetectorParams;
 use calib_targets::detect::OrientationMethod;
 use calib_targets_bench::dataset::ImageKind;
 use calib_targets_bench::Engine;
@@ -54,11 +53,6 @@ pub(crate) struct AblateArgs {
     /// `130x130_puzzle`). The key tractability lever for the private campaign.
     #[arg(long)]
     pub(crate) group: Option<String>,
-    /// Graph-build algorithm of the baseline (and every variation). Default
-    /// is the topological grid builder; `topological.*`
-    /// knob rows are only meaningful here.
-    #[arg(long, value_enum, default_value_t = AlgorithmArg::Topological)]
-    pub(crate) algorithm: AlgorithmArg,
     /// Detection engine. `pipeline` runs the full chessboard detector.
     #[arg(long, value_enum, default_value_t = EngineArg::Pipeline)]
     pub(crate) engine: EngineArg,
@@ -142,10 +136,6 @@ pub(crate) struct RunArgs {
     /// Restrict to a single image (relative path under workspace root).
     #[arg(long)]
     pub(crate) image: Option<String>,
-    /// Which graph-build algorithm to exercise. Default is the topological
-    /// grid builder, which is also the cell `bless` pins baselines from.
-    #[arg(long, value_enum, default_value_t = AlgorithmArg::Topological)]
-    pub(crate) algorithm: AlgorithmArg,
     /// Detection engine. `pipeline` runs the full chessboard detector;
     /// `grid` drives the projective-grid grid builder directly (bypassing
     /// chessboard recovery). The slug is part of the report filename so cells
@@ -178,11 +168,6 @@ pub(crate) struct PreviewArgs {
     /// Render every image, even when the dataset filter / image filter would skip.
     #[arg(long)]
     pub(crate) all: bool,
-    /// Which graph-build algorithm to exercise. Output filenames carry the
-    /// algorithm name as a suffix so two runs can coexist in the same `--out`
-    /// directory. Default is the topological grid builder.
-    #[arg(long, value_enum, default_value_t = AlgorithmArg::Topological)]
-    pub(crate) algorithm: AlgorithmArg,
     /// Detection engine (see `run --help`). The slug is part of the overlay
     /// filename so cells coexist in the same `--out` directory.
     #[arg(long, value_enum, default_value_t = EngineArg::Pipeline)]
@@ -222,18 +207,12 @@ impl From<DatasetKindArg> for ImageKind {
     }
 }
 
-#[derive(Clone, Copy, Debug, clap::ValueEnum, PartialEq, Eq)]
-pub(crate) enum AlgorithmArg {
-    Topological,
-}
-
-impl AlgorithmArg {
-    pub(crate) fn slug(self) -> &'static str {
-        match self {
-            AlgorithmArg::Topological => "topological",
-        }
-    }
-}
+/// The bench exercises a single graph-build algorithm (the topological grid
+/// builder — the sole builder since the seed-and-grow seam was removed). The
+/// slug is still embedded in the `engine.algorithm.orientation` config id, the
+/// result rows, and output filenames, so `compare` parsing and pinned baselines
+/// stay stable.
+pub(crate) const ALGORITHM_SLUG: &str = "topological";
 
 #[derive(Clone, Copy, Debug, clap::ValueEnum, PartialEq, Eq)]
 pub(crate) enum EngineArg {
@@ -283,10 +262,6 @@ impl From<OrientationMethodArg> for OrientationMethod {
             OrientationMethodArg::DiskFit => OrientationMethod::DiskFit,
         }
     }
-}
-
-pub(crate) fn params_with(_algorithm: AlgorithmArg) -> DetectorParams {
-    DetectorParams::default()
 }
 
 // Partial-config loading lives in the library so the studio server shares

--- a/crates/calib-targets-bench/src/bin/bench/main.rs
+++ b/crates/calib-targets-bench/src/bin/bench/main.rs
@@ -34,8 +34,8 @@ use calib_targets_bench::{workspace_root, Engine};
 use calib_targets_bench::compare::{build_comparison, load_report, render_markdown};
 use calib_targets_bench::report::{bench_results_dir, save_report};
 use cli::{
-    load_chessboard_config, params_with, AblateArgs, BlessArgs, Cli, Cmd, CompareArgs, PreviewArgs,
-    RunArgs,
+    load_chessboard_config, AblateArgs, BlessArgs, Cli, Cmd, CompareArgs, PreviewArgs, RunArgs,
+    ALGORITHM_SLUG,
 };
 use diagnose::cmd_diagnose;
 use report::print_summary;
@@ -97,7 +97,7 @@ fn cmd_run(args: RunArgs, fail_on_diff: bool) -> ExitCode {
     let config_id = format!(
         "{}.{}.{}",
         args.engine.slug(),
-        args.algorithm.slug(),
+        ALGORITHM_SLUG,
         args.orientation_method.slug(),
     );
     let ctx = RunContext {
@@ -149,12 +149,12 @@ fn cmd_preview(args: PreviewArgs) -> ExitCode {
     }
 
     let out_root = workspace_root().join(&args.out);
-    let params = params_with(args.algorithm);
+    let params = DetectorParams::default();
     let engine = Engine::from(args.engine);
     let config_slug = format!(
         "{}.{}.{}",
         args.engine.slug(),
-        args.algorithm.slug(),
+        ALGORITHM_SLUG,
         args.orientation_method.slug(),
     );
     let mut chess_cfg = default_chess_config();
@@ -376,7 +376,7 @@ fn cmd_ablate(args: AblateArgs) -> ExitCode {
     let base_config_id = format!(
         "{}.{}.{}",
         args.engine.slug(),
-        args.algorithm.slug(),
+        ALGORITHM_SLUG,
         args.orientation_method.slug(),
     );
     let dataset_filter = args

--- a/docs/algorithms/algorithmic_gaps.md
+++ b/docs/algorithms/algorithmic_gaps.md
@@ -167,33 +167,60 @@ opt-in legacy fallback. A proper fix (enumerate all four rotations in
 must be gated on the private ChArUco regression sweep before landing; it is
 deferred until that path needs attention.
 
-### Gap 18 — PuzzleBoard decode fails under heavy radial distortion (OPEN)
+### Gap 18 — PuzzleBoard decode under heavy radial distortion (RESOLVED, PR #61, 2026-06-23)
 
-Measured 2026-06-23 on the public `puzzleboard_reference/` author set
-(Stelldinger et al. CC0 oracle frames) via the `interop_authors` harness
-(`PuzzleBoardSpec::new(20, 20, 5.0)` + `sweep_for_board` +
-`detect_puzzleboard_best`): **4 of 10** frames decode (example0/4/5/6 — the
-last three at BER ≈ 0); the other six fail at the master-match stage.
-`example2.png` (flagged in `crates/calib-targets-bench/datasets.toml` as
-"visible radial distortion — Stage 6 refusal expected") returns *decoding
-failed: no position match above confidence threshold*.
+**Was:** on the public `puzzleboard_reference/` author set (Stelldinger et al.
+CC0 oracle frames), only **4 of 10** frames decoded (example0/4/5/6); the other
+six failed at the master-match stage, and `example2.png` ("visible radial
+distortion") returned *decoding failed: no position match above confidence
+threshold*. The chessboard **grid** detected cleanly on all of them — only the
+edge-dot → 501×501 master decode failed, because radial distortion shifts the
+dot off the raw chord midpoint enough to corrupt the bit reads.
 
-The chessboard **grid** still detects cleanly on these frames (the cross-tile
-pattern yields ChESS X-junctions at every intersection); only the edge-dot →
-501×501 master decode fails. Radial distortion shifts the sampled
-edge-midpoint dots off their nominal grid-relative positions enough to corrupt
-the bit reads below the soft-LL master-match confidence threshold. Consistent
-with precision-by-construction, the decoder **refuses** rather than mislabels.
+**Fix that landed (PR #61).** Sample each edge bit at distortion-aware candidate
+centers instead of only the raw chord midpoint, keeping the highest-confidence
+reading (the midpoint is always retained as a fallback):
 
-**Current handling.** The public performance report renders `example2.png` as
-a **chessboard** card (grid-only), not a PuzzleBoard card, because full decode
-does not succeed on it.
+- the cell's shared-edge midpoint via the local unit-cell→quad homography of
+  each adjoining square (**perspective** correction), and
+- a cubic-Lagrange interpolation of the edge midpoint along the curved grid line
+  through the two flanking corners (`-1/16, 9/16, 9/16, -1/16` at t = ½ — a
+  curvature-continuity estimate, **lens** correction).
 
-**Candidate fix.** Decode in a distortion-corrected grid frame: fit a low-order
-radial model from the labelled chessboard grid (recovered cleanly), warp the
-edge-midpoint sample points through it, and re-read the bits — rather than
-sampling in the raw image frame. The grid is already trusted; the dots just
-need the same correction. Ties into the distortion-recall line below. Deferred.
+This realizes the original "decode in a distortion-corrected grid frame"
+candidate as a *local-geometry* equivalent: no explicit global radial model is
+needed; the already-trusted grid supplies the per-cell correction.
+`sweep_for_board` additionally appends a second pass using the legacy
+hard-weighted scorer at the paper's 40% BER allowance to recover high-distortion
+fragments; `PuzzleBoardParams::for_board` (the single-config default) is
+unchanged.
+
+**Validation.** `example1/2/3` — previously among the six master-match failures
+— now decode (253/180/28 labelled corners), joining example0/4/5/6 for **7 of
+10**. The new `author_examples_1_2_3_decode_when_reference_dataset_present` test
+asserts the decoded `(i, j)` labels are consistent with the master positions
+under a single D4 transform (mod 501) — i.e. correct, not merely present. See
+Gap 19 for the residual precision caveat this pass introduces.
+
+### Gap 19 — 40% BER hard fallback has no uniqueness gate (OPEN)
+
+The high-distortion sweep pass added in Gap 18's fix decodes with the
+hard-weighted scorer at a 40% BER allowance and **no best-vs-runner-up margin
+gate** (`score_margin = ∞` on the hard path), unlike the soft scorer's
+`alignment_min_margin`. On a *full* board this is safe — wrong master origins
+sit near 50% BER, comfortably above the gate — and the author-set decode labels
+are D4-consistent. The residual risk is a *small fragment*: with few observed
+edges, 40% BER is a small absolute bit budget, so a wrong origin could pass. And
+because `detect_puzzleboard_best` selects on `(corners.len(), mean_confidence)`,
+such a fragment could in principle out-rank a correct decode.
+
+No false positive has been observed: the author D4-consistency test passes, and
+the single-config `for_board` regression path is unaffected (the sweep / 40% pass
+is reachable only through `detect_puzzleboard_best`). Per the evidence-driven
+mandate, the next step is to **construct a witness** frame the 40% pass actually
+mislabels before changing the gate. Candidate guards once a witness exists:
+require a best-vs-runner-up BER margin on the hard path, or a minimum
+observed-edge count for the 40% pass. Deferred pending a witness.
 
 ---
 

--- a/docs/development/profiling.md
+++ b/docs/development/profiling.md
@@ -105,7 +105,7 @@ wall-clock per span), enable `tracing` on the facade and set `RUST_LOG`:
 RUST_LOG=info cargo run --profile profiling \
     --features "calib-targets/tracing" \
     -p calib-targets-bench --bin bench -- run \
-    --algorithm topological --image testdata/large.png
+    --image testdata/large.png
 ```
 
 ## Capture matrix

--- a/docs/development/refactor-gates.md
+++ b/docs/development/refactor-gates.md
@@ -28,10 +28,11 @@ cargo test -p calib-targets-puzzleboard --release -- --ignored
 
 ## Canonical cells
 
-The bench CLI defaults (`--algorithm topological --engine pipeline
---orientation-source chess-axes --orientation-method ring-fit`) track the
-production `GraphBuildAlgorithm::Topological` (the sole algorithm) — the same
-cell `bench bless` pins baselines from. Non-default cells (grid engine,
+The bench CLI defaults (`--engine pipeline --orientation-source chess-axes
+--orientation-method ring-fit`) exercise the production
+`GraphBuildAlgorithm::Topological` (the sole graph builder, hard-wired since the
+seed-and-grow seam was removed) — the same cell `bench bless` pins baselines
+from. Non-default cells (grid engine,
 neighbour-edges) write coexisting reports under `bench_results/` but are
 **not** compared against the committed baseline; they are tracked by the
 "before" snapshots recorded at the start of the effort (local-only, see


### PR DESCRIPTION
Two small roadmap follow-ups after the #61 (puzzleboard fix) and #62 (C-1/C-6) merges. Both behavior-neutral.

## 1. Gap ledger: Gap 18 resolved, Gap 19 added

PR #61 fixed the PuzzleBoard radial-distortion decode failure. Update `docs/algorithms/algorithmic_gaps.md`:

- **Gap 18 → RESOLVED.** Records what landed: distortion-aware edge sampling (local unit-cell→quad homography for perspective + cubic-Lagrange grid-line interpolation `-1/16, 9/16, 9/16, -1/16` for lens curvature), keeping the chord midpoint as fallback; plus the sweep's 40% BER hard pass. This realizes the original "decode in a distortion-corrected grid frame" candidate as a *local-geometry* equivalent. example1/2/3 now decode (7 of 10 author frames) with D4-consistent labels.
- **Gap 19 → OPEN (new).** Tracks the residual precision caveat the 40% hard pass introduces: no best-vs-runner-up margin gate on the hard path, so a *small fragment* could in principle admit a wrong origin, and `detect_puzzleboard_best` selects on corner count. No false positive observed (author D4-consistency test passes; the single-config `for_board` path is unaffected). Per the evidence-driven rule, the next step is to construct a witness before changing the gate — deferred.

## 2. C-4 follow-up: drop the dead bench `AlgorithmArg` seam

The bench CLI carried the same dead single-variant seam C-4 removed from projective-grid, one layer up: an `AlgorithmArg` enum with one variant, a `--algorithm` flag on three subcommands, and a `params_with(_algorithm)` factory that ignored its arg. Removed the enum, the flags, and the factory.

The `"topological"` slug is preserved as an `ALGORITHM_SLUG` constant, so the `engine.algorithm.orientation` config id, result rows, output filenames, and `compare`'s parsing + pinned baselines are **byte-for-byte unchanged**. The two docs referencing `--algorithm topological` are updated.

## Validation
- `cargo fmt --all --check` ✅
- `cargo clippy -p calib-targets-bench --all-targets -- -D warnings` ✅
- `cargo doc --workspace --no-deps` ✅ zero warnings
- `cargo test -p calib-targets-bench` ✅ 24 passed (incl. `compare` config-id parsing) — output schema unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)