### PR TITLE
docs(projective-grid): reframe advanced tier as a composition API + document core-vs-extended boundary (C-5)

### DIFF
--- a/book/src/algo_topological_grid.md
+++ b/book/src/algo_topological_grid.md
@@ -1,7 +1,8 @@
 # Topological grid finder
 
 > Code: `projective_grid::topological`
-> (`detect_grid_all` with `SquareAlgorithm::Topological`). In-repo
+> (reached via `detect_grid_all` — the sole grid builder, selected by
+> `LatticeKind` + `Evidence`, with no algorithm enum). In-repo
 > deep-dive: `docs/algorithms/topological-grid-detection.md`.
 
 The topological grid finder is the **sole grid builder** in the

--- a/book/src/chessboard.md
+++ b/book/src/chessboard.md
@@ -175,7 +175,7 @@ only add recall, never a wrong label. Under `RingFit` it is a no-op.
 
 Hand the oriented features (positions + dual axes) and the cluster centres
 (as an axis hint) to the [topological grid finder](algo_topological_grid.md)
-(`detect_grid_all` with `SquareAlgorithm::Topological`): Delaunay
+(via `detect_grid_all` — the sole grid builder, no algorithm enum): Delaunay
 triangulation → axis-driven edge classification → triangle-pair → quad
 merge → flood-fill `(i, j)` walk → the facade's `merge_components_local`.
 The facade's *own* post-build validation / residual drop / recovery are

--- a/book/src/example_regular_grid.md
+++ b/book/src/example_regular_grid.md
@@ -84,8 +84,9 @@ let solution = detect_grid(request)?;
 assert_eq!(solution.grid.entries.len(), 9);
 ```
 
-`DetectionParams::default()` carries a `max_residual_px` fit gate and
-selects `SquareAlgorithm::Topological` — the sole grid builder. It runs a
+`DetectionParams::default()` carries a `max_residual_px` fit gate and runs
+the topological grid builder — the sole builder, so there is no algorithm to
+select. It runs a
 Delaunay triangulation over the corner cloud, classifies edges by axis
 match, merges triangle pairs into cells, and floods integer coordinates
 across the mesh, then fits a projective transform. See the

--- a/book/src/projective_grid.md
+++ b/book/src/projective_grid.md
@@ -88,7 +88,7 @@ detect, and read the recovered labels. This is the body of
 use nalgebra::Point2;
 use projective_grid::{
     detect_grid, DetectionParams, DetectionRequest, Evidence, LatticeKind, LocalAxis,
-    OrientedFeature, PointFeature, SquareAlgorithm,
+    OrientedFeature, PointFeature,
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -149,18 +149,19 @@ features).
 
 ## The square algorithm: Topological
 
-Detection of `(Square, Oriented2)` uses the **`SquareAlgorithm::Topological`**
-algorithm — the sole grid builder for all square targets. It is the Shu /
-Brunton / Fiala 2009 axis-driven grid finder: a Delaunay triangulation over
-the corner cloud whose edges are classified by per-corner axis match, with
-triangle pairs merged into cells and integer coordinates flooded across the
-mesh. Image-free; recovers dense grids and copes well with distortion. May
-produce several components — see `detect_grid_all` below.
+Detection of `(Square, Oriented2)` uses the **topological** grid finder — the
+sole grid builder for all square targets. It is the Shu / Brunton / Fiala 2009
+axis-driven grid finder: a Delaunay triangulation over the corner cloud whose
+edges are classified by per-corner axis match, with triangle pairs merged into
+cells and integer coordinates flooded across the mesh. Image-free; recovers
+dense grids and copes well with distortion. May produce several components —
+see `detect_grid_all` below.
 
-There is only one square grid builder. `GraphBuildAlgorithm` (on
-`DetectorParams`) is a single-variant, `#[non_exhaustive]` enum
-(`Topological`) retained purely as a reserved config seam — there is no
-algorithm to choose.
+There is only one square grid builder, so the request carries **no algorithm
+choice**: what to detect is selected by the `LatticeKind` (`Square` / `Hex`)
+and the `Evidence` shape on the `DetectionRequest`, not by an algorithm enum.
+The historical single-variant `SquareAlgorithm` / `GraphBuildAlgorithm` seams
+were removed once seed-and-grow was retired.
 
 The algorithm shares the post-detection validation and projective fit across
 all target types, recovering the full pattern with zero wrong labels. The

--- a/crates/projective-grid/docs/DESIGN.md
+++ b/crates/projective-grid/docs/DESIGN.md
@@ -212,18 +212,98 @@ implementation are gone.
 
 ### Two public tiers
 
