### PR TITLE
fix(puzzleboard): bounded-distance uniqueness gate closes Gap 19 false-positives (hard + soft)

### DIFF
--- a/.github/pages/performance/data.json
+++ b/.github/pages/performance/data.json
@@ -2,9 +2,9 @@
   "meta": {
     "cpu": "Apple M4 Pro",
     "rustc": "1.95.0",
-    "git_sha": "7a8b245",
-    "repeats": 100,
-    "warmup": 10,
+    "git_sha": "5aa15ca",
+    "repeats": 40,
+    "warmup": 5,
     "generated": "2026-06-23",
     "source": "scripts/gen-perf-data.sh",
     "note": "Public testdata images only. Per-stage numbers are p50 from full_stage_timing, which runs the complete detector (ChArUco for small/large, plain chessboard for mid, PuzzleBoard for example2) on each image."
@@ -20,9 +20,9 @@
       "raw_corners": 267,
       "labelled": 99,
       "markers": 40,
-      "corner_detection_ms": 0.934,
-      "grid_build_ms": 0.537,
-      "decode_ms": 8.503,
+      "corner_detection_ms": 0.976,
+      "grid_build_ms": 0.584,
+      "decode_ms": 9.038,
       "note": "A ~0.4 MP ChArUco board (22\u00d722, DICT_4X4_250). The full detector runs corner detection, a chessboard grid build, then per-cell marker decode + board alignment \u2014 the decode stage dominates on a marker-dense board."
     },
     {
@@ -35,8 +35,8 @@
       "raw_corners": 77,
       "labelled": 77,
       "markers": null,
-      "corner_detection_ms": 1.099,
-      "grid_build_ms": 0.357,
+      "corner_detection_ms": 1.213,
+      "grid_build_ms": 0.377,
       "decode_ms": null,
       "note": "A plain 11\u00d77 inner-corner chessboard (no markers, so no decode stage). Corner detection is the bulk of the work; the owned grid build is a thin slice."
     },
@@ -50,25 +50,25 @@
       "raw_corners": 571,
       "labelled": 315,
       "markers": 132,
-      "corner_detection_ms": 5.442,
-      "grid_build_ms": 2.779,
-      "decode_ms": 23.966,
+      "corner_detection_ms": 5.967,
+      "grid_build_ms": 2.96,
+      "decode_ms": 25.128,
       "note": "A 3 MP ChArUco board (22\u00d722, DICT_4X4_1000). With over a hundred markers to sample and decode, the decode stage is several times the cost of corner detection \u2014 the regime where the owned decode path dominates. The published preview is downscaled to 1024 px wide; the detector runs on the full-resolution image."
     },
     {
-      "label": "Distorted board (PuzzleBoard decode)",
+      "label": "Distorted board (grid only)",
       "file": "testdata/example2.png",
       "img": "./img/example2.png",
-      "kind": "PuzzleBoard",
+      "kind": "Chessboard",
       "width": 640,
       "height": 480,
       "raw_corners": 183,
       "labelled": 179,
       "markers": null,
-      "corner_detection_ms": 0.722,
-      "grid_build_ms": 1.012,
-      "decode_ms": 18.005,
-      "note": "A heavily radially-distorted PuzzleBoard. Its self-identifying edge-dot pattern now decodes against the 501x501 master via distortion-aware edge sampling (per-cell homography + cubic grid-line interpolation), where a raw chord-midpoint sample failed. The decode bar is the full multi-config detect_puzzleboard_best sweep \u2014 this frame only resolves on the 40% BER pass, so every preceding config is real work \u2014 making it the honest auto-detect latency, not a single decode."
+      "corner_detection_ms": 0.791,
+      "grid_build_ms": 1.081,
+      "decode_ms": null,
+      "note": "A heavily radially-distorted board. The chessboard grid detects cleanly (~179 corners), but its self-identifying PuzzleBoard edge-dot pattern does not decode uniquely: the distortion corrupts enough edge bits that a wrong master origin matches as well as the right one, so the bounded-distance uniqueness gate correctly declines the decode (a non-unique absolute position is treated as a detection failure, never a wrong label). No public test frame decodes uniquely as a PuzzleBoard, so this card shows the grid-build cost only \u2014 there is no trustworthy decode stage to time here."
     }
   ],
   "end_to_end": {
@@ -76,22 +76,22 @@
     "frames": [
       {
         "file": "testdata/mid.png",
-        "ms": 1.457,
+        "ms": 1.59,
         "note": "1024x576 Chessboard"
       },
       {
+        "file": "testdata/example2.png",
+        "ms": 1.872,
+        "note": "640x480 Chessboard"
+      },
+      {
         "file": "testdata/small.png",
-        "ms": 9.974,
+        "ms": 10.598,
         "note": "720x540 ChArUco"
       },
       {
-        "file": "testdata/example2.png",
-        "ms": 19.739,
-        "note": "640x480 PuzzleBoard"
-      },
-      {
         "file": "testdata/large.png",
-        "ms": 32.187,
+        "ms": 34.055,
         "note": "2048x1536 ChArUco"
       }
     ]

--- a/.github/pages/performance/index.html
+++ b/.github/pages/performance/index.html
@@ -84,9 +84,10 @@
   <h2>Per-image stage breakdown</h2>
   <div class="desc">Per-stage p50 from <code>full_stage_timing</code>, which runs the <b>complete</b> detector on each
     public image — ChArUco (corner detection → grid build → marker decode) for the two ArUco-marked boards, a plain
-    chessboard (corner detection → grid build) for the marker-free board, and a PuzzleBoard (corner detection → grid
-    build → edge-dot decode) for the radially-distorted board. Corners are detected once and reused, so the
-    grid/decode bars never re-count corner detection.</div>
+    chessboard (corner detection → grid build) for the marker-free board, and a grid-only chessboard for the
+    radially-distorted board (its PuzzleBoard edge-dot decode is declined as non-unique under the distortion, so there
+    is no trustworthy decode stage to time). Corners are detected once and reused, so the grid/decode bars never
+    re-count corner detection.</div>
   <div class="legend">
     <span><i class="sw" style="background:var(--amber)"></i> corner detection (external)</span>
     <span><i class="sw" style="background:var(--blue)"></i> grid build (owned)</span>

--- a/crates/calib-targets-bench/src/bin/full_stage_timing.rs
+++ b/crates/calib-targets-bench/src/bin/full_stage_timing.rs
@@ -45,9 +45,6 @@ use calib_targets::chessboard::{
 };
 use calib_targets::core::{DetectorConfig, GrayImageView};
 use calib_targets::detect::detect_corners;
-use calib_targets::puzzleboard::{
-    PuzzleBoardDetectionResult, PuzzleBoardDetector, PuzzleBoardParams, PuzzleBoardSpec,
-};
 use chess_corners::Threshold;
 use clap::Parser;
 use image::ImageReader;
@@ -76,18 +73,6 @@ enum Kind {
     Chessboard { min_corner_strength: f32 },
     /// ChArUco: a full board spec + the detector knobs the regression mirrors.
     Charuco(CharucoSpec),
-    /// PuzzleBoard: self-identifying chessboard decoded against the 501×501
-    /// master via the edge-dot pattern. Timed through the full multi-config
-    /// sweep (`detect_puzzleboard_best`) — the decode bar is the whole sweep,
-    /// not a single config.
-    Puzzleboard(PuzzleboardSpec),
-}
-
-/// The PuzzleBoard spec for one card. `PuzzleBoardSpec::new(rows, cols, cell)`.
-struct PuzzleboardSpec {
-    rows: u32,
-    cols: u32,
-    cell_size: f32,
 }
 
 /// The ChArUco board + detector parameters for one card, mirroring the
@@ -148,19 +133,18 @@ fn cards() -> Vec<Card> {
                 min_marker_inliers: 64,
             }),
         },
-        // example2.png — a heavily radially-distorted PuzzleBoard. The grid
-        // detects cleanly and, since PR #61's distortion-aware edge sampling
-        // (Gap 18 resolved), the edge-dot pattern now decodes against the
-        // 501×501 master, so it is rendered as a full PuzzleBoard card. Spec
-        // mirrors the `interop_authors` author set: `PuzzleBoardSpec::new(20,
-        // 20, 5.0)`.
+        // example2.png — a heavily radially-distorted board. The chessboard grid
+        // detects cleanly (~179 corners), but the self-identifying edge-dot
+        // pattern does NOT decode uniquely: the distortion corrupts enough bits
+        // that a wrong master origin matches as well as the right one (margin 0),
+        // so the bounded-distance uniqueness gate (Gap 19) correctly declines the
+        // PuzzleBoard decode. It is therefore measured as a grid-only chessboard
+        // card — there is no trustworthy decode stage to time on this frame.
         Card {
             file: "testdata/example2.png",
-            kind: Kind::Puzzleboard(PuzzleboardSpec {
-                rows: 20,
-                cols: 20,
-                cell_size: 5.0,
-            }),
+            kind: Kind::Chessboard {
+                min_corner_strength: 33.0,
+            },
         },
     ]
 }
@@ -365,111 +349,6 @@ fn measure_charuco(
     })
 }
 
-struct PuzzleboardMeasurement {
-    labelled: usize,
-    bit_error_rate: f32,
-    grid_build: Stat,
-    decode: Stat,
-}
-
-fn measure_puzzleboard(
-    view: &GrayImageView<'_>,
-    corners: &[ChessCorner],
-    spec: &PuzzleboardSpec,
-    repeats: usize,
-    warmup: usize,
-) -> Result<PuzzleboardMeasurement, Box<dyn Error>> {
-    let board = PuzzleBoardSpec::new(spec.rows, spec.cols, spec.cell_size)?;
-    let sweep = PuzzleBoardParams::sweep_for_board(&board);
-    let detectors = sweep
-        .iter()
-        .cloned()
-        .map(PuzzleBoardDetector::new)
-        .collect::<Result<Vec<_>, _>>()?;
-
-    // `grid_build` measures one chessboard grid pass — the per-config grid stage
-    // the sweep repeats internally — with the first config's chessboard params.
-    let chess_detector = ChessboardDetector::new(sweep[0].chessboard.clone())?;
-
-    for _ in 0..warmup {
-        let _ = chess_detector.detect_all(corners);
-        let _ = best_sweep_decode(&detectors, view, corners);
-    }
-
-    let mut grid = Vec::with_capacity(repeats);
-    let mut full = Vec::with_capacity(repeats);
-    let mut labelled = 0;
-    let mut bit_error_rate = 1.0f32;
-    let mut decoded = false;
-    for _ in 0..repeats {
-        let g_start = Instant::now();
-        let _ = chess_detector.detect_all(corners);
-        grid.push(elapsed_ms(g_start));
-
-        // Time the full multi-config sweep exactly as `detect_puzzleboard_best`
-        // runs it: every config in order, keeping the best decode. On frames
-        // that need the 40% pass the earlier configs are real work, so this is
-        // the honest end-to-end PuzzleBoard latency, not just the winner.
-        let f_start = Instant::now();
-        let best = best_sweep_decode(&detectors, view, corners);
-        full.push(elapsed_ms(f_start));
-        if let Some(res) = best {
-            decoded = true;
-            labelled = res.corners.len();
-            bit_error_rate = res.decode.bit_error_rate;
-        }
-    }
-
-    if !decoded {
-        return Err(format!(
-            "{}x{} PuzzleBoard: no sweep config decoded — refusing to publish a \
-             grid-only card as a PuzzleBoard (Gap 18 regression?)",
-            spec.rows, spec.cols
-        )
-        .into());
-    }
-
-    let grid_build = p50(grid);
-    let full_stat = p50(full);
-    // decode = full_sweep − one grid_build. The sweep's per-config grid builds
-    // and every config's edge-dot decode land in this bar; the card note flags
-    // it as the full multi-config sweep cost.
-    let decode = Stat {
-        p50_ms: (full_stat.p50_ms - grid_build.p50_ms).max(0.0),
-        mean_ms: (full_stat.mean_ms - grid_build.mean_ms).max(0.0),
-    };
-
-    Ok(PuzzleboardMeasurement {
-        labelled,
-        bit_error_rate,
-        grid_build,
-        decode,
-    })
-}
-
-/// Run every sweep config (corners precomputed) and return the best decode,
-/// matching `detect_puzzleboard_best`'s ranking (most corners, then mean
-/// confidence). `None` if no config decodes.
-fn best_sweep_decode(
-    detectors: &[PuzzleBoardDetector],
-    view: &GrayImageView<'_>,
-    corners: &[ChessCorner],
-) -> Option<PuzzleBoardDetectionResult> {
-    let mut best: Option<PuzzleBoardDetectionResult> = None;
-    for detector in detectors {
-        if let Ok(r) = detector.detect(view, corners) {
-            let better = best.as_ref().is_none_or(|b| {
-                (r.corners.len(), r.decode.mean_confidence)
-                    > (b.corners.len(), b.decode.mean_confidence)
-            });
-            if better {
-                best = Some(r);
-            }
-        }
-    }
-    best
-}
-
 fn measure_card(
     card: &Card,
     chess_cfg: &DetectorConfig,
@@ -526,27 +405,6 @@ fn measure_card(
                 raw_corners,
                 labelled: m.labelled,
                 markers: Some(m.markers),
-                corner_detection,
-                grid_build: m.grid_build,
-                decode: Some(m.decode),
-            })
-        }
-        Kind::Puzzleboard(spec) => {
-            let m = measure_puzzleboard(&view, &corners, spec, repeats, warmup)?;
-            // Surface the decode quality on stderr (not part of the published
-            // JSON schema) so a regenerate can confirm the board still decodes.
-            eprintln!(
-                "  {} → PuzzleBoard decode: {} corners, BER {:.3}",
-                card.file, m.labelled, m.bit_error_rate
-            );
-            Ok(ImageReport {
-                image: card.file.to_owned(),
-                kind: "PuzzleBoard",
-                width: img.width(),
-                height: img.height(),
-                raw_corners,
-                labelled: m.labelled,
-                markers: None,
                 corner_detection,
                 grid_build: m.grid_build,
                 decode: Some(m.decode),

--- a/crates/calib-targets-puzzleboard/src/detector/decode/hard.rs
+++ b/crates/calib-targets-puzzleboard/src/detector/decode/hard.rs
@@ -13,8 +13,8 @@ use crate::code_maps::{
 };
 
 use super::{
-    crt_master_col, crt_master_row, transform_edge_lookup, update_best_candidate, DecodeOutcome,
-    H_COLS, H_ROWS, V_COLS, V_ROWS,
+    crt_master_col, crt_master_row, finalize_hard_winner, transform_edge_lookup,
+    update_best_candidate, DecodeOutcome, HardRunnerUp, H_COLS, H_ROWS, V_COLS, V_ROWS,
 };
 
 /// Hard upper bound on `|optimalH| × |optimalV|` before the separated argmax
@@ -57,6 +57,29 @@ pub(crate) fn decode_fixed_board(
     cols: u32,
     max_bit_error_rate: f32,
 ) -> Option<DecodeOutcome> {
+    let (winner, best_matched, runner_up) = decode_fixed_board_with_runner_up(
+        observed,
+        spec_origin_row,
+        spec_origin_col,
+        rows,
+        cols,
+        max_bit_error_rate,
+    )?;
+    finalize_hard_winner(winner, best_matched, runner_up)
+}
+
+/// Core of [`decode_fixed_board`]: the winning shift plus its matched-bit count
+/// and closest competitor, *before* the uniqueness gate. See
+/// [`decode_with_runner_up`] for the rationale (test access to the pre-gate
+/// runner-up).
+pub(crate) fn decode_fixed_board_with_runner_up(
+    observed: &[PuzzleBoardObservedEdge],
+    spec_origin_row: u32,
+    spec_origin_col: u32,
+    rows: u32,
+    cols: u32,
+    max_bit_error_rate: f32,
+) -> Option<(DecodeOutcome, u32, Option<HardRunnerUp>)> {
     if observed.is_empty() || rows < 2 || cols < 2 {
         return None;
     }
@@ -88,6 +111,12 @@ pub(crate) fn decode_fixed_board(
     }
 
     let mut best: Option<DecodeOutcome> = None;
+    // Uniqueness runner-up: the highest matched-bit count over any shift /
+    // transform *other than the winning one* (tracked regardless of the BER
+    // gate, since a high-matching competitor threatens uniqueness even when it
+    // would itself be BER-rejected). The winner's exact identity moves during
+    // the scan, so on each displacement the old best demotes into the runner.
+    let mut runner_up: Option<HardRunnerUp> = None;
 
     for transform in GRID_TRANSFORMS_D4.iter().copied() {
         // Transform all lookup coordinates into this D4 frame once.
@@ -157,46 +186,103 @@ pub(crate) fn decode_fixed_board(
                         weighted += conf;
                     }
                 }
+                let master_row = spec_or + p_r;
+                let master_col = spec_oc + p_c;
                 let bit_error_rate = if total == 0 {
                     1.0
                 } else {
                     (total - matched) as f32 / total as f32
                 };
-                if bit_error_rate > max_bit_error_rate {
-                    continue;
-                }
+
+                // Would this shift become the reigning best? (BER-gated, then
+                // ranked by the same `(edges_matched, weighted_score)` rule as
+                // the full-board path.) The displaced old best, or any
+                // non-winning shift, competes for the uniqueness runner-up.
                 let score = weighted / total_conf;
-                let mean_confidence = if matched == 0 {
-                    0.0
+                let becomes_best = bit_error_rate <= max_bit_error_rate
+                    && match &best {
+                        None => true,
+                        Some(cur) => {
+                            matched > cur.edges_matched
+                                || (matched == cur.edges_matched && score > cur.weighted_score)
+                        }
+                    };
+
+                if becomes_best {
+                    // Demote the outgoing winner into the runner-up race.
+                    if let Some(prev) = &best {
+                        demote_into_runner(
+                            &mut runner_up,
+                            prev.edges_matched as u32,
+                            prev.master_origin_row,
+                            prev.master_origin_col,
+                            prev.alignment.transform,
+                        );
+                    }
+                    let mean_confidence = if matched == 0 {
+                        0.0
+                    } else {
+                        weighted / matched as f32
+                    };
+                    best = Some(DecodeOutcome {
+                        alignment: GridAlignment {
+                            transform,
+                            translation: [master_col, master_row],
+                        },
+                        edges_matched: matched,
+                        edges_observed: total,
+                        weighted_score: score,
+                        bit_error_rate,
+                        mean_confidence,
+                        master_origin_row: master_row,
+                        master_origin_col: master_col,
+                        score_best: score,
+                        score_runner_up: None,
+                        score_margin: f32::INFINITY,
+                        runner_up_origin_row: None,
+                        runner_up_origin_col: None,
+                        runner_up_transform: None,
+                    });
                 } else {
-                    weighted / matched as f32
-                };
-                let master_row = spec_or + p_r;
-                let master_col = spec_oc + p_c;
-                let candidate = DecodeOutcome {
-                    alignment: GridAlignment {
+                    demote_into_runner(
+                        &mut runner_up,
+                        matched as u32,
+                        master_row,
+                        master_col,
                         transform,
-                        translation: [master_col, master_row],
-                    },
-                    edges_matched: matched,
-                    edges_observed: total,
-                    weighted_score: score,
-                    bit_error_rate,
-                    mean_confidence,
-                    master_origin_row: master_row,
-                    master_origin_col: master_col,
-                    score_best: score,
-                    score_runner_up: None,
-                    score_margin: f32::INFINITY,
-                    runner_up_origin_row: None,
-                    runner_up_origin_col: None,
-                    runner_up_transform: None,
-                };
-                update_best_candidate(&mut best, candidate);
+                    );
+                }
             }
         }
     }
-    best
+
+    let winner = best?;
+    let best_matched = winner.edges_matched as u32;
+    Some((winner, best_matched, runner_up))
+}
+
+/// Update the uniqueness runner-up slot if `matched` exceeds the count it
+/// currently holds. Shared by the fixed-board shift scan (both the demoted
+/// outgoing winner and every non-winning shift route through here).
+fn demote_into_runner(
+    runner_up: &mut Option<HardRunnerUp>,
+    matched: u32,
+    master_row: i32,
+    master_col: i32,
+    transform: GridTransform,
+) {
+    let better = match runner_up {
+        None => true,
+        Some(r) => matched > r.matched,
+    };
+    if better {
+        *runner_up = Some(HardRunnerUp {
+            matched,
+            master_row,
+            master_col,
+            transform,
+        });
+    }
 }
 
 /// Hard-weighted decoder over the full 501 × 501 master.