-The crate exposes two tiers (see the `lib.rs` module docs):
+The crate ships an intentional two-tier public API (see the `lib.rs` module
+docs for the canonical statement). Both tiers are supported; they differ in
+audience and in how fast the surface may move.
 
 - **Stable tier** — the crate-root facade re-exports (`detect_grid*`,
   `check_consistency`, the request / result / evidence / lattice types, the
-  `orient::synthesize_*` helpers). The supported surface for external callers.
-- **Advanced tier** — the `shared` and `topological` engine modules,
-  semver-exempt pre-1.0, for in-workspace consumers (the chessboard detector)
-  that compose the engine directly with their own policies. This includes the
-  grid-growth and recovery primitives under `shared` (grow / fill / extension /
-  recovery) the chessboard crate drives for its own recovery path. Items here
-  change shape as the engine is refactored; engine items with no external
-  consumer are `pub(crate)`.
+  `orient::synthesize_*` helpers, `cluster_axes`). The supported surface for an
+  ordinary caller who wants to detect a grid and read labels back; normal
+  semver guarantees apply.
+- **Advanced tier (composition API)** — the `shared`, `topological`, `lattice`,
+  `orient`, and `cluster` modules, exposed deliberately so a consumer with its
+  own per-pattern invariants can drive the engine under its own policy. The
+  in-workspace chessboard detector is the reference example, but the contract
+  is written for external consumers too. This is *intended product*, not a
+  private engine wearing a `pub` badge.
+
+  **The composition contract.** A consumer supplies a
+  `shared::grow::SquareAttachPolicy` — the seam between the geometry-only growth
+  machinery and the pattern's rules, answering `is_eligible` /
+  `required_label_at` / `accept_candidate` / `edge_ok` per candidate — and
+  drives the growth / recovery primitives under `shared` (`grow`, `fill`,
+  `extension`, `grow_extend`, and the `recovery_schedule::RecoverySchedule`
+  fixed-point tuned by `RecoveryParams`). After its front-half builds
+  integer-labelled components, it composes the lattice-parameterised
+  back-half: local-geometry merge (`shared::merge`), the structural-cue
+  `shared::validate` gate, and the projective fit. **Guarantee:** every stage
+  is *drop-only* with respect to labels — a corner whose geometry does not
+  cohere is removed, never relabelled — so the **zero-wrong-labels** precision
+  contract holds for a consumer that composes the engine under its own policy,
+  exactly as it does on the facade path.
+
+  **Stability.** This surface is *advanced, and may evolve*: its shape tracks
+  the engine's internal structure, so an item may change between minor releases
+  when the engine is refactored. That is a deliberate trade — slower-moving
+  contract in exchange for direct engine access — not a "this is really
+  private" disclaimer. Engine items with no external consumer stay
+  `pub(crate)`, keeping the advanced surface no wider than what a consumer
+  actually composes.
+
+### Core vs. extended surface
+
+Orthogonal to the stable/advanced split, the public surface divides into a
+**core** path that production exercises and an **extended** breadth that is
+intended external product but exercised only by this crate's own tests. The
+table is the greppable map; the rationale follows.
+
+| | Core (exercised in production) | Extended (library-only breadth) |
+|---|---|---|
+| Lattice | `Square` (`LatticeKind::Square`) | `Hex` (`LatticeKind::Hex`), `topological::hex*`, `D6_TRANSFORMS`, `HEX_AXIAL_OFFSETS` |
+| Evidence | `Evidence::Oriented2` (two local axes) | `Evidence::Positions` (0 axes) · `Evidence::Oriented1` (1 axis) · `Evidence::Oriented3` (hex-native) |
+| Axis synthesis | none (native two-axis input) | `orient::synthesize_*`, the per-corner double-angle 2-means |
+| Recovery | `RecoverySchedule::Off` on the native path | `shared::recovery_schedule` (the synthesized-axis recall path), `shared::positions_policy` |
+| Exercised by | every in-workspace detector (chessboard, ChArUco, puzzleboard, marker) — the most regression-tested surface | `projective-grid`'s own tests only |
+
+The **core** path — `(Square, Oriented2)` — is what every shipping detector
+runs: native two-axis corner evidence into the topological assembler, with the
+post-convergence recovery schedule off (the native path needs no synthesized-axis
+recall). It is precision-by-construction and the most heavily gated surface in
+the crate.
+
+The **extended** breadth is the rest of the design space the crate
+deliberately spans as a published library: the hex lattice family and the
+orientation-free / single-axis inputs that synthesize the missing axes from
+neighbour geometry (`orient::*`) and lean on the geometry-only recovery
+schedule (`shared::recovery_schedule`, `positions_policy`) to reach recall
+parity. This breadth is *intended product* — it is published precisely so a
+downstream user can detect a dot grid, a circle grid, or a hex target without
+re-deriving the machinery — but no in-workspace detector exercises it today, so
+it is covered by `projective-grid`'s own tests rather than the detector
+regression sets.
+
+#### Why this is documented, not feature-gated
+
+An alternative to documenting the boundary was to put the extended breadth
+behind compile-time features (`feature = "hex"`, `feature = "orientation-free"`)
+so an external user opts in and the default build compiles only the core
+spine. That was **deliberately deferred** in favour of the table above:
+
+- The benefit is *unmeasured*. The claimed wins are smaller compile time and a
+  narrower default surface, but neither has been quantified; the extended code
+  is a bounded fraction of the crate and gating it adds a CI feature-matrix
+  obligation (every combination must build) with no demonstrated payoff.
+- The cost is a *semver break on a published crate*. `projective-grid` is
+  published, so moving `Hex`, `Evidence::Positions`, the `orient::*` helpers,
+  and the recovery schedule behind off-by-default features would break every
+  downstream user who composes them today — a real cost against a speculative
+  benefit.
+
+The breadth is intended product and stays compiled in either way; making the
+core-vs-extended split *legible* (this section, and the `lib.rs` module docs)
+achieves the comprehension goal without the breaking change. Revisit the gate
+only if compile time or surface size becomes a measured, felt cost.
 
 ## Extending to hex (without copying machinery)
 

--- a/crates/projective-grid/src/lib.rs
+++ b/crates/projective-grid/src/lib.rs
@@ -23,26 +23,108 @@
 //!
 //! # Two public tiers
 //!
-//! The crate exposes two tiers with different stability promises:
+//! The crate ships an intentional two-tier public API. Both tiers are
+//! supported; they differ in audience and in how fast the surface is allowed
+//! to move.
 //!