@@ -216,6 +302,19 @@ pub(crate) fn decode(
     observed: &[PuzzleBoardObservedEdge],
     max_bit_error_rate: f32,
 ) -> Option<DecodeOutcome> {
+    let (winner, best_matched, runner_up) = decode_with_runner_up(observed, max_bit_error_rate)?;
+    finalize_hard_winner(winner, best_matched, runner_up)
+}
+
+/// Core of [`decode`]: returns the winning hypothesis together with its
+/// matched-bit count and the closest competing origin, *before* the uniqueness
+/// gate is applied. The public [`decode`] wraps this with
+/// [`finalize_hard_winner`]; tests use the pre-gate triple directly to validate
+/// the runner-up against an independent brute-force oracle.
+pub(crate) fn decode_with_runner_up(
+    observed: &[PuzzleBoardObservedEdge],
+    max_bit_error_rate: f32,
+) -> Option<(DecodeOutcome, u32, Option<HardRunnerUp>)> {
     if observed.is_empty() {
         return None;
     }
@@ -227,6 +326,14 @@ pub(crate) fn decode(
     let total = observed.len();
 
     let mut best: Option<DecodeOutcome> = None;
+    // Index into `best` of the transform that currently owns the winner, and
+    // the per-transform `(best_count, within_runner)` summaries used to assemble
+    // the global runner-up after the scan. `within_runner` is the closest
+    // *distinct* competing origin within a single transform (a missing second
+    // level is `None`); the cross-transform competitor is the `best_count` of
+    // every *other* transform. See the runner-up assembly below the loop.
+    let mut winner_transform_idx: Option<usize> = None;
+    let mut transform_summaries: Vec<TransformSummary> = Vec::with_capacity(8);
 
     // Scratch buffers for the precompute tables — allocated once, cleared per transform.
     // h_match[a * H_COLS + b]: sum of confidences for horizontal lookups that match at class (a, b).
@@ -238,7 +345,7 @@ pub(crate) fn decode(
     let mut v_match = vec![0.0f32; V_ROWS * V_COLS];
     let mut v_count = vec![0u32; V_ROWS * V_COLS];
 
-    for transform in GRID_TRANSFORMS_D4.iter().copied() {
+    for (transform_idx, transform) in GRID_TRANSFORMS_D4.iter().copied().enumerate() {
         // Transform all lookup coordinates once.
         let transformed: Vec<(i32, i32, EdgeOrientation, u8, f32)> = observed
             .iter()
@@ -324,18 +431,37 @@ pub(crate) fn decode(
         // candidate with strictly more matched bits in one table always wins,
         // and on equal counts the weights add independently).
         //
-        // Step 1: lexicographic max `(count, weight)` over each table and the
-        // set of classes achieving it.
-        let (mc_h, max_h_w, optimal_h) = lex_max_classes(&h_count, &h_match, H_COLS);
-        let (mc_v, max_v_w, optimal_v) = lex_max_classes(&v_count, &v_match, V_COLS);
+        // Step 1: lexicographic max `(count, weight)` over each table, the set
+        // of classes achieving it, and — for the uniqueness gate — the
+        // second-distinct count level (largest count strictly below the max).
+        let h_tab = lex_max_classes(&h_count, &h_match, H_COLS);
+        let v_tab = lex_max_classes(&v_count, &v_match, V_COLS);
+        let (mc_h, max_h_w, optimal_h) = (h_tab.max_count, h_tab.max_weight, &h_tab.classes);
+        let (mc_v, max_v_w, optimal_v) = (v_tab.max_count, v_tab.max_weight, &v_tab.classes);
 
         let best_matched = (mc_h + mc_v) as usize;
         let best_weighted = max_h_w + max_v_w;
 
+        // The joint optimum is the most-matched origin under this transform, so
+        // record `best_count` for the cross-transform runner-up unconditionally
+        // (a competing origin threatens uniqueness whether or not it clears the
+        // BER gate). The representative origin is the row-major-min over the
+        // optimal product, matching the winner-selection tie-break.
+        let best_origin = row_major_min_origin(optimal_h, optimal_v);
+        let within_runner =
+            within_transform_runner_up(transform, &h_tab, &v_tab, mc_h, mc_v, best_origin);
+        transform_summaries.push(TransformSummary {
+            transform,
+            best_count: best_matched as u32,
+            best_origin,
+            within_runner,
+        });
+
         // Step 2: BER early-reject. The joint optimum has the most matched bits
         // of any origin under this transform, so if it fails the gate every
         // other origin (with `matched ≤ best_matched`, hence higher BER) fails
-        // too — the transform contributes no candidate.
+        // too — the transform contributes no winner candidate. (Its `best_count`
+        // is still tracked above as a uniqueness competitor.)
         let bit_error_rate = if total == 0 {
             1.0
         } else {
@@ -355,36 +481,23 @@ pub(crate) fn decode(
                 v_count: &v_count,
                 v_match: &v_match,
             };
-            scan_transform_direct(
+            if scan_transform_direct(
                 transform,
                 &tables,
                 total,
                 total_conf,
                 max_bit_error_rate,
                 &mut best,
-            );
+            ) {
+                winner_transform_idx = Some(transform_idx);
+            }
             continue;
         }
 
-        // Step 4: find the row-major-min origin `(mr, mc)` over the joint
-        // optimal set. The original scan visits origins in (master_row, then
-        // master_col) order and keeps the FIRST candidate at the maximum
-        // (strict `>`), so the winning origin is the lexicographic minimum of
-        // `(mr, mc)` across `optimal_h × optimal_v`.
-        let mut best_origin: Option<(i32, i32)> = None;
-        for &(ha, hb) in &optimal_h {
-            for &(va, vb) in &optimal_v {
-                let mr = crt_master_row(va, ha);
-                let mc = crt_master_col(hb, vb);
-                let better = match best_origin {
-                    None => true,
-                    Some((br, bc)) => (mr, mc) < (br, bc),
-                };
-                if better {
-                    best_origin = Some((mr, mc));
-                }
-            }
-        }
+        // Step 4: the winning origin is the row-major-min over the joint optimal
+        // set (computed above as `best_origin`): the original scan visits origins
+        // in (master_row, then master_col) order and keeps the FIRST candidate at
+        // the maximum (strict `>`).
         let (master_row, master_col) = best_origin.expect("optimal sets are non-empty");
 
         // Every entry in the optimal product shares the same `(count, weight)`,
@@ -418,22 +531,209 @@ pub(crate) fn decode(
             runner_up_origin_col: None,
             runner_up_transform: None,
         };
-        update_best_candidate(&mut best, candidate);
+        if update_best_candidate(&mut best, candidate) {
+            winner_transform_idx = Some(transform_idx);
+        }
     }
 
-    best
+    let winner = best?;
+    let runner_up = assemble_global_runner_up(&transform_summaries, winner_transform_idx);
+    let best_matched = winner.edges_matched as u32;
+    Some((winner, best_matched, runner_up))
 }
 
-/// Find the lexicographic-max `(count, weight)` over a precompute table and
-/// collect every class index `(a, b)` achieving exactly that pair.
+/// Per-transform summary needed to assemble the global uniqueness runner-up:
+/// the transform's most-matched origin count and a representative origin, plus
+/// the closest *distinct* competing origin within that single transform.
+struct TransformSummary {
+    transform: GridTransform,
+    best_count: u32,
+    best_origin: Option<(i32, i32)>,
+    within_runner: Option<HardRunnerUp>,
+}
+
+/// Row-major-min master origin over the joint optimal product `optimal_h ×
+/// optimal_v`. Matches the original scan's first-seen (strict-`>`) tie-break:
+/// the winner is the lexicographic minimum of `(master_row, master_col)`.
+fn row_major_min_origin(
+    optimal_h: &[(usize, usize)],
+    optimal_v: &[(usize, usize)],
+) -> Option<(i32, i32)> {
+    let mut best_origin: Option<(i32, i32)> = None;
+    for &(ha, hb) in optimal_h {
+        for &(va, vb) in optimal_v {
+            let mr = crt_master_row(va, ha);
+            let mc = crt_master_col(hb, vb);
+            let better = match best_origin {
+                None => true,
+                Some((br, bc)) => (mr, mc) < (br, bc),
+            };
+            if better {
+                best_origin = Some((mr, mc));
+            }
+        }
+    }
+    best_origin
+}
+
+/// Closest *distinct* competing origin within a single transform.
 ///
-/// Returns `(max_count, max_weight, classes)` where `classes` holds the
-/// `(a, b)` of each cell with `count == max_count && weight == max_weight`.
+/// The per-origin matched count separates as `h_count[a,b] + v_count[c,d]`, so
+/// the highest sum is `mc_h + mc_v`, achieved by `n_h · n_v` distinct origins
+/// where `n_h` / `n_v` are the counts of cells *at the max count* (weights
+/// ignored — two origins at equal count are two distinct competitors regardless
+/// of weight). If that product exceeds 1 there are ≥2 distinct origins tied at
+/// the maximum — a genuinely ambiguous decode whose runner-up sits at the *same*
+/// count (margin 0). Otherwise the second-highest distinct sum keeps one table
+/// at its max and drops the other to its second-distinct count level:
+/// `max(mc_h + second_v, second_h + mc_v)`. A missing second level (`None`)
+/// means that table is constant and offers no competitor on that side. Returns
+/// `None` only when neither side offers any competitor (a degenerate
+/// single-count-value table pair, e.g. a single observation).
+fn within_transform_runner_up(
+    transform: GridTransform,
+    h_tab: &LexMax,
+    v_tab: &LexMax,
+    mc_h: u32,
+    mc_v: u32,
+    winner_origin: Option<(i32, i32)>,
+) -> Option<HardRunnerUp> {
+    // Case A: ≥2 distinct origins at the joint maximum count → runner-up at the
+    // same count as the winner (margin 0, a genuinely ambiguous decode). The
+    // gate only consumes the count; for the diagnostic origin we prefer a
+    // distinct cell drawn from the weight-max `classes` (the common case), and
+    // fall back to the winner's own origin when the count tie is realized only
+    // by lower-weight cells (a rare degenerate path).
+    if h_tab.n_at_max_count.saturating_mul(v_tab.n_at_max_count) > 1 {
+        let (wr, wc) = winner_origin.unwrap_or((i32::MIN, i32::MIN));
+        // Prefer a distinct origin from the weight-max classes (cheap, common).
+        for &(ha, hb) in &h_tab.classes {
+            for &(va, vb) in &v_tab.classes {
+                let mr = crt_master_row(va, ha);
+                let mc = crt_master_col(hb, vb);
+                if (mr, mc) != (wr, wc) {
+                    return Some(HardRunnerUp {
+                        matched: mc_h + mc_v,
+                        master_row: mr,
+                        master_col: mc,
+                        transform,
+                    });
+                }
+            }
+        }
+        // All weight-max product cells coincide with the winner but the count
+        // tie comes from lower-weight cells: the competing origin still sits at
+        // the full max count. Report it with the winner's origin as the
+        // representative (the gate only consumes the count; the diagnostic
+        // origin is best-effort here, a rare degenerate path).
+        return Some(HardRunnerUp {
+            matched: mc_h + mc_v,
+            master_row: wr,
+            master_col: wc,
+            transform,
+        });
+    }
+
+    // Case B: second-highest distinct sum = max-of-one + second-of-other.
+    let from_v = v_tab.second_count.map(|sv| {
+        // Keep H at its max class, drop V to a second-level class.
+        let (ha, hb) = h_tab.classes[0];
+        let (va, vb) = v_tab
+            .second_class
+            .expect("second_count implies second_class");
+        HardRunnerUp {
+            matched: mc_h + sv,
+            master_row: crt_master_row(va, ha),
+            master_col: crt_master_col(hb, vb),
+            transform,
+        }
+    });
+    let from_h = h_tab.second_count.map(|sh| {
+        let (va, vb) = v_tab.classes[0];
+        let (ha, hb) = h_tab
+            .second_class
+            .expect("second_count implies second_class");
+        HardRunnerUp {
+            matched: sh + mc_v,
+            master_row: crt_master_row(va, ha),
+            master_col: crt_master_col(hb, vb),
+            transform,
+        }
+    });
+    match (from_h, from_v) {
+        (Some(h), Some(v)) => Some(if h.matched >= v.matched { h } else { v }),
+        (Some(h), None) => Some(h),
+        (None, Some(v)) => Some(v),
+        (None, None) => None,
+    }
+}
+
+/// Assemble the global uniqueness runner-up across all transforms.
+///
+/// The runner-up matched count is `max(within_runner of the winning transform,
+/// best_count of every *other* transform)`. A different transform yielding a
+/// D4-equivalent labeling legitimately competes (a fragment too small to break
+/// D4 symmetry cannot pin an absolute orientation and must be rejected).
+fn assemble_global_runner_up(
+    summaries: &[TransformSummary],
+    winner_idx: Option<usize>,
+) -> Option<HardRunnerUp> {
+    let winner_idx = winner_idx?;
+    let mut runner: Option<HardRunnerUp> = summaries[winner_idx].within_runner;
+    for (idx, s) in summaries.iter().enumerate() {
+        if idx == winner_idx {
+            continue;
+        }
+        let candidate = HardRunnerUp {
+            matched: s.best_count,
+            // A degenerate transform with no optimal origin (impossible for a
+            // non-empty observation set) contributes count 0 at a placeholder.
+            master_row: s.best_origin.map_or(0, |(r, _)| r),
+            master_col: s.best_origin.map_or(0, |(_, c)| c),
+            transform: s.transform,
+        };
+        let better = match runner {
+            None => true,
+            Some(r) => candidate.matched > r.matched,
+        };
+        if better {
+            runner = Some(candidate);
+        }
+    }
+    runner
+}
+
+/// Lexicographic-max summary of one precompute table, plus the second-distinct
+/// *count* level used by the uniqueness gate.
+struct LexMax {
+    /// Highest matched count over the table.
+    max_count: u32,
+    /// Highest weight among cells at `max_count` (the lexicographic-max weight).
+    max_weight: f32,
+    /// Cells matching exactly `(max_count, max_weight)`. Drives the winner
+    /// selection's strict-`>` first-seen tie-break — must stay weight-restricted
+    /// for byte-exactness with the original scan.
+    classes: Vec<(usize, usize)>,
+    /// Number of cells whose *count* equals `max_count` (weight ignored). Two
+    /// cells at the same count are two distinct competing origins for the
+    /// uniqueness gate, even if their weights differ.
+    n_at_max_count: usize,
+    /// Largest count strictly below `max_count`, if any.
+    second_count: Option<u32>,
+    /// A representative `(a, b)` cell at `second_count` (row-major first).
+    second_class: Option<(usize, usize)>,
+}
+
+/// Find the lexicographic-max `(count, weight)` over a precompute table, collect
+/// the `(max_count, max_weight)` classes (for the winner tie-break), and report
+/// the second-distinct *count* level (for the uniqueness gate).
+///
 /// `cols` is the table's column count (both tables happen to be length 501, so
 /// it cannot be inferred from the slice length — the H table is `H_ROWS ×
-/// H_COLS` and the V table is `V_ROWS × V_COLS`). The float comparison is exact
-/// `==` so the collected set matches the original scan's strict-`>` tie-break.
-fn lex_max_classes(count: &[u32], weight: &[f32], cols: usize) -> (u32, f32, Vec<(usize, usize)>) {
+/// H_COLS` and the V table is `V_ROWS × V_COLS`). The weight comparison is exact
+/// `==` so the collected `classes` set matches the original scan's strict-`>`
+/// tie-break.
+fn lex_max_classes(count: &[u32], weight: &[f32], cols: usize) -> LexMax {
     debug_assert_eq!(count.len(), weight.len());
     // First pass: lexicographic max of (count, weight).
     let mut max_count = 0u32;
@@ -445,14 +745,39 @@ fn lex_max_classes(count: &[u32], weight: &[f32], cols: usize) -> (u32, f32, Vec
             max_weight = w;
         }
     }
-    // Second pass: collect all classes achieving exactly that pair.
+    // Second pass: collect `(max_count, max_weight)` classes, count the cells at
+    // `max_count` (weight ignored), and find the second-distinct count level
+    // with a row-major-first representative.
     let mut classes = Vec::new();
+    let mut n_at_max_count = 0usize;
+    let mut second_count: Option<u32> = None;
+    let mut second_class: Option<(usize, usize)> = None;
     for (i, &c) in count.iter().enumerate() {
-        if c == max_count && weight[i] == max_weight {
-            classes.push((i / cols, i % cols));
+        if c == max_count {
+            n_at_max_count += 1;
+            if weight[i] == max_weight {
+                classes.push((i / cols, i % cols));
+            }
+        } else {
+            // Track the largest count strictly below the max.
+            let take = match second_count {
+                None => true,
+                Some(s) => c > s,
+            };
+            if take {
+                second_count = Some(c);
+                second_class = Some((i / cols, i % cols));
+            }
         }
     }
-    (max_count, max_weight, classes)
+    LexMax {
+        max_count,
+        max_weight,
+        classes,
+        n_at_max_count,
+        second_count,
+        second_class,
+    }
 }
 
 /// Borrowed view over the four per-transform precompute tables, bundled so the
@@ -467,6 +792,10 @@ struct TransformTables<'a> {
 /// Fallback direct scan over all 501² origins for a single transform, using
 /// the precomputed tables. Byte-identical to the original inner loop; only
 /// invoked when the separated optimal set is pathologically large.
+///
+/// Returns `true` if any of this transform's origins became the reigning best
+/// (so the caller can attribute the global winner to this transform for the
+/// uniqueness runner-up).
 fn scan_transform_direct(
     transform: GridTransform,
     tables: &TransformTables<'_>,
@@ -474,7 +803,8 @@ fn scan_transform_direct(
     total_conf: f32,
     max_bit_error_rate: f32,
     best: &mut Option<DecodeOutcome>,
-) {
+) -> bool {
+    let mut won_any = false;
     for master_row in 0..MASTER_ROWS as i32 {
         let ha = (master_row % H_ROWS as i32) as usize;
         let va = (master_row % V_ROWS as i32) as usize;
@@ -520,7 +850,8 @@ fn scan_transform_direct(
                 runner_up_origin_col: None,
                 runner_up_transform: None,
             };
-            update_best_candidate(best, candidate);
+            won_any |= update_best_candidate(best, candidate);
         }
     }
+    won_any
 }

--- a/crates/calib-targets-puzzleboard/src/detector/decode/mod.rs
+++ b/crates/calib-targets-puzzleboard/src/detector/decode/mod.rs
@@ -46,7 +46,9 @@ mod soft;
 #[cfg(test)]
 mod tests;
 
-pub(crate) use hard::{decode, decode_fixed_board};
+pub(crate) use hard::{
+    decode, decode_fixed_board, decode_fixed_board_with_runner_up, decode_with_runner_up,
+};
 pub(crate) use soft::{decode_fixed_board_soft, decode_soft};
 
 /// Cyclic-period sizes for the precompute tables.
@@ -81,6 +83,202 @@ fn crt_master_col(hb: usize, vb: usize) -> i32 {
 
 const MASTER_ROWS_I32: i32 = crate::board::MASTER_ROWS as i32;
 const MASTER_COLS_I32: i32 = crate::board::MASTER_COLS as i32;
+
+/// The parameter-free uniqueness predicate, shared by the hard and soft paths.
+///
+/// Accept iff `margin > k_winner`, where `margin = best_matched −
+/// runner_up_matched` and `k_winner = edges_observed − best_matched` (the
+/// winner's own mismatch count). Equivalently, the winner's net score
+/// (`matched − mismatched`) must strictly exceed the runner-up's matched count:
+/// `2·best_matched − runner_up_matched > edges_observed`.
+///
+/// `best_matched` is the winning origin's matched-bit count; `runner_up_matched`
+/// is the highest matched-bit count of any *distinct* competing origin (across
+/// all D4 transforms). `margin` is computed with saturating subtraction, so when
+/// a distinct origin out-matches the winner (`runner_up_matched ≥ best_matched`,
+/// which can happen when the soft-LL winner is not the maximum-matched origin)
+/// the margin is `0` and the decode is correctly rejected.
+///
+/// **Why this and not a `C·√N` magnitude threshold:** the master edge code has
+/// minimum Hamming distance `d(w)` that grows ~quadratically with window size
+/// but is only `1` at the `4×4` minimum window (zero error-correction). A
+/// magnitude threshold either rejects clean small *unique* patches (margin `1`,
+/// `k_winner = 0`) or accepts corrupted small *alias* patches (a 1-bit-corrupted
+/// `4×4` is frequently a perfect read of a *different* master location:
+/// `best_matched = N`, `k_winner = 0`, `margin = 1`, but wrong). `margin >
+/// k_winner` rejects the alias case (the perfect alias still only beats the true
+/// origin by `1`, while `k_winner = 0` demands the winner be *strictly* perfect
+/// *and* uniquely so) — but because `d(4) = 1`, no acceptance test can make the
+/// `4×4` window safe under noise, so the pipeline pairs this gate with a
+/// `min_window` sized to the code's distance for the BER budget (bounded-distance
+/// decoding). At those window sizes a worst-case guarantee is unachievable
+/// (`d` would need to exceed `2·⌊BER·N⌋ ≈ 0.8N`, far above the ~`N/4` the code
+/// provides), so safety is empirical-with-defense-in-depth: `min_window` keeps
+/// random corruption below the aliasing regime, and this gate catches the
+/// residual near-aliases.
+#[inline]
+fn passes_uniqueness_gate(
+    edges_observed: usize,
+    best_matched: u32,
+    runner_up_matched: u32,
+) -> bool {
+    let margin = best_matched.saturating_sub(runner_up_matched);
+    let k_winner = (edges_observed as u32).saturating_sub(best_matched);
+    margin > k_winner
+}
+
+/// Apply the parameter-free uniqueness gate to a hard-path winner.
+///
+/// `best_matched` is the winning origin's matched-bit count; `runner_up_matched`
+/// is the highest matched-bit count of any *distinct* competing origin (across
+/// all D4 transforms — D4-equivalent labelings of a fragment too small to break
+/// the symmetry legitimately compete here).
+///
+/// **Criterion (no magic constant):** accept iff
+///
+/// ```text
+///   margin > k_winner
+/// ```
+///
+/// where `margin = best_matched − runner_up_matched` and `k_winner =
+/// edges_observed − best_matched` is the winner's own mismatch count.
+/// Equivalently `2·best_matched − runner_up_matched > edges_observed`: the
+/// winner's *net* score (matched − mismatched) must strictly beat the
+/// runner-up's matched count.
+///
+/// The decode is trustworthy only when the best hypothesis is strictly closer
+/// to a *perfect* read than to its nearest competitor. This separates two
+/// distinct failure modes that a single-magnitude margin threshold conflates:
+///
+/// - A **clean exact** read (`k_winner = 0`) passes at any `margin ≥ 1`, so the
+///   board's exact-uniqueness design is honored at *any* fragment size down to
+///   the pipeline's `min_window` — even a 4×4 patch, whose true origin out-votes
+///   every alias by ≥1 bit, decodes.
+/// - A **noisy-ambiguous** read fails: when the observation is corrupted enough
+///   that a wrong origin matches nearly as many bits (`margin` small) *and* the
+///   winner itself mismatches many bits (`k_winner` large), the winner is not
+///   meaningfully closer to a perfect read than the competitor, and the decode
+///   declines (a miss). The witnessed false positive — a heavily distorted board
+///   where `margin = 0` while `k_winner` is large — is rejected here.
+///
+/// Rejection returns `None`, exactly like a BER-gate failure — a miss, never a
+/// wrong label; the detection contract forbids wrong labels far more strongly
+/// than misses. On acceptance the runner-up diagnostic fields are populated and
+/// `score_margin` carries the integer bit margin (`best_matched −
+/// runner_up_matched`) as `f32`; the winner's own origin / weighted score are
+/// left untouched.
+///
+/// The gate is mode-independent — it is a property of `(observed bits, winning
+/// origin)`, not of how the winner was scored — so the soft-LL path applies the
+/// identical predicate via [`passes_uniqueness_gate`] over its own
+/// matched-count runner-up (the soft `alignment_min_margin` score-gap does *not*
+/// enforce origin uniqueness; measured to false-accept at every window size).
+fn finalize_hard_winner(
+    mut winner: DecodeOutcome,
+    best_matched: u32,
+    runner_up: Option<HardRunnerUp>,
+) -> Option<DecodeOutcome> {
+    let runner_up_matched = runner_up.as_ref().map_or(0, |r| r.matched);
+    if !passes_uniqueness_gate(winner.edges_observed, best_matched, runner_up_matched) {
+        return None;
+    }
+    let margin = best_matched.saturating_sub(runner_up_matched);
+    match runner_up {
+        Some(r) => {
+            winner.score_runner_up = Some(r.matched as f32);
+            winner.score_margin = margin as f32;
+            winner.runner_up_origin_row = Some(r.master_row);
+            winner.runner_up_origin_col = Some(r.master_col);
+            winner.runner_up_transform = Some(r.transform);
+        }
+        None => {
+            // No competing origin at all (degenerate: a single observation, or
+            // a master with a unique total match). Margin is the full count.
+            winner.score_runner_up = None;
+            winner.score_margin = margin as f32;
+            winner.runner_up_origin_row = None;
+            winner.runner_up_origin_col = None;
+            winner.runner_up_transform = None;
+        }
+    }
+    Some(winner)
+}
+
+/// The closest competing origin to a hard-path winner: its matched-bit count
+/// and the master origin / transform that realizes it. Used to populate the
+/// winner's runner-up diagnostic fields and drive the uniqueness gate.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct HardRunnerUp {
+    pub matched: u32,
+    pub master_row: i32,
+    pub master_col: i32,
+    pub transform: GridTransform,
+}
+
+/// Apply the matched-count uniqueness gate to a *soft-LL* winner.
+///
+/// The soft scorer ranks by summed log-likelihood, whose `alignment_min_margin`
+/// gate does **not** enforce origin uniqueness — measured to false-accept a
+/// wrong physical origin at every window size. This re-gates the soft winner by
+/// the same matched-count predicate the hard path uses ([`passes_uniqueness_gate`]).
+///
+/// `matched_top2` is the global matched-count top-2 over the *same* candidate
+/// set the soft winner was drawn from (full master or fixed-board shifts): the
+/// maximum-matched origin (with its identity and matched count) and the closest
+/// distinct competitor. The competitor count for the soft winner is:
+///
+/// - `runner.matched` when the soft winner *is* the maximum-matched origin, or
+/// - `best_matched` (the maximum) otherwise — a distinct origin out-matches the
+///   soft winner, which saturates the margin to `0` and rejects (correct: the
+///   soft winner is not even the best-supported origin).
+///
+/// On acceptance, the soft winner's runner-up diagnostic fields are overwritten
+/// with the matched-count competitor (so consumers see the uniqueness margin,
+/// not the soft-score gap), and `score_best` / `weighted_score` (the soft score)
+/// are preserved.
+fn apply_soft_uniqueness_gate(
+    mut winner: DecodeOutcome,
+    matched_top2: (u32, i32, i32, GridTransform, Option<HardRunnerUp>),
+) -> Option<DecodeOutcome> {
+    let (best_matched, best_row, best_col, best_transform, runner) = matched_top2;
+    let soft_matched = winner.edges_matched as u32;
+    let soft_is_global_best = winner.master_origin_row == best_row
+        && winner.master_origin_col == best_col
+        && winner.alignment.transform == best_transform;
+    let (competitor_matched, competitor) = if soft_is_global_best {
+        (runner.map_or(0, |r| r.matched), runner)
+    } else {
+        (
+            best_matched,
+            Some(HardRunnerUp {
+                matched: best_matched,
+                master_row: best_row,
+                master_col: best_col,
+                transform: best_transform,
+            }),
+        )
+    };
+    if !passes_uniqueness_gate(winner.edges_observed, soft_matched, competitor_matched) {
+        return None;
+    }
+    // Surface the matched-count uniqueness margin in the runner-up diagnostics
+    // (overwriting the soft-score-gap runner-up populated by the LL finalizer).
+    match competitor {
+        Some(c) => {
+            winner.score_runner_up = Some(c.matched as f32);
+            winner.runner_up_origin_row = Some(c.master_row);
+            winner.runner_up_origin_col = Some(c.master_col);
+            winner.runner_up_transform = Some(c.transform);
+        }
+        None => {
+            winner.score_runner_up = None;
+            winner.runner_up_origin_row = None;
+            winner.runner_up_origin_col = None;
+            winner.runner_up_transform = None;
+        }
+    }
+    Some(winner)
+}
 
 /// Tuning knobs for the soft-log-likelihood scorer. See [`soft::decode_soft`].
 #[derive(Clone, Copy, Debug)]
@@ -119,7 +317,11 @@ pub(crate) struct DecodeOutcome {
     pub runner_up_transform: Option<GridTransform>,
 }
 
-fn update_best_candidate(best: &mut Option<DecodeOutcome>, candidate: DecodeOutcome) {
+/// Rank `candidate` against the current `best`, replacing it on a win.
+///
+/// Returns `true` when `candidate` became the new best (caller uses this to
+/// track which transform owns the winner for the uniqueness runner-up).
+fn update_best_candidate(best: &mut Option<DecodeOutcome>, candidate: DecodeOutcome) -> bool {
     // Rank lexicographically by (edges_matched, weighted_score): a candidate
     // with strictly more matched bits always wins regardless of per-bit
     // confidence; weighted_score only breaks ties on equal match count.
@@ -134,6 +336,7 @@ fn update_best_candidate(best: &mut Option<DecodeOutcome>, candidate: DecodeOutc
     if wins {
         *best = Some(candidate);
     }
+    wins
 }
 
 /// Per-observation `(ll_match, ll_mismatch)` contributions under the

--- a/crates/calib-targets-puzzleboard/src/detector/decode/soft.rs
+++ b/crates/calib-targets-puzzleboard/src/detector/decode/soft.rs
@@ -16,8 +16,9 @@ use crate::code_maps::{
 };
 
 use super::{
-    ll_pair, transform_edge_lookup, update_best_and_runner_up, DecodeOutcome, SoftLlConfig, H_COLS,
-    H_ROWS, V_COLS, V_ROWS,
+    apply_soft_uniqueness_gate, decode_fixed_board_with_runner_up, decode_with_runner_up, ll_pair,
+    transform_edge_lookup, update_best_and_runner_up, DecodeOutcome, SoftLlConfig, H_COLS, H_ROWS,
+    V_COLS, V_ROWS,
 };
 
 /// Finalize the winning hypothesis: populate `score_runner_up`,
@@ -231,7 +232,31 @@ pub(crate) fn decode_soft(
         }
     }
 
-    finalize_soft_winner(best, runner_up, cfg, max_bit_error_rate)
+    let winner = finalize_soft_winner(best, runner_up, cfg, max_bit_error_rate)?;
+    // Re-gate the soft winner by the matched-count uniqueness predicate. The
+    // soft-LL `alignment_min_margin` gate does not enforce origin uniqueness;
+    // the matched-count top-2 over the full master (the same candidate set the
+    // soft winner was drawn from) supplies the competitor.
+    //
+    // TODO(perf): this runs a second full O(8·501·N) precompute + crossed-CRT
+    // top-2 over the same observations the soft scan already processed. The soft
+    // scan already builds per-transform `h_match`/`v_match` count tables; the
+    // matched-count top-2 could be computed inline from those (reusing the hard
+    // `lex_max_classes` + cross-transform assembly) to avoid the second pass.
+    // Kept as a separate call here for a correct, obviously-equivalent gate; the
+    // decode runs in the low-ms range, so the doubling is acceptable until the
+    // PuzzleBoard decode shows up on a hot path.
+    let (hard_winner, best_matched, runner) = decode_with_runner_up(observed, max_bit_error_rate)?;
+    apply_soft_uniqueness_gate(
+        winner,
+        (
+            best_matched,
+            hard_winner.master_origin_row,
+            hard_winner.master_origin_col,
+            hard_winner.alignment.transform,
+            runner,
+        ),
+    )
 }
 
 /// Borrowed view over the six per-transform soft precompute tables.
@@ -467,5 +492,25 @@ pub(crate) fn decode_fixed_board_soft(
         }
     }
 
-    finalize_soft_winner(best, runner_up, cfg, max_bit_error_rate)
+    let winner = finalize_soft_winner(best, runner_up, cfg, max_bit_error_rate)?;
+    // Re-gate by matched-count uniqueness over the *fixed-board* candidate set
+    // (the declared board's shift scan), mirroring the full-master soft path.
+    let (hard_winner, best_matched, runner) = decode_fixed_board_with_runner_up(
+        observed,
+        spec_origin_row,
+        spec_origin_col,
+        rows,
+        cols,
+        max_bit_error_rate,
+    )?;
+    apply_soft_uniqueness_gate(
+        winner,
+        (
+            best_matched,
+            hard_winner.master_origin_row,
+            hard_winner.master_origin_col,
+            hard_winner.alignment.transform,
+            runner,
+        ),
+    )
 }

--- a/crates/calib-targets-puzzleboard/src/detector/decode/tests.rs
+++ b/crates/calib-targets-puzzleboard/src/detector/decode/tests.rs
@@ -32,6 +32,84 @@ fn update_best_candidate_if_accepted(
     }
 }
 
+/// Brute-force matched-count top-2 over all `(transform, origin)` — the
+/// independent oracle for the uniqueness gate. Returns the global maximum
+/// matched count with its `(transform, master_row, master_col)`, and the highest
+/// matched count of any *distinct* origin.
+fn brute_matched_top2(
+    observed: &[PuzzleBoardObservedEdge],
+) -> Option<(u32, GridTransform, i32, i32, u32)> {
+    if observed.is_empty() {
+        return None;
+    }
+    let mut best: Option<(u32, GridTransform, i32, i32)> = None;
+    let mut all: Vec<(u32, GridTransform, i32, i32)> = Vec::new();
+    for transform in GRID_TRANSFORMS_D4.iter().copied() {
+        let tf: Vec<(i32, i32, EdgeOrientation, u8)> = observed
+            .iter()
+            .map(|e| {
+                let lk = transform_edge_lookup(e, &transform);
+                (lk.lookup_row, lk.lookup_col, lk.orientation, e.bit)
+            })
+            .collect();
+        for mr in 0..MASTER_ROWS as i32 {
+            for mc in 0..MASTER_COLS as i32 {
+                let mut m = 0u32;
+                for &(lr, lc, orient, bit) in &tf {
+                    let exp = match orient {
+                        EdgeOrientation::Horizontal => horizontal_edge_bit(mr + lr, mc + lc),
+                        EdgeOrientation::Vertical => vertical_edge_bit(mr + lr, mc + lc),
+                    };
+                    if exp == bit {
+                        m += 1;
+                    }
+                }
+                all.push((m, transform, mr, mc));
+                if best.is_none_or(|(bm, _, _, _)| m > bm) {
+                    best = Some((m, transform, mr, mc));
+                }
+            }
+        }
+    }
+    let (bm, bt, br, bc) = best.unwrap();
+    let mut runner = 0u32;
+    for &(m, t, r, c) in &all {
+        if (t, r, c) != (bt, br, bc) {
+            runner = runner.max(m);
+        }
+    }
+    Some((bm, bt, br, bc, runner))
+}
+
+/// Re-gate a reference winner by the matched-count uniqueness predicate
+/// (`margin > k_winner`), using the independent brute-force top-2. Mirrors the
+/// production gate's accept/reject decision and matched-count runner-up
+/// (`score_runner_up`); the runner-up *origin* representative is the brute-force
+/// tie-break, which the soft equivalence check does not compare.
+fn gate_reference_winner(
+    observed: &[PuzzleBoardObservedEdge],
+    best: Option<DecodeOutcome>,
+) -> Option<DecodeOutcome> {
+    let mut winner = best?;
+    let (gbest, gt, gr, gc, grunner) = brute_matched_top2(observed)?;
+    let win_matched = winner.edges_matched as u32;
+    let is_global_best = winner.master_origin_row == gr
+        && winner.master_origin_col == gc
+        && winner.alignment.transform == gt;
+    let competitor = if is_global_best { grunner } else { gbest };
+    let margin = win_matched.saturating_sub(competitor);
+    let k_winner = (winner.edges_observed as u32).saturating_sub(win_matched);
+    if margin <= k_winner {
+        return None;
+    }
+    winner.score_runner_up = if is_global_best && grunner == 0 {
+        None
+    } else {
+        Some(competitor as f32)
+    };
+    Some(winner)
+}
+
 /// Reference (slow, O(501² × N)) implementation kept for correctness guards.
 ///
 /// Produces the same result as [`decode`] but iterates observations in the
@@ -115,7 +193,7 @@ fn decode_reference(
             }
         }
     }
-    best
+    gate_reference_winner(observed, best)
 }
 
 /// Reference (slow, O(501² × N)) soft-log-likelihood decoder, kept verbatim
@@ -275,7 +353,11 @@ fn decode_soft_reference(
     if best.bit_error_rate > max_bit_error_rate {
         return None;
     }
-    Some(best)
+    // Mirror production: the soft `alignment_min_margin` gate does not enforce
+    // origin uniqueness, so re-gate by the matched-count predicate. Preserves
+    // `score_margin` (the LL gap); overwrites `score_runner_up` with the
+    // matched-count competitor.
+    gate_reference_winner(observed, Some(best))
 }
 
 fn rotate_observed_edge_canonically(
@@ -1217,18 +1299,13 @@ fn assert_soft_equivalent(
                 ),
                 _ => panic!("{ctx}: score_runner_up Some/None mismatch"),
             }
-            assert_eq!(
-                f.runner_up_origin_row, r.runner_up_origin_row,
-                "{ctx}: runner_up_origin_row"
-            );
-            assert_eq!(
-                f.runner_up_origin_col, r.runner_up_origin_col,
-                "{ctx}: runner_up_origin_col"
-            );
-            assert_eq!(
-                f.runner_up_transform, r.runner_up_transform,
-                "{ctx}: runner_up_transform"
-            );
+            // The runner-up *origin / transform* are now matched-count uniqueness
+            // diagnostics whose representative is an implementation-defined
+            // tie-break (production uses the crossed-CRT representative; this
+            // oracle uses a row-major brute-force one). The accept/reject decision
+            // and the runner-up matched *count* (`score_runner_up`) are compared
+            // above; the representative origin is not part of the equivalence
+            // contract.
         }
         (f, r) => panic!("{ctx}: None/Some mismatch fast={f:?} ref={r:?}"),
     }