-//! * **Stable tier — the facade.** The items re-exported at the crate root
-//!   ([`detect_grid`], [`detect_grid_all`], [`check_consistency`], the
-//!   [`Evidence`] / [`DetectionParams`] / [`DetectionRequest`] request types,
-//!   the [`GridSolution`] / [`LabelledGrid`] result types, the [`Lattice`] /
-//!   [`LatticeKind`] / [`Coord`] model, the feature evidence types, and the
-//!   `orient::synthesize_*` helpers, and the [`cluster_axes`]
-//!   global-direction prior with its [`AxisClusterCenters`] /
-//!   [`AxisAssignment`] types). This is the supported surface for
-//!   external callers and follows normal semver intent.
-//! * **Advanced tier — the engine modules.** [`shared`] and [`topological`]
-//!   expose the assembly engines the facade is built from, for in-workspace
-//!   consumers (the chessboard detector) that compose the engine directly with
-//!   their own policies. [`shared`] hosts the geometry-only grid-growth
-//!   primitives ([`shared::grow`], [`shared::fill`], [`shared::extension`],
-//!   [`shared::grow_extend`]) and the [`shared::recovery_schedule`] schedule.
-//!   These are **semver-exempt pre-1.0**: items here may change shape between
-//!   minor releases as the engine is refactored. Depend on the facade unless
-//!   you are building a new detector on top of the engine.
+//! ## Stable tier — the facade (ordinary users)
+//!
+//! The items re-exported at the crate root are the supported surface for an
+//! ordinary caller who wants to *detect a grid* and read the labels back:
+//!
+//! * the entry points [`detect_grid`] / [`detect_grid_all`] and the
+//!   consistency check [`check_consistency`];
+//! * the request types [`Evidence`] / [`DetectionParams`] /
+//!   [`DetectionRequest`] (and the consistency-task [`ConsistencyParams`] /
+//!   [`ConsistencyRequest`]);
+//! * the result types [`GridSolution`] / [`LabelledGrid`] /
+//!   [`DetectionReport`];
+//! * the lattice model [`Lattice`] / [`LatticeKind`] / [`Coord`] and the
+//!   feature-evidence types ([`PointFeature`], [`OrientedFeature`],
+//!   [`LocalAxis`]);
+//! * the orientation-synthesis helpers ([`synthesize_oriented2`] and friends)
+//!   and the [`cluster_axes`] global-direction prior with its
+//!   [`AxisClusterCenters`] / [`AxisAssignment`] types.
+//!
+//! This tier carries normal semver guarantees: breaking changes here go
+//! through the usual deprecation cycle.
+//!
+//! ## Advanced tier — the composition API (build your own detector)
+//!
+//! [`shared`], [`topological`], [`lattice`], [`orient`], and [`cluster`]
+//! expose the assembly engine the facade is built from, as a deliberate
+//! **composition API**. It exists so a consumer with its own per-pattern
+//! invariants — the in-workspace chessboard detector is the reference example,
+//! but the contract is written for external consumers too — can drive the same
+//! grid-growth and recovery machinery under its own policy instead of going
+//! through the one-size-fits-all facade. This is intended product, not a
+//! private engine that merely happens to be `pub`.
+//!
+//! The composition contract — what a consumer supplies and what the engine
+//! guarantees in return:
+//!
+//! * **You supply a [`shared::grow::SquareAttachPolicy`].** This is the seam
+//!   between the geometry-only growth machinery and your pattern's rules. The
+//!   policy answers four questions per candidate — `is_eligible`,
+//!   `required_label_at`, `accept_candidate`, `edge_ok` — letting you veto an
+//!   attachment that is geometrically plausible but illegal for your pattern
+//!   (e.g. a chessboard's alternating-colour parity, or a per-corner
+//!   blacklist). The engine never relabels behind your back: every attachment
+//!   it proposes has already passed your policy.
+//! * **You drive the growth / recovery engine.** The geometry-only primitives
+//!   live under [`shared`]: [`shared::grow`] (candidate search + ambiguity
+//!   resolution + the per-edge cardinal gate), [`shared::fill`] (interior
+//!   hole fill), [`shared::extension`] / [`shared::grow_extend`] (boundary
+//!   extension by local homography then cardinal BFS), and
+//!   [`shared::recovery_schedule`] — the [`RecoverySchedule`]
+//!   fixed-point that composes extension + fill + revalidation + drop filters
+//!   into one post-convergence pass. Tune it with [`RecoveryParams`].
+//! * **You compose the shared back-half.** After your front-half has built
+//!   integer-labelled components, the lattice-parameterised back-half reunites
+//!   them with local geometry only ([`shared::merge`]), drops outliers with the
+//!   structural-cue gate ([`shared::validate`]), and fits the model→image
+//!   projective transform. The whole back-half is written against the
+//!   [`Lattice`] trait, so it serves any implemented family.
+//! * **The guarantees.** Every stage is *drop-only* with respect to labels: a
+//!   corner whose geometry does not cohere is removed, never relabelled. The
+//!   precision contract of the facade — **zero wrong `(i, j)` labels**, misses
+//!   acceptable — therefore holds for a consumer that composes the engine
+//!   under its own policy, because the policy gates and the validate/drop
+//!   filters run on every attachment exactly as they do on the facade path.
+//!   Returned components are rebased so the labelled bounding-box minimum is
+//!   `(0, 0)`; quad / homography corner order is TL, TR, BR, BL.
+//!
+//! **Stability of the advanced tier.** This surface is *advanced, and may
+//! evolve*: its shape tracks the engine's internal structure, so an item may
+//! change between minor releases when the engine is refactored. That is a
+//! deliberate product choice — the tier trades a slower-moving contract for
+//! direct access to the engine — not a disclaimer that it is really private.
+//! If you only need to detect a grid, depend on the facade; reach for the
+//! composition tier when you are building a *new kind of detector* on top of
+//! the engine. Engine items with no external consumer stay `pub(crate)`, so
+//! the advanced surface is kept no wider than what a consumer actually
+//! composes.
+//!
+//! # Core vs. extended surface
+//!
+//! Orthogonal to the stable/advanced split is a second distinction worth
+//! making explicit, because the two halves are exercised very differently in
+//! practice:
+//!
+//! * **Core path (exercised in production).** The square lattice
+//!   ([`LatticeKind::Square`]) driven by two-axis evidence
+//!   ([`Evidence::Oriented2`]). This is the path every in-workspace detector —
+//!   chessboard, ChArUco, puzzleboard, marker board — actually runs, and it is
+//!   the most heavily regression-tested surface in the crate.
+//! * **Extended path (library-only breadth).** The hexagonal lattice
+//!   ([`Hex`], the [`topological`] hex arm, [`D6_TRANSFORMS`]) and the
+//!   orientation-free / single-axis synthesis ([`orient`],
+//!   [`shared::recovery_schedule`], [`Evidence::Positions`] /
+//!   [`Evidence::Oriented1`]). This breadth is intended external product — it
+//!   is published precisely so a downstream user can detect a dot grid or a
+//!   hex target — but no in-workspace detector exercises it today; it is
+//!   covered by this crate's own tests. See `docs/DESIGN.md` for the full
+//!   core-vs-extended map.
 
 #![warn(missing_docs)]
 

--- a/docs/architecture/chore-backlog.md
+++ b/docs/architecture/chore-backlog.md
@@ -1,8 +1,11 @@
 # Chore Backlog — Detection Stack Consolidation
 
 > The actionable output of the [critique](critique.md): a ranked ledger of
-> evidence-backed cleanup items. **Doc-only as of this snapshot — nothing here is
-> executed yet.** Each item is tagged with effort, regression risk, blast radius,
+> evidence-backed cleanup items. **Status: the consolidation is essentially
+> complete.** C-1 through C-8 have all merged; C-5 (this item) lands as a
+> docs PR that reframes the advanced tier and documents the core-vs-extended
+> boundary; C-9 was **deliberately deferred** (see its section for the
+> rationale). Each item is tagged with effort, regression risk, blast radius,
 > and **API impact** (because `projective-grid`, `core`, and the detectors are
 > published — semver matters).
 
@@ -15,26 +18,33 @@ stage with deprecations) · `additive` (new items only) · `feature` (new cfg fl
 Legibility quick-wins first, then the one high-value structural fix, then the large
 migration once the surface is clearer. Optional/strategic last.
 
-| Order | Item | What | Sev | Effort | Risk | API |
-|---|---|---|---|---|---|---|
-| 1 | [C-8](#c-8) | Sanitize private-dataset specifics in source comments | P3 | S | Low | none |
-| 2 | [C-3](#c-3) | Rename `recovery`/`validation` modules by role | P2 | S | Low | internal-safe¹ |
-| 3 | [C-6](#c-6) | Share one `build_corner_map` | P2 | S | Low | additive |
-| 4 | [C-4](#c-4) | Delete the single-variant `SquareAlgorithm` seam | P3 | S | Low | semver² |
-| 5 | [C-1](#c-1) | Unify the forked homography (single source of truth) | **P1** | M | Med | internal-safe |
-| 6 | [C-5](#c-5) | Decide what `pg`'s advanced tier *is* | P2 | M | Low | semver/doc |
-| 7 | [C-7](#c-7) | Retire or justify the legacy ChArUco matcher | P3 | M | Med | semver |
-| 8 | [C-2](#c-2) | Finish the `GridCoords → Coord` migration | **P1** | L | Med-High | semver |
-| 9 | [C-9](#c-9) | Feature-gate the library-only breadth (optional) | — | M | Med | feature |
+| Order | Item | What | Sev | Effort | Risk | API | Status |
+|---|---|---|---|---|---|---|---|
+| 1 | [C-8](#c-8) | Sanitize private-dataset specifics in source comments | P3 | S | Low | none | ✅ DONE |
+| 2 | [C-3](#c-3) | Rename `recovery`/`validation` modules by role | P2 | S | Low | internal-safe¹ | ✅ DONE |
+| 3 | [C-6](#c-6) | Share the complete-square-cell enumeration | P2 | S | Low | additive | ✅ DONE |
+| 4 | [C-4](#c-4) | Delete the single-variant `SquareAlgorithm` seam | P3 | S | Low | semver² | ✅ DONE |
+| 5 | [C-1](#c-1) | Unify the forked homography (single source of truth) | **P1** | M | Med | internal-safe | ✅ DONE |
+| 6 | [C-5](#c-5) | Decide what `pg`'s advanced tier *is* | P2 | M | Low | semver/doc | 📝 THIS PR (option a) |
+| 7 | [C-7](#c-7) | Retire or justify the legacy ChArUco matcher | P3 | M | Med | semver | ✅ DONE |
+| 8 | [C-2](#c-2) | Finish the `GridCoords → Coord` migration | **P1** | L | Med-High | semver | ✅ DONE |
+| 9 | [C-9](#c-9) | Feature-gate the library-only breadth (optional) | — | M | Med | feature | ⏸️ DEFERRED |
 
-¹ The `pg shared/*` renames touch the *advanced tier*, which `lib.rs` declares
-semver-exempt; the one public rename (`charuco validation.rs`) needs a deprecation
-alias. ² Removes a `pub enum` — trivially breaking; deprecate one release first.
+¹ The `pg shared/*` renames touch the *advanced tier*, which `lib.rs` documents
+as "advanced, may evolve" (per C-5); the one public rename (`charuco
+validation.rs`) needs a deprecation alias. ² Removes a `pub enum` — trivially
+breaking; C-4 took the delete-now option.
 
 ---
 
-## <a id="c-1"></a>C-1 · Unify the forked homography
+## <a id="c-1"></a>C-1 · Unify the forked homography — DONE
 **Severity P1 · Effort M · Risk Med · API internal-safe (if names preserved)**
+
+- **Outcome:** done. The pure DLT solver now lives once in `pg geometry`; `core`
+  re-implements `estimate_homography_rect_to_img` as a thin wrapper over it and
+  keeps only the image-domain extras. Public names preserved; both regression
+  sets stayed green.
+
 
 - **Problem:** [D-1](critique.md#d-1-homography-is-forked-verbatim). The DLT solver in
   `pg geometry/homography.rs::estimate_homography` is a verbatim copy of
@@ -52,8 +62,15 @@ alias. ² Removes a `pub enum` — trivially breaking; deprecate one release fir
   fixed correspondence set before deleting the `core` body.
 - **Deps:** none. Do before [C-2](#c-2) (shrinks the `core` public surface in flux).
 
-## <a id="c-2"></a>C-2 · Finish the `GridCoords → Coord` migration
+## <a id="c-2"></a>C-2 · Finish the `GridCoords → Coord` migration — DONE
 **Severity P1 · Effort L · Risk Med-High · API semver**
+
+- **Outcome:** done (PR #68). `pg Coord` is the sole grid-coordinate type; the
+  `core GridCoords` model and the `grid_alignment_*_to_next` coordinate shims
+  are deleted. (The `homography_to_next` / `homography_from_next` *homography*
+  bridge is a separate, intentionally-retained seam, not part of this
+  coordinate migration.)
+
 
 - **Problem:** [D-2](critique.md#d-2-the-gridcoords--coord-migration-is-frozen-mid-flight).
   Dual coordinate models (`core GridCoords{i,j}` vs `pg Coord{u,v}`) bridged by
@@ -69,8 +86,13 @@ alias. ² Removes a `pub enum` — trivially breaking; deprecate one release fir
   aliases, (b) alias removal next minor. Full regression matrix each step.
 - **Deps:** after [C-1](#c-1); coordinate the deprecation window with [C-4](#c-4).
 
-## <a id="c-3"></a>C-3 · Rename `recovery`/`validation` modules by role
+## <a id="c-3"></a>C-3 · Rename `recovery`/`validation` modules by role — DONE
 **Severity P2 · Effort S · Risk Low · API internal-safe¹**
+
+- **Outcome:** done. `pg shared/recovery.rs` → `recovery_schedule.rs`,
+  `pg shared/validate/recovery.rs` → `wrong_label_filters.rs`, the charuco
+  renames applied, with a deprecation re-export on the one public name.
+
 
 - **Problem:** [D-3](critique.md#d-3-two-validations-two-corner-maps). Two `recovery.rs`
   in `pg shared/` (schedule vs drop-filters); two "validation" concepts in `charuco`.
@@ -83,47 +105,57 @@ alias. ² Removes a `pub enum` — trivially breaking; deprecate one release fir
 - **Risk control:** pure renames; `cargo build` + `cargo doc` (zero-warning gate)
   catch every miss.
 
-## <a id="c-4"></a>C-4 · Delete the single-variant `SquareAlgorithm` seam
+## <a id="c-4"></a>C-4 · Delete the single-variant `SquareAlgorithm` seam — DONE
 **Severity P3 · Effort S · Risk Low · API semver (trivial)**
 
-- **Problem:** [D-4](critique.md#d-4-deadspeculative-seams-kept-for-later).
-  `pg detect.rs::SquareAlgorithm` has one variant; the `with_algorithm` builder and
-  the bench `AlgorithmReq` seam scaffold a builder that doesn't exist.
-- **Fix:** remove the enum + builder + the `match` with one arm; inline the
-  topological path. Keep `DetectionParams` `#[non_exhaustive]` for headroom. Update
-  `bench/compare.rs` to drop the synthetic second-builder slug.
-- **Blast radius:** `pg detect.rs` (removes a `pub enum`), `chessboard` (one call
-  site), `bench`.
-- **Judgment call:** legitimate to *keep* as semver headroom on a library. Recommend
-  deleting (deprecate one release) — re-add when a real second builder lands.
+- **Outcome:** done. The recommendation to delete was taken: the single-variant
+  `pg detect.rs::SquareAlgorithm` and `chessboard`'s `GraphBuildAlgorithm`
+  selector enums, the `with_algorithm` builder, and the synthetic bench
+  `AlgorithmReq` / `AlgorithmArg` seam are all removed. `DetectionParams` stays
+  `#[non_exhaustive]` for headroom; the topological path is inlined and what to
+  detect is selected by `LatticeKind` + `Evidence`, not an algorithm enum.
+  Re-introduce a strategy enum only when a second builder actually lands.
+- **Original problem:** [D-4](critique.md#d-4-deadspeculative-seams-kept-for-later).
+  `pg detect.rs::SquareAlgorithm` had one variant; the `with_algorithm` builder and
+  the bench `AlgorithmReq` seam scaffolded a builder that did not exist.
 
-## <a id="c-5"></a>C-5 · Decide what `pg`'s advanced tier *is*
+## <a id="c-5"></a>C-5 · Decide what `pg`'s advanced tier *is* — THIS PR (option a)
 **Severity P2 · Effort M · Risk Low · API semver/doc**
 
-- **Problem:** [D-5](critique.md#d-5-the-advanced-tier-is-a-private-api-wearing-a-pub-badge).
-  `pub mod shared` / `pub mod topological` are "semver-exempt" yet published — both a
-  public API and chessboard's private engine.
-- **Fix (pick one):** (a) **embrace it as public** — document the composition
-  contract (the `SquareAttachPolicy` a consumer supplies, the recovery-schedule
-  guarantees), drop the "private" framing; or (b) **make it private** — move the
-  engine to a non-published `*-engine` crate (or `pub(crate)` + workspace path),
-  leaving only the facade public.
-- **Blast radius:** `pg lib.rs` + docs (option a), or a new crate + `chessboard`
-  import paths (option b).
-- **Recommendation:** option (a) doc-first (cheaper, keeps external composability);
-  revisit (b) only if no external consumer composes the engine.
+- **Outcome:** **option (a) — embrace it as public.** This docs PR reframes
+  `pub mod shared` / `pub mod topological` (plus `lattice` / `orient` /
+  `cluster`) from an apologetic "semver-exempt private engine" into an
+  intentional, documented **composition API**, and writes down the composition
+  contract: a consumer supplies a `shared::grow::SquareAttachPolicy`, drives the
+  growth / recovery primitives (`grow` / `fill` / `extension` / `grow_extend` /
+  `recovery_schedule`), and composes the shared back-half (`merge` / `validate`
+  / fit), with the drop-only **zero-wrong-labels** guarantee carried over. The
+  stable facade tier carries normal semver; the advanced tier is framed as
+  "advanced, may evolve" — a deliberate product choice, not a hedge. No public
+  API surface changed (no `pub`→`pub(crate)` churn, no feature flags). Same PR
+  also documents the core-vs-extended boundary (the C-9 replacement, below).
+- **Original problem:** [D-5](critique.md#d-5-the-advanced-tier-is-a-private-api-wearing-a-pub-badge).
+  `pub mod shared` / `pub mod topological` were "semver-exempt" yet published —
+  both a public API and chessboard's engine.
+- **Why not option (b):** the chessboard detector is the reference consumer, but
+  the engine composes cleanly for external consumers too; moving it to a
+  non-published `*-engine` crate would foreclose that without a measured reason.
 
-## <a id="c-6"></a>C-6 · Share one `build_corner_map`
+## <a id="c-6"></a>C-6 · Share the complete-square-cell enumeration — DONE
 **Severity P2 · Effort S · Risk Low · API additive**
 
-- **Problem:** [D-3](critique.md#d-3-two-validations-two-corner-maps).
-  `charuco detector/marker_sampling.rs` and `marker detector.rs` each implement
-  "chessboard grid → grid→pixel map" in parallel.
-- **Fix:** add a `build_corner_map` helper to `chessboard` (it owns
-  `ChessboardDetection`) and have both `charuco` and `marker` call it.
-- **Blast radius:** `chessboard` (new `pub` helper), `charuco`, `marker`.
-- **Risk control:** assert the shared helper reproduces both current maps on a fixed
-  detection before deleting the locals.
+- **Outcome:** done — but the framing changed on inspection. The two
+  `build_corner_map` functions turned out to be genuinely different operations
+  (marker's is a trivial map over a non-optional grid; charuco's is an
+  inlier-filtered loop over `&[LabeledCorner]` with an optional grid), so
+  merging *them* would be a worse abstraction and they stayed separate. The
+  real duplication was the **complete-square-cell enumeration** shared by
+  charuco's `build_marker_cells` and marker's `detect_circles_via_square_warp`
+  (fold corner-map keys into a bbox; per cell form the four `g00/g10/g11/g01`
+  keys, skip if any missing, assemble `[p00,p10,p11,p01]` in TL,TR,BR,BL). That
+  was extracted into a new `calib-targets-core::corner_map` module.
+- **Original problem:** [D-3](critique.md#d-3-two-validations-two-corner-maps),
+  the "two `build_corner_map`" strand.
 
 ## <a id="c-7"></a>C-7 · Retire or justify the legacy ChArUco matcher — DONE
 **Severity P3 · Effort M · Risk Med · API semver**
@@ -139,31 +171,40 @@ alias. ² Removes a `pub enum` — trivially breaking; deprecate one release fir
   `Unreleased` → `Breaking` section.
 - **Blast radius:** `charuco` (+ WASM type / Python overlay parity).
 
-## <a id="c-8"></a>C-8 · Sanitize private-dataset specifics in source comments
+## <a id="c-8"></a>C-8 · Sanitize private-dataset specifics in source comments — DONE
 **Severity P3 · Effort S · Risk Low · API none**
 
-- **Problem:** [D-6](critique.md#d-6-a-superseded-legacy-fallback-and-private-dataset-specifics-in-source).
-  `charuco detector/params.rs` default-constant comments cite concrete private-dataset
-  board sizes and frame counts, against
-  [`private-dataset-policy.md`](../development/private-dataset-policy.md).
-- **Fix:** rewrite those comments as general statements ("tuned on internal ArUco/
-  AprilTag regression sets; κ is the minimum that clears them with zero wrong-ids");
-  move any concrete figures to a local-only note. Grep the workspace for the same
-  pattern elsewhere while here.
-- **Blast radius:** comments only — zero behaviour change.
-- **Why early:** it's a policy-compliance item and trivially safe.
+- **Outcome:** done. The `charuco detector/params.rs` default-constant comments
+  that cited concrete private-dataset board sizes / frame counts were rewritten
+  as general statements ("tuned on internal ArUco/AprilTag regression sets; the
+  minimum that clears them with zero wrong-ids"); concrete figures live only in
+  local-only notes. Comments only — zero behaviour change.
+- **Original problem:** [D-6](critique.md#d-6-a-superseded-legacy-fallback-and-private-dataset-specifics-in-source),
+  against [`private-dataset-policy.md`](../development/private-dataset-policy.md).
 
-## <a id="c-9"></a>C-9 · Feature-gate the library-only breadth (optional / strategic)
+## <a id="c-9"></a>C-9 · Feature-gate the library-only breadth — DELIBERATELY DEFERRED
 **Severity — · Effort M · Risk Med · API feature**
 
-- **Problem:** [What the breadth costs](critique.md#what-the-breadth-costs). Hex and
-  orientation-free paths are always compiled though no workspace detector uses them.
-- **Fix:** gate them behind `feature = "hex"` and `feature = "orientation-free"`.
-  Keep current defaults *on* to avoid a breaking change, or flip defaults *off* in the
-  next minor (semver-sensitive) so the minimal engine is the default mental model.
-- **Blast radius:** `pg` cfg matrix + CI (must build all feature combinations).
-- **Note:** strategic, not urgent. Only worthwhile if compile time / surface size is
-  a felt cost; the breadth itself is intended product and stays either way.
+- **Decision: deferred, in favour of documenting the boundary** (done in the
+  C-5 PR). The cost/benefit did not justify the change:
+  - **Benefit is unmeasured.** The claimed wins — smaller compile time, a
+    narrower default surface — have not been quantified; the extended code is a
+    bounded fraction of the crate, and gating it imposes a CI feature-matrix
+    obligation (every combination must build) for no demonstrated payoff.
+  - **Cost is a semver break on a published crate.** Moving `Hex`,
+    `Evidence::Positions`, the `orient::*` helpers, and the recovery schedule
+    behind off-by-default features would break every downstream user who
+    composes them today.
+  - The breadth is **intended product** and stays compiled in either way.
+    Making the core-vs-extended split *legible* (the table in
+    `crates/projective-grid/docs/DESIGN.md` and the "Core vs. extended surface"
+    section in `pg lib.rs`) achieves the comprehension goal without the breaking
+    change.
+- **Revisit only** if compile time or surface size becomes a *measured*, felt
+  cost.
+- **Original problem:** [What the breadth costs](critique.md#what-the-breadth-costs).
+  Hex and orientation-free paths are always compiled though no in-workspace
+  detector uses them.
 
 ---
 

--- a/docs/architecture/critique.md
+++ b/docs/architecture/critique.md
@@ -45,6 +45,15 @@ This is *not* a codebase that needs a rewrite. It needs **consolidation**.
 
 Severity: **P1** worth doing soon · **P2** worth doing · **P3** judgment / nice-to-have.
 
+> **Status (update):** the consolidation these findings drove is essentially
+> complete. D-1, D-2, D-3, D-4, and D-6 are **resolved** (backlog C-1/C-2/C-3/
+> C-4/C-6/C-7/C-8, all merged); D-5 is **resolved by documentation** — the
+> advanced tier is now an intentional, documented composition API with a
+> written contract (backlog C-5). The "what the breadth costs" feature-gate
+> (C-9) was **deliberately deferred** in favour of documenting the
+> core-vs-extended boundary. The original analysis is kept below for the record;
+> per-finding resolution notes are inline.
+
 ### <a id="d-1-homography-is-forked-verbatim"></a>D-1 Homography is forked verbatim
 **Severity: P1 · the top finding.**
 
@@ -113,7 +122,13 @@ disambiguate every time:
   [backlog C-3](chore-backlog.md#c-3), [C-6](chore-backlog.md#c-6).
 
 ### <a id="d-4-deadspeculative-seams-kept-for-later"></a>D-4 Dead/speculative seams kept "for later"
-**Severity: P3 · low cost, but pure comprehension drag.**
+**Severity: P3 · low cost, but pure comprehension drag. — RESOLVED (C-4).**
+
+> *Resolved:* the recommendation to delete was taken. `pg detect.rs::SquareAlgorithm`,
+> `chessboard`'s `GraphBuildAlgorithm`, the `with_algorithm` builder, and the
+> bench `AlgorithmReq` / `AlgorithmArg` seam are all removed; the topological
+> path is inlined and selection is `LatticeKind` + `Evidence`. The original
+> analysis (describing the seam as still present) is kept below for the record.
 
 - `pg detect.rs::SquareAlgorithm` is a **single-variant `#[non_exhaustive]` enum**
   (`Topological`). Every call site passes that one value; the
@@ -129,7 +144,17 @@ disambiguate every time:
   [backlog C-4](chore-backlog.md#c-4).
 
 ### <a id="d-5-the-advanced-tier-is-a-private-api-wearing-a-pub-badge"></a>D-5 The advanced tier is a private API wearing a `pub` badge
-**Severity: P2 · library-design clarity.**
+**Severity: P2 · library-design clarity. — RESOLVED by documentation (C-5).**
+
+> *Resolved (option a):* the advanced tier is now framed as an intentional,
+> documented **composition API**, not a "semver-exempt private engine". `pg
+> lib.rs` and `docs/DESIGN.md` write down the composition contract — a consumer
+> supplies a `shared::grow::SquareAttachPolicy`, drives the growth / recovery
+> primitives, and composes the shared back-half, with the drop-only
+> zero-wrong-labels guarantee carried over — and state plainly that the stable
+> facade tier carries normal semver while the advanced tier is "advanced, may
+> evolve" (a deliberate product trade, not a hedge). No public API surface
+> changed. The original analysis is kept below for the record.
 
 `pg lib.rs` exposes `pub mod shared` and `pub mod topological` as a "semver-exempt
 pre-1.0" advanced tier "for in-workspace consumers (the chessboard detector)"
@@ -203,6 +228,11 @@ detectors — I would keep the layering almost exactly (it is a clean DAG, the d
 layers are well-isolated, the grid spine is shared by embedding). What I would *not*
 reproduce is the accumulated debris. Six concrete changes turn the current stack into
 the one I'd design:
+
+> **Status:** changes 1–5 below are now **done** (backlog C-1…C-7); change 6 (gate
+> the breadth) was **deliberately deferred** in favour of documenting the
+> core-vs-extended boundary (C-9 → the C-5 docs PR). The list reads as the
+> as-designed end state rather than a to-do.
 
 1. **One source of truth for geometry.** Pure homography/projective DLT lives in the
    lowest crate (`pg`); `core` re-exports and adds image-domain helpers. Kill the

--- a/docs/architecture/pipeline-maps.md
+++ b/docs/architecture/pipeline-maps.md
@@ -38,7 +38,7 @@ The reference pipeline. Entry: `chess detector.rs::Detector::detect` →
 |---|---|---|---|---|
 | 1 | Prefilter | `chess pipeline/inputs.rs::topological_inputs` | ChESS strength/fit prefilter (§2) | **Local** |
 | 2 | Axis cluster | `chess pipeline/cluster.rs` | Global axis clustering (§3) | **Delegated** → `pg cluster_axes` |
-| 3 | Topological grid | `pg ...::detect_square_oriented2_topological_all` via `pipeline/mod.rs:112` | Delaunay → classify → quads → filter → walk (§4) | **Delegated** → `pg` (`SquareAlgorithm::Topological`, `RecoverySchedule::Off`) |
+| 3 | Topological grid | `pg ...::detect_square_oriented2_topological_all` via `pipeline/mod.rs:112` | Delaunay → classify → quads → filter → walk (§4) | **Delegated** → `pg` (sole grid builder; `RecoverySchedule::Off`) |
 | 4 | Merge + recover | `chess pipeline/recover.rs::recover_topological_components` | Geometric merge (§6) + shared-index merge (§6) + boosters fill (§7) | **Mixed**: `pg merge_components_local` + `pg fill_grid_holes`; merge-by-index + directional scale **local** |
 | 5 | Geometry check | `chess pipeline/geometry_check.rs::run_geometry_check` | Line collinearity + local-H + wrong-label drops + largest-component (§8) | **Delegated** → `pg shared::validate` |
 | 6 | Output | `chess pipeline/output.rs::build_detection` | Normalize + rebase to non-negative (§8) | **Delegated** → `pg LabelledGrid::normalize` |

--- a/docs/development/detection-pipeline.md
+++ b/docs/development/detection-pipeline.md
@@ -26,8 +26,10 @@ been **removed** entirely; what to detect is selected by the `LatticeKind` +
 historical `SeedAndGrow` variant (a self-consistent 4-corner seed plus BFS grow
 with axis-coupled boosters) was retired once the topological builder matched or
 beat it on every shipping path, including ChArUco. The wire string
-`"seed_and_grow"` no longer deserializes; config loaders that previously
-accepted a `graph_build_algorithm` value now ignore it.
+`"seed_and_grow"` no longer deserializes, and the `graph_build_algorithm` key
+itself is now **rejected** — `DetectorParams` is `#[serde(deny_unknown_fields)]`,
+so a config that still carries the removed key fails to parse (see the
+`unknown_key_is_rejected` test). Drop the key from any config that still sets it.
 
 ### Marker-internal corners (formerly the ChArUco concern)
 

--- a/docs/development/detection-pipeline.md
+++ b/docs/development/detection-pipeline.md
@@ -16,17 +16,18 @@ integer labels → shared validate → shared fit. It carries no global cell-siz
 dependency, and the same `(i, j) → corner_idx` map flows to every downstream
 consumer.
 
+**Topological is the sole grid builder, so the request carries no algorithm
+choice.** The historical `projective_grid::SquareAlgorithm` and
 `calib_targets_chessboard::DetectorParams::graph_build_algorithm` (typed
-`GraphBuildAlgorithm`) and `projective_grid::SquareAlgorithm` are now
-**single-variant `#[non_exhaustive]` enums** with only `Topological`. They are
-**retained, not deleted** — reserved config seams so the schema stays stable and
-a future alternative builder can be added without a breaking change. The
+`GraphBuildAlgorithm`) selector enums — first collapsed to single-variant
+`#[non_exhaustive]` reserved seams when seed-and-grow was retired — have since
+been **removed** entirely; what to detect is selected by the `LatticeKind` +
+`Evidence` shape on the `DetectionRequest`, not by an algorithm enum. The
 historical `SeedAndGrow` variant (a self-consistent 4-corner seed plus BFS grow
 with axis-coupled boosters) was retired once the topological builder matched or
 beat it on every shipping path, including ChArUco. The wire string
 `"seed_and_grow"` no longer deserializes; config loaders that previously
-accepted it now resolve any legacy `graph_build_algorithm` value to
-`Topological`.
+accepted a `graph_build_algorithm` value now ignore it.
 
 ### Marker-internal corners (formerly the ChArUco concern)
 


### PR DESCRIPTION
## Summary

Backlog **C-5** as a single docs PR. `projective-grid` is a standalone published library; until now its `pub mod shared` / `pub mod topological` engine modules were framed as a "semver-exempt advanced tier" — a public-API-wearing-a-private-badge hedge. This PR takes **option (a)**: embrace them as a real, documented public **composition API**. It also documents the **core-vs-extended boundary** (the deliberately-skipped C-9), and purges stale `SquareAlgorithm` / `GraphBuildAlgorithm` doc debris.

**Docs-only.** No public API surface change — no `pub`→`pub(crate)` churn, no feature flags. Framing + a stale-reference purge.

## What changed

### 1. Advanced tier reframed as a composition API (`lib.rs`, `docs/DESIGN.md`)
- Replaces the apologetic "semver-exempt pre-1.0" framing with a clear, intentional **two-tier** statement:
  - **Stable facade tier** — `detect_grid` / `detect_grid_all`, `DetectionParams`, `DetectionRequest`, the result/evidence/lattice types — carries normal semver.
  - **Advanced composition tier** — `shared`, `topological`, `lattice`, `orient`, `cluster` — framed as *"advanced, may evolve"*: a deliberate product trade (slower-moving contract in exchange for direct engine access), not a "really private" disclaimer.
- Writes down the **composition contract**, verified against source: a consumer supplies a `shared::grow::SquareAttachPolicy` (`is_eligible` / `required_label_at` / `accept_candidate` / `edge_ok`), drives the growth + recovery primitives (`grow` / `fill` / `extension` / `grow_extend` / `recovery_schedule::RecoverySchedule` + `RecoveryParams`), and composes the lattice-parameterised back-half (`merge` / `validate` / fit) — with the **drop-only zero-wrong-labels guarantee** carried over.

### 2. Core-vs-extended boundary made explicit (the C-9 replacement)
- A greppable section + table separating the exercised **CORE** path — square lattice + `Evidence::Oriented2`, what every in-workspace detector runs — from the **EXTENDED** library-only breadth: hex (`Hex`, `topological::hex*`, `D6_TRANSFORMS`) and orientation-free / single-axis synthesis (`orient::*`, `shared::recovery_schedule`, `positions_policy`). The breadth is intended external product, exercised only by `projective-grid`'s own tests today.
- Documents **why C-9 was deferred**: unmeasured compile/binary benefit against a real semver break on a published crate; the boundary is documented instead.

### 3. Stale `SquareAlgorithm` / `AlgorithmReq` purge
These types were removed from code in C-4. Every doc hit that still described them as a *live* type/API is rewritten to the current model (Topological is the sole grid builder; selection is `LatticeKind` + `Evidence`, not an algorithm enum): `book/src/{projective_grid,example_regular_grid,algo_topological_grid,chessboard}.md`, `docs/architecture/pipeline-maps.md`, `docs/development/detection-pipeline.md`. The **historical CHANGELOG** entries describing the removal are left intact.

### 4. Architecture status
`docs/architecture/chore-backlog.md` (header + table + per-item: C-1…C-8 DONE, C-5 this PR, C-9 deferred with rationale) and the resolved findings in `docs/architecture/critique.md`.

## Verification
- `cargo doc --workspace --no-deps` — **0 warnings** (fixed two redundant-explicit-link-target warnings at source)
- `cargo test -p projective-grid --doc` — green (0 doctests)
- `cargo clippy --workspace --all-targets -- -D warnings` — green
- `mdbook build book` — green, no broken links

## Notes
- No private-dataset specifics anywhere.
- C-6 marked DONE but with a corrected framing: the two `build_corner_map` functions stayed separate by design; the real shared logic (the complete-square-cell enumeration) was extracted into `calib-targets-core::corner_map`.
- No item in the advanced tier looks genuinely internal-leaking: `shared::grow::SquareAttachPolicy` and the growth/recovery/merge/validate primitives are a coherent, composable surface; `shared::fit` is already `pub(crate)` (correctly), so the advanced surface is no wider than what a consumer composes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)