@@ -1325,4 +1402,195 @@ fn crt_inverse_round_trips_every_residue_pair() {
         }
     }
     assert_eq!(cols.len(), MASTER_COLS as usize, "mc inverse not bijective");
+}
+
+// --- Gap 19: bounded-distance uniqueness gate regressions -----------------
+
+/// Flip `k` bits at distinct positions chosen by a tiny seeded LCG.
+fn flip_k_bits(obs: &mut [PuzzleBoardObservedEdge], k: usize, seed: u64) {
+    let mut rng = Lcg::new(seed);
+    let n = obs.len();
+    if k == 0 || n == 0 {
+        return;
+    }
+    let mut idxs: Vec<usize> = (0..n).collect();
+    for i in 0..k.min(n) {
+        let j = i + (rng.below((n - i) as u32) as usize);
+        idxs.swap(i, j);
+        obs[idxs[i]].bit ^= 1;
+    }
+}
+
+/// Number of corners whose decoded master ID differs from the true `(pos_col+gi,
+/// pos_row+gj)` (mod master).
+fn wrong_corner_count(out: &DecodeOutcome, pos_row: i32, pos_col: i32, n: i32) -> usize {
+    let mut wrong = 0;
+    for gi in 0..n {
+        for gj in 0..n {
+            let g = out.alignment.map(gi, gj);
+            let mi = g.i.rem_euclid(MASTER_COLS as i32);
+            let mj = g.j.rem_euclid(MASTER_ROWS as i32);
+            let ti = (pos_col + gi).rem_euclid(MASTER_COLS as i32);
+            let tj = (pos_row + gj).rem_euclid(MASTER_ROWS as i32);
+            if (mi, mj) != (ti, tj) {
+                wrong += 1;
+            }
+        }
+    }
+    wrong
+}
+
+/// (a) At the *safe* window (7×7, the production `min_window`), a corrupted
+/// fragment is either decoded correctly or DECLINED (`None`) — the uniqueness
+/// gate never ships a wrong absolute labeling. This is the decoder-level
+/// witness: heavy noise that makes a wrong origin competitive drives `margin ≤
+/// k_winner`, so the decode declines.
+///
+/// (The 4×4 window is deliberately *not* tested here: the master code has
+/// minimum Hamming distance `1` at 4×4 — a 1-bit-corrupted 4×4 fragment is
+/// frequently a *perfect* read of a different master location, which no
+/// acceptance test can distinguish from a true perfect read. Safety at small
+/// windows is provided by the pipeline's `min_window = 7` / limiting-dimension
+/// floor, validated separately, not by the window-agnostic decoder.)
+#[test]
+fn uniqueness_gate_declines_corrupted_safe_window() {
+    let mut accepted_correct = 0usize;
+    let mut declined = 0usize;
+    for &(pr, pc) in &[(2i32, 3i32), (5, 7), (33, 44), (100, 7)] {
+        // Sweep from light noise (decodes) to heavy noise (declines), spanning
+        // the gate's accept→decline transition on the 84-edge window.
+        for k in 1..=33usize {
+            for seed in 0..6u64 {
+                let mut obs = build_pipeline_style_observation(pr, pc, 7, 7);
+                flip_k_bits(
+                    &mut obs,
+                    k,
+                    0xC0DE_0000 ^ (k as u64) << 8 ^ seed ^ (pr as u64) << 16,
+                );
+                match decode(&obs, 0.40) {
+                    Some(out) => {
+                        assert_eq!(
+                            wrong_corner_count(&out, pr, pc, 7),
+                            0,
+                            "gate accepted a WRONG corrupted 7×7 decode (pr={pr} pc={pc} k={k} seed={seed})"
+                        );
+                        accepted_correct += 1;
+                    }
+                    None => declined += 1,
+                }
+            }
+        }
+    }
+    // Sanity: the regime is genuinely exercised on both sides (some decode, some
+    // decline) — otherwise the test would pass vacuously.
+    assert!(
+        declined > 0,
+        "expected some heavily-corrupted 7×7 fragments to decline"
+    );
+    assert!(
+        accepted_correct > 0,
+        "expected some 7×7 fragments to still decode correctly"
+    );
+}
+
+/// (b) A clean (noise-free) fragment at the safe window decodes correctly with a
+/// healthy uniqueness margin (margin > k_winner; here k_winner = 0 so any
+/// margin ≥ 1 passes). Exercises both the 7×7 floor and a larger window.
+#[test]
+fn uniqueness_gate_accepts_clean_window_with_margin() {
+    for &n in &[7i32, 8, 10] {
+        let obs = build_pipeline_style_observation(12, 37, n, n);
+        let out = decode(&obs, 0.40).expect("clean window must decode");
+        assert_eq!(
+            out.edges_matched, out.edges_observed,
+            "clean read matches all bits"
+        );
+        assert_eq!(out.master_origin_row, 12);
+        assert_eq!(out.master_origin_col, 37);
+        // k_winner = 0 (perfect read); margin = best - runner > 0.
+        let k_winner = out.edges_observed as f32 - out.edges_matched as f32;
+        assert!(
+            out.score_margin > k_winner,
+            "n={n}: margin {} must exceed k_winner {}",
+            out.score_margin,
+            k_winner
+        );
+        assert!(out.score_margin >= 1.0, "n={n}: clean unique margin ≥ 1");
+    }
+}
+
+/// (b') A clean 4×4 fragment (below the production min_window, but the decoder
+/// itself is window-agnostic) is still *uniquely* decodable and must decode:
+/// the gate honors the code's exact-uniqueness design at any size — the floor
+/// that rejects 4×4 lives in the pipeline (`min_window`/`required_edges`/
+/// limiting-dimension), not in the gate.
+#[test]
+fn uniqueness_gate_accepts_clean_4x4() {
+    let obs = build_pipeline_style_observation(8, 19, 4, 4);
+    let out = decode(&obs, 0.40).expect("clean 4×4 is unique and must decode");
+    assert_eq!(out.master_origin_row, 8);
+    assert_eq!(out.master_origin_col, 19);
+    assert_eq!(wrong_corner_count(&out, 8, 19, 4), 0);
+}
+
+/// (c) The soft n=8 witness from the Phase-A discovery: under heavy noise the
+/// soft-LL scorer alone accepted a wrong physical origin (true (125,16) →
+/// decoded a different origin, all corners wrong, passing `alignment_min_margin`).
+/// With the uniqueness gate now applied to the soft path, a heavily-corrupted
+/// 8×8 fragment must not ship a wrong labeling.
+#[test]
+fn soft_uniqueness_gate_declines_corrupted_8x8() {
+    let cfg = SoftLlConfig {
+        kappa: 12.0,
+        per_bit_floor: -6.0,
+        alignment_min_margin: 0.02,
+    };
+    // Sweep origins × heavy noise; any accepted soft decode must be correct.
+    for &(pr, pc) in &[(125i32, 16i32), (3, 4), (200, 90), (50, 300)] {
+        for k in 24..=30usize {
+            for seed in 0..4u64 {
+                let mut obs = build_pipeline_style_observation(pr, pc, 8, 8);
+                flip_k_bits(
+                    &mut obs,
+                    k,
+                    0x50F7_0000 ^ (k as u64) << 8 ^ seed ^ (pr as u64) << 16,
+                );
+                if let Some(out) = decode_soft(&obs, &cfg, 0.40) {
+                    assert_eq!(
+                        wrong_corner_count(&out, pr, pc, 8),
+                        0,
+                        "soft gate accepted a WRONG corrupted 8×8 decode (pr={pr} pc={pc} k={k} seed={seed})"
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// The uniqueness gate's accept/reject decision is identical on the optimized
+/// `decode` and the brute-force-gated `decode_reference` for corrupted small
+/// fragments (the regime where the gate actually fires).
+#[test]
+fn gate_decision_matches_reference_on_corrupted_fragments() {
+    for &n in &[4i32, 5, 6, 7] {
+        for k in 0..=4usize {
+            for seed in 0..4u64 {
+                let mut obs = build_pipeline_style_observation(7, 13, n, n);
+                flip_k_bits(
+                    &mut obs,
+                    k,
+                    0xBEEF_0000 ^ (n as u64) << 16 ^ (k as u64) << 8 ^ seed,
+                );
+                let fast = decode(&obs, 0.40);
+                let reference = decode_reference(&obs, 0.40);
+                assert_eq!(
+                    fast.is_some(),
+                    reference.is_some(),
+                    "gate accept/reject mismatch n={n} k={k} seed={seed}: fast={} ref={}",
+                    fast.is_some(),
+                    reference.is_some()
+                );
+            }
+        }
+    }
 }

--- a/crates/calib-targets-puzzleboard/src/detector/error.rs
+++ b/crates/calib-targets-puzzleboard/src/detector/error.rs
@@ -18,6 +18,22 @@ pub enum PuzzleBoardDetectError {
         /// Minimum number of edge dots the decoder requires.
         needed: usize,
     },
+    /// The labelled corner region is too thin along one axis to decode safely.
+    ///
+    /// Bounded-distance decoding requires the observed window to span at least
+    /// `min_window` corners in *both* grid directions: a wide-but-short strip
+    /// can meet the total edge-count floor yet still alias (its limiting
+    /// dimension carries too little code distance). Rejecting it is a soundness
+    /// guard, not a recall choice.
+    #[error("decode window too thin (spans {span_i}×{span_j} corners, need {needed}×{needed})")]
+    WindowTooThin {
+        /// Corner span along the grid `i` axis (`max_i − min_i + 1`).
+        span_i: u32,
+        /// Corner span along the grid `j` axis (`max_j − min_j + 1`).
+        span_j: u32,
+        /// Minimum span required along each axis (`min_window`).
+        needed: u32,
+    },
     /// The edge-code decoder found no master position above the
     /// confidence threshold.
     #[error("decoding failed: no position match above confidence threshold")]

--- a/crates/calib-targets-puzzleboard/src/detector/params.rs
+++ b/crates/calib-targets-puzzleboard/src/detector/params.rs
@@ -71,8 +71,16 @@ pub enum PuzzleBoardScoringMode {
 pub struct PuzzleBoardDecodeConfig {
     /// Minimum window size (in squares) required to attempt a decode.
     ///
-    /// The paper guarantees 3×3 = 99.33 % unique and 4×4 = 100 % unique.
-    /// Default is 4 for calibration use.
+    /// The paper's "4×4 = 100 % unique" holds only for a *noise-free* read: the
+    /// master edge code has minimum Hamming distance `1` at a 4×4 window (zero
+    /// error-correction), so a single corrupted bit can turn a corrupted 4×4
+    /// fragment into a perfect read of a *different* master location — a false
+    /// positive. The code's minimum distance grows with window size; an empirical
+    /// 300k-trial sweep (random origins × error patterns up to the BER budget)
+    /// finds the smallest window with zero false-accepts under the uniqueness
+    /// gate to be **7×7 (84 interior edges)** at both 30 % and 40 % BER. The
+    /// default is therefore 7 (bounded-distance decoding); smaller boards become
+    /// correct detection *misses* rather than risk a wrong absolute label.
     #[serde(default = "default_min_window")]
     pub min_window: u32,
     /// Per-bit confidence floor — bits below this are treated as unknown.
@@ -136,7 +144,10 @@ pub struct PuzzleBoardDecodeConfig {
 }
 
 fn default_min_window() -> u32 {
-    4
+    // 7×7 (84 interior edges) — the smallest window the master code can decode
+    // with zero empirical false-accepts under the uniqueness gate at ≤40 % BER
+    // (bounded-distance decoding; see `min_window` field docs and Gap 19).
+    7
 }
 fn default_min_bit_confidence() -> f32 {
     0.15

--- a/crates/calib-targets-puzzleboard/src/detector/pipeline.rs
+++ b/crates/calib-targets-puzzleboard/src/detector/pipeline.rs
@@ -8,7 +8,7 @@ use calib_targets_core::{GrayImageView, GridCoords, LabeledCorner, TargetDetecti
 use nalgebra::Point2;
 
 use crate::board::{PuzzleBoardSpec, PuzzleBoardSpecError, MASTER_COLS, MASTER_ROWS};
-use crate::code_maps::PuzzleBoardObservedEdge;
+use crate::code_maps::{EdgeOrientation, PuzzleBoardObservedEdge};
 use crate::detector::decode::{
     decode as run_decode, decode_fixed_board, decode_fixed_board_soft, decode_soft, SoftLlConfig,
 };
@@ -241,13 +241,27 @@ impl PuzzleBoardDetector {
             return Err((e, diagnostics_on_fail(&observed)));
         }
 
-        // Limiting-dimension (bounded-distance) guard. The edge-count floor
-        // assumes a roughly-square window; a wide-but-short strip can meet it yet
-        // still alias because its thin axis carries too little code distance
-        // (measured: a 3-corner-tall strip at the 84-edge floor false-accepts at
-        // a low rate, while every window spanning ≥ `min_window` corners on both
-        // axes is empirically alias-free). Require both grid spans ≥ `min_window`.
-        if let Some((span_i, span_j)) = grid_span_dims(labeled) {
+        let filtered: Vec<PuzzleBoardObservedEdge> = observed
+            .iter()
+            .copied()
+            .filter(|e| e.confidence >= self.params.decode.min_bit_confidence)
+            .collect();
+        if let Err(e) = ensure_min_edges(filtered.len(), min_edges) {
+            return Err((e, diagnostics_on_fail(&observed)));
+        }
+
+        // Limiting-dimension (bounded-distance) guard, applied to the
+        // *post-confidence-filter* observation set — the window the decoder
+        // actually decodes. The edge-count floor assumes a roughly-square window;
+        // a wide-but-short strip can meet it yet still alias because its thin axis
+        // carries too little code distance (measured: a 3-corner-tall strip at the
+        // 84-edge floor false-accepts at a low rate, while every window spanning
+        // ≥ `min_window` corners on both axes is empirically alias-free). A
+        // component that is wide overall can also collapse to a thin strip *after*
+        // the `min_bit_confidence` filter drops its low-confidence edges, so the
+        // span must be measured on `filtered`, not on the full labelled set.
+        // Require both corner spans ≥ `min_window`.
+        if let Some((span_i, span_j)) = observed_corner_span(&filtered) {
             let need = self.params.decode.min_window;
             if span_i < need || span_j < need {
                 return Err((
@@ -259,15 +273,6 @@ impl PuzzleBoardDetector {
                     diagnostics_on_fail(&observed),
                 ));
             }
-        }
-
-        let filtered: Vec<PuzzleBoardObservedEdge> = observed
-            .iter()
-            .copied()
-            .filter(|e| e.confidence >= self.params.decode.min_bit_confidence)
-            .collect();
-        if let Err(e) = ensure_min_edges(filtered.len(), min_edges) {
-            return Err((e, diagnostics_on_fail(&observed)));
         }
 
         let max_err = self.params.decode.max_bit_error_rate;
@@ -632,29 +637,39 @@ fn is_better_component_decode(
     }
 }
 
-/// Grid-label span of a labelled corner set: `(span_i, span_j)` where each span
-/// is `max − min + 1` over the `(i, j)` labels (corners without a grid label are
-/// ignored). `None` when no corner carries a grid label. Used by the
-/// limiting-dimension (bounded-distance) decode guard.
-fn grid_span_dims(labeled: &[LabeledCorner]) -> Option<(u32, u32)> {
-    let mut min_i = i32::MAX;
-    let mut max_i = i32::MIN;
-    let mut min_j = i32::MAX;
-    let mut max_j = i32::MIN;
-    let mut any = false;
-    for c in labeled {
-        if let Some(g) = c.grid {
-            any = true;
-            min_i = min_i.min(g.i);
-            max_i = max_i.max(g.i);
-            min_j = min_j.min(g.j);
-            max_j = max_j.max(g.j);
-        }
+/// Corner-grid span `(span_col, span_row)` actually covered by an observed-edge
+/// set, where each span is `max − min + 1` over the corner intersections the
+/// edges reference. An edge anchored at local `(col, row)` references the corner
+/// `(col, row)` plus its far endpoint — `(col + 1, row)` for a horizontal edge,
+/// `(col, row + 1)` for a vertical one. `None` for an empty set.
+///
+/// This must be computed on the set the decoder actually decodes (the
+/// post-confidence-filter observations), not the full labelled corner set: a
+/// component that is wide overall can collapse to a long thin high-confidence
+/// strip after the `min_bit_confidence` filter, and that strip is the window
+/// whose code distance the bounded-distance guard governs.
+fn observed_corner_span(edges: &[PuzzleBoardObservedEdge]) -> Option<(u32, u32)> {
+    let mut min_col = i32::MAX;
+    let mut max_col = i32::MIN;
+    let mut min_row = i32::MAX;
+    let mut max_row = i32::MIN;
+    for e in edges {
+        let (far_col, far_row) = match e.orientation {
+            EdgeOrientation::Horizontal => (e.col + 1, e.row),
+            EdgeOrientation::Vertical => (e.col, e.row + 1),
+        };
+        min_col = min_col.min(e.col).min(far_col);
+        max_col = max_col.max(e.col).max(far_col);
+        min_row = min_row.min(e.row).min(far_row);
+        max_row = max_row.max(e.row).max(far_row);
     }
-    if !any {
+    if edges.is_empty() {
         return None;
     }
-    Some(((max_i - min_i + 1) as u32, (max_j - min_j + 1) as u32))
+    Some((
+        (max_col - min_col + 1) as u32,
+        (max_row - min_row + 1) as u32,
+    ))
 }
 
 /// Extract the soft-LL knobs from a decode config into the decoder-level
@@ -670,7 +685,229 @@ fn soft_cfg_from(cfg: &PuzzleBoardDecodeConfig) -> SoftLlConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::board::{MASTER_COLS, MASTER_ROWS};
+    use crate::code_maps::{horizontal_edge_bit, vertical_edge_bit};
     use calib_targets_core::GridAlignment;
+
+    /// Tiny seeded LCG (no external `rand`); shared by the guard regressions.
+    struct Lcg(u64);
+    impl Lcg {
+        fn new(seed: u64) -> Self {
+            Lcg(seed.wrapping_mul(0x9E37_79B9_7F4A_7C15).wrapping_add(1))
+        }
+        fn next_u32(&mut self) -> u32 {
+            self.0 = self
+                .0
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1_442_695_040_888_963_407);
+            (self.0 >> 32) as u32
+        }
+        fn below(&mut self, n: u32) -> u32 {
+            if n == 0 {
+                0
+            } else {
+                self.next_u32() % n
+            }
+        }
+    }
+
+    /// Build a `local_rows × local_cols` window of correct edges at the given
+    /// master origin. Edges whose anchor row is outside `[0, strip_rows)` get
+    /// `off_conf`; in-strip edges get confidence 1.0.
+    fn window_with_confidence_strip(
+        pos_row: i32,
+        pos_col: i32,
+        local_rows: i32,
+        local_cols: i32,
+        strip_rows: i32,
+        off_conf: f32,
+    ) -> Vec<PuzzleBoardObservedEdge> {
+        let mut out = Vec::new();
+        for r in 0..local_rows {
+            for c in 0..local_cols {
+                let conf = if r < strip_rows { 1.0 } else { off_conf };
+                if c + 1 < local_cols {
+                    out.push(PuzzleBoardObservedEdge {
+                        row: r,
+                        col: c,
+                        orientation: EdgeOrientation::Horizontal,
+                        bit: horizontal_edge_bit(pos_row + r - 1, pos_col + c),
+                        confidence: conf,
+                    });
+                }
+                if r + 1 < local_rows {
+                    out.push(PuzzleBoardObservedEdge {
+                        row: r,
+                        col: c,
+                        orientation: EdgeOrientation::Vertical,
+                        bit: vertical_edge_bit(pos_row + r, pos_col + c - 1),
+                        confidence: conf,
+                    });
+                }
+            }
+        }
+        out
+    }
+
+    fn wrong_corners(
+        out: &crate::detector::decode::DecodeOutcome,
+        pr: i32,
+        pc: i32,
+        rows: i32,
+        cols: i32,
+    ) -> usize {
+        let mut wrong = 0;
+        for gi in 0..cols {
+            for gj in 0..rows {
+                let g = out.alignment.map(gi, gj);
+                let mi = g.i.rem_euclid(MASTER_COLS as i32);
+                let mj = g.j.rem_euclid(MASTER_ROWS as i32);
+                let ti = (pc + gi).rem_euclid(MASTER_COLS as i32);
+                let tj = (pr + gj).rem_euclid(MASTER_ROWS as i32);
+                if (mi, mj) != (ti, tj) {
+                    wrong += 1;
+                }
+            }
+        }
+        wrong
+    }
+
+    /// `observed_corner_span` measures the corner bbox, including each edge's far
+    /// endpoint (`col+1` for H, `row+1` for V).
+    #[test]
+    fn observed_corner_span_counts_far_endpoint() {
+        // A single horizontal edge at (col=4, row=2) spans corners (4,2)-(5,2).
+        let h = vec![PuzzleBoardObservedEdge {
+            row: 2,
+            col: 4,
+            orientation: EdgeOrientation::Horizontal,
+            bit: 0,
+            confidence: 1.0,
+        }];
+        assert_eq!(observed_corner_span(&h), Some((2, 1)));
+        // A single vertical edge spans (4,2)-(4,3).
+        let v = vec![PuzzleBoardObservedEdge {
+            row: 2,
+            col: 4,
+            orientation: EdgeOrientation::Vertical,
+            bit: 0,
+            confidence: 1.0,
+        }];
+        assert_eq!(observed_corner_span(&v), Some((1, 2)));
+        assert_eq!(observed_corner_span(&[]), None);
+    }
+
+    /// Regression for the post-filter thin-window hole: a window that is wide
+    /// overall but whose *surviving* high-confidence edges (after the
+    /// `min_bit_confidence` filter) form a thin strip must be measured on the
+    /// FILTERED set — the span must reflect the strip, not the wide pre-filter
+    /// extent. (The guard itself lives in `decode_component`, gated on
+    /// `observed_corner_span(&filtered)`.)
+    #[test]
+    fn post_filter_span_reflects_surviving_strip() {
+        let min_conf = 0.15f32;
+        let edges = window_with_confidence_strip(5, 7, 12, 12, 3, 0.0);
+        let pre = observed_corner_span(&edges).unwrap();
+        assert!(
+            pre.0 >= 7 && pre.1 >= 7,
+            "pre-filter span {pre:?} is wide on both axes"
+        );
+        let filtered: Vec<_> = edges
+            .iter()
+            .copied()
+            .filter(|e| e.confidence >= min_conf)
+            .collect();
+        let post = observed_corner_span(&filtered).unwrap();
+        assert!(
+            post.1 < 7,
+            "post-filter corner-row span {} must be thin (< min_window) so the guard fires",
+            post.1
+        );
+    }
+
+    /// The guard is load-bearing AND sufficient: the decoder DOES false-accept a
+    /// confidence-induced thin strip when handed it directly, and the
+    /// limiting-dimension span check rejects every such strip — so zero wrong
+    /// decodes slip past. Sweeps corrupted 3-corner-row strips.
+    #[test]
+    fn post_filter_thin_strip_guard_blocks_false_accepts() {
+        let min_window = 7u32;
+        let trials = 60_000usize;
+        let mut rng = Lcg::new(0xC0DE_F11E);
+        let mut decoder_fa_without_guard = 0usize;
+        let mut fa_past_guard = 0usize;
+        let mut guard_rejected = 0usize;
+        for _ in 0..trials {
+            let pr = rng.below(MASTER_ROWS) as i32;
+            let pc = rng.below(MASTER_COLS) as i32;
+            let mut strip = window_with_confidence_strip(pr, pc, 3, 12, 3, 1.0);
+            let n = strip.len();
+            let kmax = (0.40 * n as f32).floor() as usize;
+            let k = rng.below((kmax + 1) as u32) as usize;
+            let mut idxs: Vec<usize> = (0..n).collect();
+            for i in 0..k.min(n) {
+                let j = i + (rng.below((n - i) as u32) as usize);
+                idxs.swap(i, j);
+                strip[idxs[i]].bit ^= 1;
+            }
+            let span = observed_corner_span(&strip).unwrap();
+            let guard_rejects = span.0 < min_window || span.1 < min_window;
+            if guard_rejects {
+                guard_rejected += 1;
+            }
+            if let Some(out) = run_decode(&strip, 0.40) {
+                if wrong_corners(&out, pr, pc, 3, 12) > 0 {
+                    decoder_fa_without_guard += 1;
+                    if !guard_rejects {
+                        fa_past_guard += 1;
+                    }
+                }
+            }
+        }
+        // Every 3-corner-row strip has row-span 3 < 7 → the guard rejects all.
+        assert_eq!(guard_rejected, trials, "guard must reject every thin strip");
+        // The hole was real: the decoder false-accepts these strips without it.
+        assert!(
+            decoder_fa_without_guard > 0,
+            "decoder should false-accept thin strips without the guard (got 0 — test not exercising the hole)"
+        );
+        // ...and zero slip past the guard.
+        assert_eq!(
+            fa_past_guard, 0,
+            "no wrong decode may pass the post-filter guard"
+        );
+    }
+
+    /// A legitimate full board with *scattered* low-confidence drops still spans
+    /// ≥ `min_window` on both axes after filtering, so the guard must NOT fire
+    /// (no spurious rejection).
+    #[test]
+    fn scattered_lowconf_does_not_trip_guard() {
+        let min_conf = 0.15f32;
+        let min_window = 7u32;
+        let mut rng = Lcg::new(0x5CA7_7E12);
+        for _ in 0..3000 {
+            let mut edges = window_with_confidence_strip(3, 4, 9, 9, 9, 1.0);
+            for e in edges.iter_mut() {
+                if rng.below(100) < 30 {
+                    e.confidence = 0.05;
+                }
+            }
+            let filtered: Vec<_> = edges
+                .iter()
+                .copied()
+                .filter(|e| e.confidence >= min_conf)
+                .collect();
+            if filtered.is_empty() {
+                continue;
+            }
+            let span = observed_corner_span(&filtered).unwrap();
+            assert!(
+                span.0 >= min_window && span.1 >= min_window,
+                "scattered low-confidence drops wrongly thinned the window to {span:?}"
+            );
+        }
+    }
 
     /// Build a `ComponentDecode` whose result summary and diagnostics carry
     /// the values `is_better_component_decode` reads. `detection`/`alignment`

--- a/crates/calib-targets-puzzleboard/src/detector/pipeline.rs
+++ b/crates/calib-targets-puzzleboard/src/detector/pipeline.rs
@@ -241,6 +241,26 @@ impl PuzzleBoardDetector {
             return Err((e, diagnostics_on_fail(&observed)));
         }
 
+        // Limiting-dimension (bounded-distance) guard. The edge-count floor
+        // assumes a roughly-square window; a wide-but-short strip can meet it yet
+        // still alias because its thin axis carries too little code distance
+        // (measured: a 3-corner-tall strip at the 84-edge floor false-accepts at
+        // a low rate, while every window spanning ≥ `min_window` corners on both
+        // axes is empirically alias-free). Require both grid spans ≥ `min_window`.
+        if let Some((span_i, span_j)) = grid_span_dims(labeled) {
+            let need = self.params.decode.min_window;
+            if span_i < need || span_j < need {
+                return Err((
+                    PuzzleBoardDetectError::WindowTooThin {
+                        span_i,
+                        span_j,
+                        needed: need,
+                    },
+                    diagnostics_on_fail(&observed),
+                ));
+            }
+        }
+
         let filtered: Vec<PuzzleBoardObservedEdge> = observed
             .iter()
             .copied()
@@ -610,6 +630,31 @@ fn is_better_component_decode(
             cmp_higher(cand_decode.mean_confidence, curr_decode.mean_confidence).unwrap_or(false)
         }
     }
+}
+
+/// Grid-label span of a labelled corner set: `(span_i, span_j)` where each span
+/// is `max − min + 1` over the `(i, j)` labels (corners without a grid label are
+/// ignored). `None` when no corner carries a grid label. Used by the
+/// limiting-dimension (bounded-distance) decode guard.
+fn grid_span_dims(labeled: &[LabeledCorner]) -> Option<(u32, u32)> {
+    let mut min_i = i32::MAX;
+    let mut max_i = i32::MIN;
+    let mut min_j = i32::MAX;
+    let mut max_j = i32::MIN;
+    let mut any = false;
+    for c in labeled {
+        if let Some(g) = c.grid {
+            any = true;
+            min_i = min_i.min(g.i);
+            max_i = max_i.max(g.i);
+            min_j = min_j.min(g.j);
+            max_j = max_j.max(g.j);
+        }
+    }
+    if !any {
+        return None;
+    }
+    Some(((max_i - min_i + 1) as u32, (max_j - min_j + 1) as u32))
 }
 
 /// Extract the soft-LL knobs from a decode config into the decoder-level

--- a/crates/calib-targets-puzzleboard/tests/check_consistency.rs
+++ b/crates/calib-targets-puzzleboard/tests/check_consistency.rs
@@ -49,14 +49,18 @@ fn render_png_to_gray_image(bundle_bytes: &[u8]) -> ImageBuffer<Luma<u8>, Vec<u8
 /// hypothesis set under a square lattice without rejecting anything.
 #[test]
 fn puzzleboard_corners_pass_check_consistency_square_lattice() {
-    // 1) Render a small synthetic puzzleboard. Small dimensions are
-    //    enough to exercise the contract; we don't need a large board
-    //    to test the conversion + fit shape.
-    let spec = PuzzleBoardTargetSpec::new(8, 8, 12.0);
+    // 1) Render a synthetic puzzleboard. The board must be large enough that the
+    //    detector's decodable interior window clears the bounded-distance floor
+    //    (`min_window = 7` → 84 interior edges; Gap 19): the ChESS detector drops
+    //    the outermost corner ring, so a board of `w×w` squares yields roughly a
+    //    `(w-2)×(w-2)` decodable corner grid. A 10×10 board leaves an ~8×8
+    //    interior, comfortably above the 7×7 floor, while still being small
+    //    enough to exercise the conversion + fit shape.
+    let spec = PuzzleBoardTargetSpec::new(10, 10, 12.0);
     let mut doc = PrintableTargetDocument::new(TargetSpec::PuzzleBoard(spec.clone()));
     doc.page.size = PageSize::Custom {
-        width_mm: 160.0,
-        height_mm: 160.0,
+        width_mm: 200.0,
+        height_mm: 200.0,
     };
     doc.page.margin_mm = 5.0;
     doc.render.png_dpi = 300;

--- a/crates/calib-targets-puzzleboard/tests/interop_authors.rs
+++ b/crates/calib-targets-puzzleboard/tests/interop_authors.rs
@@ -36,7 +36,7 @@
 //! failed — the reference images vary widely in scale and quality.
 
 use calib_targets::detect::{self};
-use calib_targets::puzzleboard::{PuzzleBoardDetectionResult, PuzzleBoardParams, PuzzleBoardSpec};
+use calib_targets::puzzleboard::{PuzzleBoardParams, PuzzleBoardSpec};
 use calib_targets_core::GRID_TRANSFORMS_D4;
 // Imports used only by the `diagnostics`-gated `diag_example0_edge_bits` test.
 #[cfg(feature = "diagnostics")]
@@ -95,89 +95,6 @@ fn load_ref_json(dir: &Path, index: usize) -> Option<RefJson> {
     }
     let text = std::fs::read_to_string(&path).ok()?;
     serde_json::from_str(&text).ok()
-}
-
-fn detect_reference_image(
-    index: usize,
-    dir: &Path,
-) -> Option<(RefJson, PuzzleBoardDetectionResult)> {
-    let img_path = dir.join(format!("example{index}.png"));
-    if !img_path.exists() {
-        return None;
-    }
-    let ref_data = load_ref_json(dir, index)?;
-    if ref_data.decoded_corners.is_empty() {
-        return None;
-    }
-
-    let img = ImageReader::open(&img_path).ok()?.decode().ok()?.to_luma8();
-    let board = PuzzleBoardSpec::new(20, 20, 5.0).expect("board spec");
-    let sweep = PuzzleBoardParams::sweep_for_board(&board);
-    let result = detect::detect_puzzleboard_best(&img, &sweep).ok()?;
-    Some((ref_data, result))
-}
-
-fn assert_reference_consistency(
-    index: usize,
-    ref_data: &RefJson,
-    result: &PuzzleBoardDetectionResult,
-) {
-    let our_corners = &result.corners;
-    let ber = result.decode.bit_error_rate;
-    assert!(
-        our_corners.len() >= MIN_DECODED_CORNERS,
-        "example{index}: only {} corners (need at least {})",
-        our_corners.len(),
-        MIN_DECODED_CORNERS
-    );
-    assert!(
-        ber <= MAX_BER,
-        "example{index}: BER={ber:.3} exceeds threshold {MAX_BER:.3}"
-    );
-
-    let mut pairs: Vec<(i32, i32, i32, i32)> = Vec::new();
-    for lc in our_corners {
-        let grid = lc.grid;
-        let px = lc.position.x;
-        let py = lc.position.y;
-
-        let mut best_dist = f32::MAX;
-        let mut best_ref: Option<&RefCorner> = None;
-        for rc in &ref_data.decoded_corners {
-            let dx = px - rc.pixel_x as f32;
-            let dy = py - rc.pixel_y as f32;
-            let dist = (dx * dx + dy * dy).sqrt();
-            if dist < best_dist {
-                best_dist = dist;
-                best_ref = Some(rc);
-            }
-        }
-        if best_dist <= PIXEL_TOL {
-            let rc = best_ref.expect("best ref set");
-            pairs.push((grid.j, grid.i, rc.master_row, rc.master_col));
-        }
-    }
-
-    if pairs.len() < 3 {
-        return;
-    }
-
-    let found_transform = GRID_TRANSFORMS_D4.iter().any(|t| {
-        let deltas: Vec<(i32, i32)> = pairs
-            .iter()
-            .map(|(or, oc, rr, rc)| {
-                let nr = t.a * or + t.b * oc;
-                let nc = t.c * or + t.d * oc;
-                ((rr - nr).rem_euclid(501), (rc - nc).rem_euclid(501))
-            })
-            .collect();
-        deltas.iter().all(|d| d == &deltas[0])
-    });
-    assert!(
-        found_transform,
-        "example{index}: {} matched pairs are not consistent with any single D4 transform",
-        pairs.len()
-    );
 }
 
 fn run_one_image(index: usize, dir: &Path) {
@@ -342,21 +259,42 @@ fn run_one_image(index: usize, dir: &Path) {
     );
 }
 
+/// Examples 1/2/3 are heavily radially-distorted author frames. The
+/// distortion-aware edge sampling (Gap 18) lets their grid build, and they were
+/// briefly "recovered" by the 40 % BER hard pass — but that decode is
+/// *non-unique*: a distinct master origin matches the corrupted edge bits as
+/// well as (or within a bit or two of) the chosen one (measured margins 0–2 out
+/// of hundreds of edges). The bounded-distance uniqueness gate (Gap 19) now
+/// correctly DECLINES them: a non-unique decode is a wrong absolute label
+/// waiting to happen, and the detection contract forbids wrong labels far more
+/// strongly than misses. These frames are therefore detection *failures*, not
+/// decodes — the right behavior.
 #[test]
-fn author_examples_1_2_3_decode_when_reference_dataset_present() {
+fn author_examples_1_2_3_are_declined_as_non_unique() {
     let dir = testdata_dir();
     if !dir.exists() {
-        eprintln!(
-            "[skipped] author_examples_1_2_3_decode_when_reference_dataset_present: {:?} missing",
-            dir
-        );
+        eprintln!("[skipped] author_examples_1_2_3_are_declined_as_non_unique: {dir:?} missing");
         return;
     }
-
+    let board = PuzzleBoardSpec::new(20, 20, 5.0).expect("board spec");
+    let sweep = PuzzleBoardParams::sweep_for_board(&board);
     for index in [1usize, 2, 3] {
-        let (ref_data, result) = detect_reference_image(index, &dir)
-            .unwrap_or_else(|| panic!("example{index}: expected PuzzleBoard decode"));
-        assert_reference_consistency(index, &ref_data, &result);
+        let img_path = dir.join(format!("example{index}.png"));
+        if !img_path.exists() {
+            eprintln!("[skipped] example{index}.png missing");
+            continue;
+        }
+        let img = ImageReader::open(&img_path)
+            .expect("open")
+            .decode()
+            .expect("decode")
+            .to_luma8();
+        let result = detect::detect_puzzleboard_best(&img, &sweep);
+        assert!(
+            result.is_err(),
+            "example{index}: a non-unique distorted frame must be DECLINED by the \
+             uniqueness gate, but it decoded — possible false positive"
+        );
     }
 }
 

--- a/docs/algorithms/algorithmic_gaps.md
+++ b/docs/algorithms/algorithmic_gaps.md
@@ -195,32 +195,85 @@ hard-weighted scorer at the paper's 40% BER allowance to recover high-distortion
 fragments; `PuzzleBoardParams::for_board` (the single-config default) is
 unchanged.
 
-**Validation.** `example1/2/3` — previously among the six master-match failures
-— now decode (253/180/28 labelled corners), joining example0/4/5/6 for **7 of
-10**. The new `author_examples_1_2_3_decode_when_reference_dataset_present` test
-asserts the decoded `(i, j)` labels are consistent with the master positions
-under a single D4 transform (mod 501) — i.e. correct, not merely present. See
-Gap 19 for the residual precision caveat this pass introduces.
+**What stays / what was corrected (see Gap 19).** The distortion-aware edge
+*sampling* is a genuine improvement and remains. The 40% BER sweep pass also
+remains, but the claim that it "recovers" the distorted author examples did **not
+survive a precision audit**: those decodes (example0/1/2/3/8) are *non-unique* —
+a distinct master origin matches the distortion-corrupted edge bits as well as
+(or within one or two bits of) the chosen origin. They passed a D4-consistency
+check only because the tie-break happened to land on the reference origin. Under
+the bounded-distance uniqueness gate added in Gap 19 they are correctly **declined
+as detection failures** (a non-unique absolute decode is a wrong label waiting to
+happen). The clean, full author boards (example4/5/6) decode with enormous
+uniqueness margins and are unaffected. The grid still detects on the distorted
+frames; only the *decode* declines.
 
-### Gap 19 — 40% BER hard fallback has no uniqueness gate (OPEN)
+### Gap 19 — PuzzleBoard decode lacked an origin-uniqueness gate (RESOLVED)
 
-The high-distortion sweep pass added in Gap 18's fix decodes with the
-hard-weighted scorer at a 40% BER allowance and **no best-vs-runner-up margin
-gate** (`score_margin = ∞` on the hard path), unlike the soft scorer's
-`alignment_min_margin`. On a *full* board this is safe — wrong master origins
-sit near 50% BER, comfortably above the gate — and the author-set decode labels
-are D4-consistent. The residual risk is a *small fragment*: with few observed
-edges, 40% BER is a small absolute bit budget, so a wrong origin could pass. And
-because `detect_puzzleboard_best` selects on `(corners.len(), mean_confidence)`,
-such a fragment could in principle out-rank a correct decode.
+**Was.** Neither decode path enforced that the chosen master origin was
+*uniquely* the best-supported one. The hard-weighted path (including the 40% BER
+sweep pass) emitted `score_margin = ∞` and never computed a runner-up; the
+soft-LL default path gated on a normalized log-likelihood *score gap*
+(`alignment_min_margin`), which does not enforce origin uniqueness. A witness was
+constructed and confirmed: a small or distortion-corrupted fragment frequently
+has a *distinct* master origin (a different position and/or D4 transform) that
+matches the observed edge bits as well as — or within a bit of — the true origin.
+Shipping such a decode is a false positive (an unrecoverable wrong absolute
+label), even though every per-frame `(i, j)` is internally D4-consistent.
 
-No false positive has been observed: the author D4-consistency test passes, and
-the single-config `for_board` regression path is unaffected (the sweep / 40% pass
-is reachable only through `detect_puzzleboard_best`). Per the evidence-driven
-mandate, the next step is to **construct a witness** frame the 40% pass actually
-mislabels before changing the gate. Candidate guards once a witness exists:
-require a best-vs-runner-up BER margin on the hard path, or a minimum
-observed-edge count for the 40% pass. Deferred pending a witness.
+**Root cause — this is error-correcting-code decoding.** The master edge code is
+a De Bruijn torus whose minimum Hamming distance `d(w)` between a `w×w` window's
+codeword and its nearest neighbour (over all origins and all 8 D4 transforms)
+grows roughly quadratically with `w` but is only **1 at the 4×4 minimum window**
+(zero error-correction). So a single corrupted bit can turn a corrupted 4×4
+fragment into a *perfect* read of a different location. No acceptance test can
+make the 4×4 window safe; the safe window must be sized to the code's distance
+for the error budget (bounded-distance decoding).
+
+**Fix.**
+
+1. **Uniqueness gate (both paths).** Compute the matched-bit count of the closest
+   *distinct* competing origin (full-master via an exact crossed-CRT top-2;
+   fixed-board via the shift-scan top-2) and accept only when
+   `margin > k_winner`, where `margin = best_matched − runner_up_matched` and
+   `k_winner = edges_observed − best_matched` (the winner's own mismatch count).
+   Equivalently, the winner's net score (`matched − mismatched`) must strictly
+   exceed the runner-up's matched count. This is **parameter-free** (no magic
+   constant): a clean exact read (`k_winner = 0`) passes at any `margin ≥ 1`,
+   honoring the code's exact-uniqueness design at any size; a noisy-ambiguous read
+   (small `margin`, large `k_winner`) declines. The soft path applies the
+   identical matched-count predicate in addition to its score-gap gate (the soft
+   default was *separately* vulnerable — it false-accepted a wrong origin at every
+   window size in a high-trial sweep, a pre-existing defect in the production
+   default, now closed).
+2. **Bounded-distance floor.** `min_window` is raised to **7** (84 interior
+   edges): a 300k-trial sweep (random origins × random error patterns up to the
+   BER budget, per-corner ground-truth checked) finds 7×7 the smallest square
+   window with zero false-accepts under the gate at both 30% and 40% BER (5×5 and
+   6×6 still alias). A limiting-dimension guard additionally rejects wide-but-short
+   strips that meet the edge-count floor yet are too thin on one axis to carry the
+   code distance (a 3-corner-tall strip at the floor aliases at a low rate; every
+   window spanning ≥ `min_window` corners on *both* axes is alias-free in the
+   sweep).
+
+**Honest guarantee.** Safety is **empirical-with-defense-in-depth, not a
+worst-case guarantee**: at these BER budgets a worst-case bound would require
+`d(w) > 2·⌊BER·N⌋ ≈ 0.8·N`, far above the ~`N/4` the code actually provides, so a
+specifically-adversarial error pattern of weight ~`d/2` can still alias at any
+practical window. The `min_window` floor keeps *random* corruption below the
+aliasing regime, and the gate catches the residual near-aliases — validated to
+zero false-accepts across the high-trial sweep. The criterion is structural
+(scale-relative, dataset-independent); it is not fitted to any frame.
+
+**Effect on the author set.** example4/5/6 (clean, full boards) decode with huge
+uniqueness margins, unaffected. example0/1/2/3/8 (distorted or small) are
+*non-unique* and are now correctly declined as detection failures — the
+`author_examples_1_2_3_are_declined_as_non_unique` test pins this. The
+single-config `for_board` default path inherits the raised floor and the soft
+uniqueness gate (a deliberate, documented recall tradeoff on noisy/partial views:
+boards below the safe window become correct misses rather than risk a wrong
+label). The public regression and the private regression set hold at baseline
+with zero wrong labels.
 
 ---
 


### PR DESCRIPTION
## Gap 19 — bounded-distance uniqueness gate for PuzzleBoard decoding

### The bug (witnessed)
PuzzleBoard decoding is error-correcting-code decoding against a De Bruijn master
torus. Neither decode path enforced that the chosen master origin was *uniquely*
the best-supported one:
- the hard-weighted path (incl. the 40% BER sweep pass) emitted `score_margin = ∞`
  and never computed a runner-up;
- the soft-LL default path gated on a normalized log-likelihood *score gap*
  (`alignment_min_margin`), which does **not** enforce origin uniqueness.

A constructed witness confirms the failure: a small or distortion-corrupted
fragment frequently has a *distinct* master origin (different position and/or D4
transform) matching the observed edge bits as well as — or within a bit of — the
true origin. Shipping such a decode is a false positive (an unrecoverable wrong
absolute label), even though every per-frame `(i, j)` is internally
D4-consistent. The public author frames example0/1/2/3/8 are exactly this:
non-unique decodes that passed a D4-consistency check only because the tie-break
happened to land on the reference origin.

### Root cause: `d = 1` at the minimum window
The master code's minimum Hamming distance `d(w)` between a `w×w` window's
codeword and its nearest neighbour (over all origins and all 8 D4 transforms)
grows ~quadratically with `w` but is only **1 at the 4×4 minimum window** (zero
error-correction). A single corrupted bit can turn a corrupted 4×4 fragment into
a *perfect* read of a different location, so no acceptance test can make the 4×4
window safe under noise — the safe window must be sized to the code's distance
for the error budget (bounded-distance decoding).

### The fix
1. **Parameter-free uniqueness gate (both paths).** Compute the matched-bit count
   of the closest *distinct* competing origin (full-master via an exact
   crossed-CRT top-2; fixed-board via the shift-scan top-2) and accept only when
   `margin > k_winner`, where `margin = best_matched − runner_up_matched` and
   `k_winner = edges_observed − best_matched`. Equivalently, the winner's net
   score (`matched − mismatched`) must strictly exceed the runner-up's matched
   count. No magic constant: a clean exact read (`k_winner = 0`) passes at any
   `margin ≥ 1`, honoring the code's exact-uniqueness design at any size; a
   noisy-ambiguous read declines. The soft path applies this in addition to its
   existing score-gap gate (the soft default was *separately* vulnerable — it
   false-accepted a wrong origin at every window size in a high-trial sweep, a
   pre-existing defect in the production default, now closed).
2. **Bounded-distance floor.** `min_window` is raised to **7** (84 interior
   edges): a 300k-trial sweep (random origins × random error patterns up to the
   BER budget, per-corner ground-truth checked) finds 7×7 the smallest square
   window with zero false-accepts under the gate at both 30% and 40% BER. A
   limiting-dimension guard additionally rejects wide-but-short strips that meet
   the edge-count floor yet are too thin on one axis to carry the code distance.

### Honest guarantee
Safety is **empirical-with-defense-in-depth, not a worst-case guarantee**: at
these BER budgets a worst-case bound would require `d(w) > 2·⌊BER·N⌋ ≈ 0.8·N`,
far above the ~`N/4` the code provides. The `min_window` floor keeps *random*
corruption below the aliasing regime; the gate catches the residual near-aliases
— validated to zero false-accepts across the high-trial sweep. The criterion is
structural (scale-relative, dataset-independent), not fitted to any frame.

### Effect
- Clean full boards decode with huge uniqueness margins, unaffected.
- The distorted author frames (example0/1/2/3/8) are now correctly **declined as
  detection failures** — a non-unique absolute decode is a wrong label waiting to
  happen, and the contract forbids wrong labels far more strongly than misses.
- `example2.png` (the documented Gap-19 problem case) is reframed in the public
  performance report as a **grid-only chessboard card**: its grid builds cleanly
  (~179 corners), but the PuzzleBoard decode is correctly declined, so there is no
  trustworthy decode stage to time. No public test frame decodes uniquely as a
  PuzzleBoard.
- The default `for_board` path inherits the raised floor and the soft uniqueness
  gate — a deliberate, documented recall tradeoff on noisy/partial views (boards
  below the safe window become correct misses rather than risk a wrong label).

### Validation
- New permanent regressions: a corrupted safe-window fragment declines (never
  ships a wrong labeling); a clean fragment decodes with `margin > k_winner`; the
  soft 8×8 witness is now declined; the author distorted frames are declined; the
  gate decision matches an independent brute-force-gated oracle.
- The byte-identity oracle tests now gate `decode_reference` / `decode_soft_reference`
  identically.
- `bench check` public + private: zero `pos`/`id`/`dup` (the grid pipeline is
  untouched; its pre-existing recall deltas are unrelated).
- The private PuzzleBoard regression (`full_vs_fixed_board_origin_match_on_all_snaps`)
  holds with zero origin disagreements under the gate in both scoring modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
