### PR TITLE
Add synthetic PuzzleBoard photo fixtures

### DIFF
--- a/crates/calib-targets-print/src/model/puzzleboard.rs
+++ b/crates/calib-targets-print/src/model/puzzleboard.rs
@@ -15,7 +15,7 @@ pub(super) fn default_puzzleboard_dot_diameter_rel() -> f64 {
 ///
 /// A PuzzleBoard is a standard checkerboard of `rows × cols` squares with a
 /// small colour-coded dot at every interior edge midpoint. The dots encode
-/// one bit each (white = 0, black = 1) via the two cyclic sub-perfect maps
+/// one bit each (black = 0, white = 1) via the two cyclic sub-perfect maps
 /// shipped in `calib-targets-puzzleboard`. The printable board is a
 /// contiguous sub-rectangle of the 501×501 master pattern anchored at
 /// `(origin_row, origin_col)`.

--- a/crates/calib-targets-puzzleboard/docs/SYNTHETIC_AUTHOR_LIKE.md
+++ b/crates/calib-targets-puzzleboard/docs/SYNTHETIC_AUTHOR_LIKE.md
@@ -1,0 +1,70 @@
+# Synthetic Author-Like PuzzleBoard Fixtures
+
+This fixture set tests PuzzleBoard decoding on realistic photo-like images
+whose ground truth is unambiguous. The upstream author examples are useful for
+visual comparison, but the image bit pattern does not match the current
+canonical 501 x 501 map exactly. These synthetic images are generated directly
+from the committed `map_a.bin` and `map_b.bin` files, so successful detection
+proves the detector can match the current canonical map under similar visual
+conditions.
+
+## Fixture Generation
+
+Generate the images and manifest with:
+
+```bash
+uv venv .venv-synth
+uv pip install --python .venv-synth/bin/python opencv-python-headless numpy
+.venv-synth/bin/python crates/calib-targets-puzzleboard/tools/synth_puzzleboard_photo.py \
+  --preview-dir report/puzzleboard_synthetic_author_like
+```
+
+The generator is deterministic. Each scenario records its seed, board size,
+master origin, perspective quad, radial distortion, blur, noise, illumination,
+and every ground-truth corner coordinate in:
+
+```text
+testdata/puzzleboard_synthetic_author_like/manifest.json
+```
+
+Default generated scenarios:
+
+| Scenario | Board | Origin | Purpose |
+| --- | ---: | ---: | --- |
+| `author_like_oblique` | 20 x 20 | `(18, 219)` | Broad author-style partial view |
+| `author_like_foreshortened` | 20 x 20 | `(30, 8)` | Strong perspective and mild distortion |
+| `small_rotated_fragment` | 9 x 9 | `(453, 376)` | Small rotated patch near the decode-size boundary |
+
+## Validation
+
+Run:
+
+```bash
+CARGO_TARGET_DIR=/tmp/calib-targets-target \
+cargo test -p calib-targets-puzzleboard --test synthetic_author_like -- --nocapture
+```
+
+To write visual overlays:
+
+```bash
+CALIB_PUZZLE_SYNTHETIC_OVERLAY_DIR="$PWD/report/puzzleboard_synthetic_author_like" \
+CARGO_TARGET_DIR=/tmp/calib-targets-target \
+cargo test -p calib-targets-puzzleboard --test synthetic_author_like -- --nocapture
+```
+
+Overlay legend:
+
+- red rings: synthetic ground-truth corners;
+- green dots: detected PuzzleBoard-labelled corners.
+
+Current `origin/main`-based results after adding the fixtures:
+
+| Scenario | Decoded Corners | Truth-Matched Corners | BER | D4 Relation |
+| --- | ---: | ---: | ---: | --- |
+| `author_like_oblique` | 361 | 361 | 0.000 | identity |
+| `author_like_foreshortened` | 348 | 348 | 0.000 | identity |
+| `small_rotated_fragment` | 64 | 64 | 0.000 | identity |
+
+The regression accepts any single D4 + translation relation between detected
+master IDs and ground truth, but the current generated fixtures decode as the
+identity relation.

--- a/crates/calib-targets-puzzleboard/tests/synthetic_author_like.rs
+++ b/crates/calib-targets-puzzleboard/tests/synthetic_author_like.rs
@@ -1,0 +1,237 @@
+//! Synthetic author-like PuzzleBoard photo regression.
+//!
+//! The images under `testdata/puzzleboard_synthetic_author_like/` are
+//! deterministic renders from the committed 501×501 PuzzleBoard maps, then
+//! warped through perspective, radial distortion, blur, noise, vignetting, and
+//! JPEG-like compression. Unlike the upstream example photos, these fixtures
+//! have unambiguous ground-truth master coordinates.
+
+use calib_targets::detect;
+use calib_targets::puzzleboard::PuzzleBoardDetectionResult;
+use calib_targets::puzzleboard::{PuzzleBoardParams, PuzzleBoardSpec};
+use calib_targets_core::GRID_TRANSFORMS_D4;
+use image::{GrayImage, ImageReader, Rgb, RgbImage};
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
+
+const PIXEL_MATCH_TOL: f32 = 4.0;
+const MIN_MATCHED_CORNERS: usize = 24;
+const MAX_BER: f32 = 0.18;
+
+#[derive(Debug, Deserialize)]
+struct Manifest {
+    scenarios: Vec<Scenario>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Scenario {
+    name: String,
+    image: String,
+    rows: u32,
+    cols: u32,
+    origin_row: u32,
+    origin_col: u32,
+    corners: Vec<TruthCorner>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TruthCorner {
+    master_row: i32,
+    master_col: i32,
+    pixel_x: f32,
+    pixel_y: f32,
+}
+
+fn fixture_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("testdata")
+        .join("puzzleboard_synthetic_author_like")
+}
+
+fn load_manifest(dir: &Path) -> Manifest {
+    let text = std::fs::read_to_string(dir.join("manifest.json")).expect("read manifest");
+    serde_json::from_str(&text).expect("parse manifest")
+}
+
+fn d4_consistent(pairs: &[(i32, i32, i32, i32)]) -> Option<(usize, i32, i32)> {
+    for (idx, t) in GRID_TRANSFORMS_D4.iter().enumerate() {
+        let deltas: Vec<(i32, i32)> = pairs
+            .iter()
+            .map(|&(our_row, our_col, truth_row, truth_col)| {
+                let mapped_row = t.a * our_row + t.b * our_col;
+                let mapped_col = t.c * our_row + t.d * our_col;
+                (
+                    (truth_row - mapped_row).rem_euclid(501),
+                    (truth_col - mapped_col).rem_euclid(501),
+                )
+            })
+            .collect();
+        if deltas.iter().all(|d| *d == deltas[0]) {
+            return Some((idx, deltas[0].0, deltas[0].1));
+        }
+    }
+    None
+}
+
+fn draw_disc(img: &mut RgbImage, x: f32, y: f32, radius: i32, color: Rgb<u8>) {
+    let cx = x.round() as i32;
+    let cy = y.round() as i32;
+    let r2 = radius * radius;
+    for yy in (cy - radius)..=(cy + radius) {
+        for xx in (cx - radius)..=(cx + radius) {
+            let dx = xx - cx;
+            let dy = yy - cy;
+            if dx * dx + dy * dy <= r2
+                && xx >= 0
+                && yy >= 0
+                && (xx as u32) < img.width()
+                && (yy as u32) < img.height()
+            {
+                img.put_pixel(xx as u32, yy as u32, color);
+            }
+        }
+    }
+}
+
+fn draw_ring(img: &mut RgbImage, x: f32, y: f32, radius: i32, color: Rgb<u8>) {
+    let cx = x.round() as i32;
+    let cy = y.round() as i32;
+    let inner = (radius - 2).max(1);
+    let outer2 = radius * radius;
+    let inner2 = inner * inner;
+    for yy in (cy - radius)..=(cy + radius) {
+        for xx in (cx - radius)..=(cx + radius) {
+            let dx = xx - cx;
+            let dy = yy - cy;
+            let d2 = dx * dx + dy * dy;
+            if d2 <= outer2
+                && d2 >= inner2
+                && xx >= 0
+                && yy >= 0
+                && (xx as u32) < img.width()
+                && (yy as u32) < img.height()
+            {
+                img.put_pixel(xx as u32, yy as u32, color);
+            }
+        }
+    }
+}
+
+fn write_overlay(
+    out_dir: &Path,
+    scenario: &Scenario,
+    image: &GrayImage,
+    result: &PuzzleBoardDetectionResult,
+) {
+    std::fs::create_dir_all(out_dir).expect("create overlay dir");
+    let mut rgb = RgbImage::from_fn(image.width(), image.height(), |x, y| {
+        let v = image.get_pixel(x, y).0[0];
+        Rgb([v, v, v])
+    });
+
+    // Red = generated ground-truth corner locations.
+    for truth in &scenario.corners {
+        draw_ring(&mut rgb, truth.pixel_x, truth.pixel_y, 4, Rgb([255, 0, 0]));
+    }
+    // Green = detected PuzzleBoard-labelled corners.
+    for corner in &result.corners {
+        draw_disc(
+            &mut rgb,
+            corner.position.x,
+            corner.position.y,
+            2,
+            Rgb([0, 230, 0]),
+        );
+    }
+    rgb.save(out_dir.join(format!("{}_detected_vs_truth.png", scenario.name)))
+        .expect("save overlay");
+}
+
+#[test]
+fn synthetic_author_like_photos_decode_against_canonical_map() {
+    let dir = fixture_dir();
+    let manifest = load_manifest(&dir);
+    let overlay_dir = std::env::var_os("CALIB_PUZZLE_SYNTHETIC_OVERLAY_DIR").map(PathBuf::from);
+    for scenario in &manifest.scenarios {
+        let img = ImageReader::open(dir.join(&scenario.image))
+            .expect("open fixture image")
+            .decode()
+            .expect("decode fixture image")
+            .to_luma8();
+
+        let board = PuzzleBoardSpec::with_origin(
+            scenario.rows,
+            scenario.cols,
+            5.0,
+            scenario.origin_row,
+            scenario.origin_col,
+        )
+        .expect("board spec");
+        let sweep = PuzzleBoardParams::sweep_for_board(&board);
+        let result = detect::detect_puzzleboard_best(&img, &sweep)
+            .unwrap_or_else(|err| panic!("{} failed to decode: {err}", scenario.name));
+        if let Some(out_dir) = overlay_dir.as_deref() {
+            write_overlay(out_dir, scenario, &img, &result);
+        }
+
+        assert!(
+            result.decode.bit_error_rate <= MAX_BER,
+            "{} BER {:.3} exceeds {:.3}; matched {}/{} edges",
+            scenario.name,
+            result.decode.bit_error_rate,
+            MAX_BER,
+            result.decode.edges_matched,
+            result.decode.edges_observed
+        );
+
+        let mut pairs = Vec::new();
+        for detected in &result.corners {
+            let mut best: Option<(&TruthCorner, f32)> = None;
+            for truth in &scenario.corners {
+                let dx = detected.position.x - truth.pixel_x;
+                let dy = detected.position.y - truth.pixel_y;
+                let dist = (dx * dx + dy * dy).sqrt();
+                if best.is_none_or(|(_, best_dist)| dist < best_dist) {
+                    best = Some((truth, dist));
+                }
+            }
+            let Some((truth, dist)) = best else {
+                continue;
+            };
+            if dist <= PIXEL_MATCH_TOL {
+                pairs.push((
+                    detected.grid.v,
+                    detected.grid.u,
+                    truth.master_row,
+                    truth.master_col,
+                ));
+            }
+        }
+
+        assert!(
+            pairs.len() >= MIN_MATCHED_CORNERS,
+            "{} matched only {} detected corners to truth within {PIXEL_MATCH_TOL}px",
+            scenario.name,
+            pairs.len()
+        );
+
+        let relation = d4_consistent(&pairs);
+        assert!(
+            relation.is_some(),
+            "{} detected master IDs are not explainable by one D4+translation relation over {} matched corners",
+            scenario.name,
+            pairs.len()
+        );
+
+        println!(
+            "{}: decoded {} corners, matched {} to truth, BER={:.3}, D4+offset={:?}",
+            scenario.name,
+            result.corners.len(),
+            pairs.len(),
+            result.decode.bit_error_rate,
+            relation
+        );
+    }
+}

--- a/crates/calib-targets-puzzleboard/tools/synth_puzzleboard_photo.py
+++ b/crates/calib-targets-puzzleboard/tools/synth_puzzleboard_photo.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""Generate deterministic author-like PuzzleBoard photo fixtures.
+
+The generator intentionally uses the same physical convention as
+`calib-targets-print`:
+
+- black checker square iff `(master_row + master_col) % 2 == 0`;
+- horizontal edge dots are between square rows and use `map_b`;
+- vertical edge dots are between square columns and use `map_a`;
+- dot polarity is black = 0, white = 1.
+
+It renders a clean board texture, projects it through a perspective camera,
+adds radial distortion and mild camera artefacts, and writes both images and a
+JSON manifest with exact corner ground truth.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import cv2
+import numpy as np
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MAP_DIR = REPO_ROOT / "crates/calib-targets-puzzleboard/src/data"
+DEFAULT_OUT = REPO_ROOT / "testdata/puzzleboard_synthetic_author_like"
+
+
+@dataclass(frozen=True)
+class Scenario:
+    name: str
+    seed: int
+    rows: int
+    cols: int
+    origin_row: int
+    origin_col: int
+    texture_px_per_square: int
+    image_width: int
+    image_height: int
+    quad: tuple[tuple[float, float], tuple[float, float], tuple[float, float], tuple[float, float]]
+    k1: float
+    k2: float
+    blur_sigma: float
+    noise_sigma: float
+    vignette: float
+    brightness: float
+    contrast: float
+    jpeg_quality: int
+
+
+SCENARIOS = [
+    Scenario(
+        name="author_like_oblique",
+        seed=0xC001,
+        rows=20,
+        cols=20,
+        origin_row=18,
+        origin_col=219,
+        texture_px_per_square=52,
+        image_width=640,
+        image_height=480,
+        quad=((36.0, 18.0), (610.0, 40.0), (590.0, 444.0), (18.0, 410.0)),
+        k1=-0.075,
+        k2=0.018,
+        blur_sigma=0.75,
+        noise_sigma=2.2,
+        vignette=0.18,
+        brightness=2.0,
+        contrast=1.00,
+        jpeg_quality=92,
+    ),
+    Scenario(
+        name="author_like_foreshortened",
+        seed=0xC002,
+        rows=20,
+        cols=20,
+        origin_row=30,
+        origin_col=8,
+        texture_px_per_square=54,
+        image_width=640,
+        image_height=480,
+        quad=((128.0, 4.0), (566.0, 32.0), (632.0, 470.0), (24.0, 392.0)),
+        k1=-0.115,
+        k2=0.032,
+        blur_sigma=0.95,
+        noise_sigma=2.8,
+        vignette=0.24,
+        brightness=1.0,
+        contrast=0.96,
+        jpeg_quality=90,
+    ),
+    Scenario(
+        name="small_rotated_fragment",
+        seed=0xC003,
+        rows=9,
+        cols=9,
+        origin_row=453,
+        origin_col=376,
+        texture_px_per_square=72,
+        image_width=640,
+        image_height=480,
+        quad=((186.0, 22.0), (504.0, 84.0), (444.0, 394.0), (112.0, 320.0)),
+        k1=-0.045,
+        k2=0.006,
+        blur_sigma=0.45,
+        noise_sigma=1.4,
+        vignette=0.10,
+        brightness=4.0,
+        contrast=1.03,
+        jpeg_quality=94,
+    ),
+]
+
+
+def unpack_map(path: Path, rows: int, cols: int) -> np.ndarray:
+    data = path.read_bytes()
+    out = np.zeros((rows, cols), dtype=np.uint8)
+    for idx in range(rows * cols):
+        out.flat[idx] = (data[idx // 8] >> (idx % 8)) & 1
+    return out
+
+
+def horizontal_bit(map_b: np.ndarray, row: int, col: int) -> int:
+    return int(map_b[row % 167, col % 3])
+
+
+def vertical_bit(map_a: np.ndarray, row: int, col: int) -> int:
+    return int(map_a[row % 3, col % 167])
+
+
+def render_texture(s: Scenario, map_a: np.ndarray, map_b: np.ndarray) -> np.ndarray:
+    px = s.texture_px_per_square
+    h = s.rows * px
+    w = s.cols * px
+    img = np.full((h, w), 222, dtype=np.uint8)
+    black = 34
+    white = 222
+    dot_black = 18
+    dot_white = 244
+    radius = max(2, round(px / 6.0))
+
+    for r in range(s.rows):
+        y0 = r * px
+        y1 = (r + 1) * px
+        for c in range(s.cols):
+            x0 = c * px
+            x1 = (c + 1) * px
+            master_r = s.origin_row + r
+            master_c = s.origin_col + c
+            img[y0:y1, x0:x1] = black if (master_r + master_c) % 2 == 0 else white
+
+    for r in range(s.rows - 1):
+        for c in range(s.cols):
+            bit = horizontal_bit(map_b, s.origin_row + r, s.origin_col + c)
+            color = dot_white if bit == 1 else dot_black
+            center = (round((c + 0.5) * px), round((r + 1.0) * px))
+            cv2.circle(img, center, radius, color, thickness=-1, lineType=cv2.LINE_AA)
+
+    for r in range(s.rows):
+        for c in range(s.cols - 1):
+            bit = vertical_bit(map_a, s.origin_row + r, s.origin_col + c)
+            color = dot_white if bit == 1 else dot_black
+            center = (round((c + 1.0) * px), round((r + 0.5) * px))
+            cv2.circle(img, center, radius, color, thickness=-1, lineType=cv2.LINE_AA)
+
+    return img
+
+
+def distort_points(points: np.ndarray, width: int, height: int, k1: float, k2: float) -> np.ndarray:
+    cx = 0.5 * (width - 1)
+    cy = 0.5 * (height - 1)
+    fx = max(width, height)
+    fy = fx
+    x = (points[:, 0] - cx) / fx
+    y = (points[:, 1] - cy) / fy
+    r2 = x * x + y * y
+    scale = 1.0 + k1 * r2 + k2 * r2 * r2
+    out = np.empty_like(points, dtype=np.float32)
+    out[:, 0] = cx + fx * x * scale
+    out[:, 1] = cy + fy * y * scale
+    return out
+
+
+def apply_radial_distortion(img: np.ndarray, k1: float, k2: float) -> np.ndarray:
+    height, width = img.shape[:2]
+    cx = 0.5 * (width - 1)
+    cy = 0.5 * (height - 1)
+    fx = max(width, height)
+    fy = fx
+    yy, xx = np.indices((height, width), dtype=np.float32)
+    xd = (xx - cx) / fx
+    yd = (yy - cy) / fy
+    r2d = xd * xd + yd * yd
+    # First-order inverse is sufficient for these mild synthetic distortions.
+    scale = 1.0 + k1 * r2d + k2 * r2d * r2d
+    xu = xd / scale
+    yu = yd / scale
+    map_x = cx + fx * xu
+    map_y = cy + fy * yu
+    return cv2.remap(img, map_x, map_y, interpolation=cv2.INTER_LINEAR, borderValue=182)
+
+
+def apply_camera_effects(img: np.ndarray, s: Scenario) -> np.ndarray:
+    rng = np.random.default_rng(s.seed)
+    out = img.astype(np.float32)
+    h, w = out.shape
+    yy, xx = np.indices((h, w), dtype=np.float32)
+    cx = 0.54 * w
+    cy = 0.47 * h
+    r = np.sqrt(((xx - cx) / w) ** 2 + ((yy - cy) / h) ** 2)
+    illum = 1.0 - s.vignette * (r / max(r.max(), 1e-6)) ** 2
+    illum += 0.035 * ((xx / max(w - 1, 1)) - 0.5)
+    out = (out - 128.0) * s.contrast + 128.0
+    out = out * illum + s.brightness
+    if s.blur_sigma > 0.0:
+        out = cv2.GaussianBlur(out, (0, 0), s.blur_sigma)
+    if s.noise_sigma > 0.0:
+        out += rng.normal(0.0, s.noise_sigma, out.shape).astype(np.float32)
+    out = np.clip(out, 0.0, 255.0).astype(np.uint8)
+    ok, enc = cv2.imencode(".jpg", out, [int(cv2.IMWRITE_JPEG_QUALITY), s.jpeg_quality])
+    if not ok:
+        raise RuntimeError("JPEG compression failed")
+    return cv2.imdecode(enc, cv2.IMREAD_GRAYSCALE)
+
+
+def scenario_image(s: Scenario, map_a: np.ndarray, map_b: np.ndarray) -> tuple[np.ndarray, list[dict[str, Any]]]:
+    tex = render_texture(s, map_a, map_b)
+    src = np.array(
+        [[0.0, 0.0], [tex.shape[1] - 1.0, 0.0], [tex.shape[1] - 1.0, tex.shape[0] - 1.0], [0.0, tex.shape[0] - 1.0]],
+        dtype=np.float32,
+    )
+    dst = np.array(s.quad, dtype=np.float32)
+    h_mat = cv2.getPerspectiveTransform(src, dst)
+    warped = cv2.warpPerspective(
+        tex,
+        h_mat,
+        (s.image_width, s.image_height),
+        flags=cv2.INTER_LINEAR,
+        borderMode=cv2.BORDER_CONSTANT,
+        borderValue=182,
+    )
+    distorted = apply_radial_distortion(warped, s.k1, s.k2)
+    photo = apply_camera_effects(distorted, s)
+
+    local = []
+    for r in range(s.rows + 1):
+        for c in range(s.cols + 1):
+            local.append([c * s.texture_px_per_square, r * s.texture_px_per_square])
+    local_np = np.asarray(local, dtype=np.float32).reshape(-1, 1, 2)
+    projected = cv2.perspectiveTransform(local_np, h_mat).reshape(-1, 2)
+    projected = distort_points(projected, s.image_width, s.image_height, s.k1, s.k2)
+    corners = []
+    idx = 0
+    for r in range(s.rows + 1):
+        for c in range(s.cols + 1):
+            x, y = projected[idx]
+            corners.append(
+                {
+                    "local_row": r,
+                    "local_col": c,
+                    "master_row": s.origin_row + r,
+                    "master_col": s.origin_col + c,
+                    "pixel_x": float(x),
+                    "pixel_y": float(y),
+                }
+            )
+            idx += 1
+    return photo, corners
+
+
+def write_overlay(img: np.ndarray, corners: list[dict[str, Any]], path: Path) -> None:
+    color = cv2.cvtColor(img, cv2.COLOR_GRAY2BGR)
+    for corner in corners:
+        x = int(round(corner["pixel_x"]))
+        y = int(round(corner["pixel_y"]))
+        if 0 <= x < color.shape[1] and 0 <= y < color.shape[0]:
+            cv2.circle(color, (x, y), 2, (0, 0, 255), thickness=-1, lineType=cv2.LINE_AA)
+    cv2.imwrite(str(path), color)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT)
+    parser.add_argument("--preview-dir", type=Path)
+    args = parser.parse_args()
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    if args.preview_dir:
+        args.preview_dir.mkdir(parents=True, exist_ok=True)
+
+    map_a = unpack_map(MAP_DIR / "map_a.bin", 3, 167)
+    map_b = unpack_map(MAP_DIR / "map_b.bin", 167, 3)
+
+    manifest: dict[str, Any] = {
+        "schema": "calib-targets-puzzleboard.synthetic-author-like.v1",
+        "generator": "crates/calib-targets-puzzleboard/tools/synth_puzzleboard_photo.py",
+        "map_source": "crates/calib-targets-puzzleboard/src/data/map_a.bin + map_b.bin",
+        "pixel_frame": "image pixels, origin top-left, x right, y down; pixel centers at integer coordinates",
+        "scenarios": [],
+    }
+    for s in SCENARIOS:
+        img, corners = scenario_image(s, map_a, map_b)
+        image_name = f"{s.name}.png"
+        cv2.imwrite(str(args.out_dir / image_name), img)
+        if args.preview_dir:
+            write_overlay(img, corners, args.preview_dir / f"{s.name}_truth_corners.png")
+        entry = asdict(s)
+        entry["image"] = image_name
+        entry["corners"] = corners
+        manifest["scenarios"].append(entry)
+
+    (args.out_dir / "manifest.json").write_text(json.dumps(manifest, indent=2) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/testdata/puzzleboard_synthetic_author_like/author_like_foreshortened.png
+++ b/testdata/puzzleboard_synthetic_author_like/author_like_foreshortened.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:37148362fc791e6a4f340108e6e50e150e02d5d12bccd54fa547ce78652f20a8
+size 197673

--- a/testdata/puzzleboard_synthetic_author_like/author_like_oblique.png
+++ b/testdata/puzzleboard_synthetic_author_like/author_like_oblique.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f48785107f6e8cfa169f95a5d8da5bc5f50e571b0138956bb1cfd7d18eadcb2d
+size 191102

--- a/testdata/puzzleboard_synthetic_author_like/manifest.json
+++ b/testdata/puzzleboard_synthetic_author_like/manifest.json
@@ -1,0 +1,7984 @@
+{
+  "schema": "calib-targets-puzzleboard.synthetic-author-like.v1",
+  "generator": "crates/calib-targets-puzzleboard/tools/synth_puzzleboard_photo.py",
+  "map_source": "crates/calib-targets-puzzleboard/src/data/map_a.bin + map_b.bin",
+  "pixel_frame": "image pixels, origin top-left, x right, y down; pixel centers at integer coordinates",
+  "scenarios": [
+    {
+      "name": "author_like_oblique",
+      "seed": 49153,
+      "rows": 20,
+      "cols": 20,
+      "origin_row": 18,
+      "origin_col": 219,
+      "texture_px_per_square": 52,
+      "image_width": 640,
+      "image_height": 480,
+      "quad": [
+        [
+          36.0,
+          18.0
+        ],
+        [
+          610.0,
+          40.0
+        ],
+        [
+          590.0,
+          444.0
+        ],
+        [
+          18.0,
+          410.0
+        ]
+      ],
+      "k1": -0.075,
+      "k2": 0.018,
+      "blur_sigma": 0.75,
+      "noise_sigma": 2.2,
+      "vignette": 0.18,
+      "brightness": 2.0,
+      "contrast": 1.0,
+      "jpeg_quality": 92,
+      "image": "author_like_oblique.png",
+      "corners": [
+        {
+          "local_row": 0,
+          "local_col": 0,
+          "master_row": 18,
+          "master_col": 219,
+          "pixel_x": 42.20941162109375,
+          "pixel_y": 22.851455688476562
+        },
+        {
+          "local_row": 0,
+          "local_col": 1,
+          "master_row": 18,
+          "master_col": 220,
+          "pixel_x": 68.88558959960938,
+          "pixel_y": 23.360702514648438
+        },
+        {
+          "local_row": 0,
+          "local_col": 2,
+          "master_row": 18,
+          "master_col": 221,
+          "pixel_x": 95.82437133789062,
+          "pixel_y": 23.92095947265625
+        },
+        {
+          "local_row": 0,
+          "local_col": 3,
+          "master_row": 18,
+          "master_col": 222,
+          "pixel_x": 123.01356506347656,
+          "pixel_y": 24.535125732421875
+        },
+        {
+          "local_row": 0,
+          "local_col": 4,
+          "master_row": 18,
+          "master_col": 223,
+          "pixel_x": 150.43887329101562,
+          "pixel_y": 25.20574951171875
+        },
+        {
+          "local_row": 0,
+          "local_col": 5,
+          "master_row": 18,
+          "master_col": 224,
+          "pixel_x": 178.0840301513672,
+          "pixel_y": 25.935012817382812
+        },
+        {
+          "local_row": 0,
+          "local_col": 6,
+          "master_row": 18,
+          "master_col": 225,
+          "pixel_x": 205.93093872070312,
+          "pixel_y": 26.724716186523438
+        },
+        {
+          "local_row": 0,
+          "local_col": 7,
+          "master_row": 18,
+          "master_col": 226,
+          "pixel_x": 233.9599609375,
+          "pixel_y": 27.576248168945312
+        },
+        {
+          "local_row": 0,
+          "local_col": 8,
+          "master_row": 18,
+          "master_col": 227,
+          "pixel_x": 262.15008544921875,
+          "pixel_y": 28.49072265625
+        },
+        {
+          "local_row": 0,
+          "local_col": 9,
+          "master_row": 18,
+          "master_col": 228,
+          "pixel_x": 290.4790344238281,
+          "pixel_y": 29.468795776367188
+        },
+        {
+          "local_row": 0,
+          "local_col": 10,
+          "master_row": 18,
+          "master_col": 229,
+          "pixel_x": 318.92364501953125,
+          "pixel_y": 30.510772705078125
+        },
+        {
+          "local_row": 0,
+          "local_col": 11,
+          "master_row": 18,
+          "master_col": 230,
+          "pixel_x": 347.4599304199219,
+          "pixel_y": 31.616607666015625
+        },
+        {
+          "local_row": 0,
+          "local_col": 12,
+          "master_row": 18,
+          "master_col": 231,
+          "pixel_x": 376.06341552734375,
+          "pixel_y": 32.78578186035156
+        },
+        {
+          "local_row": 0,
+          "local_col": 13,
+          "master_row": 18,
+          "master_col": 232,
+          "pixel_x": 404.70941162109375,
+          "pixel_y": 34.01750183105469
+        },
+        {
+          "local_row": 0,
+          "local_col": 14,
+          "master_row": 18,
+          "master_col": 233,
+          "pixel_x": 433.37322998046875,
+          "pixel_y": 35.31050109863281
+        },
+        {
+          "local_row": 0,
+          "local_col": 15,
+          "master_row": 18,
+          "master_col": 234,
+          "pixel_x": 462.0303955078125,
+          "pixel_y": 36.66319274902344
+        },
+        {
+          "local_row": 0,
+          "local_col": 16,
+          "master_row": 18,
+          "master_col": 235,
+          "pixel_x": 490.65704345703125,
+          "pixel_y": 38.07353210449219
+        },
+        {
+          "local_row": 0,
+          "local_col": 17,
+          "master_row": 18,
+          "master_col": 236,
+          "pixel_x": 519.2301025390625,
+          "pixel_y": 39.53916931152344
+        },
+        {
+          "local_row": 0,
+          "local_col": 18,
+          "master_row": 18,
+          "master_col": 237,
+          "pixel_x": 547.727783203125,
+          "pixel_y": 41.05729675292969
+        },
+        {
+          "local_row": 0,
+          "local_col": 19,
+          "master_row": 18,
+          "master_col": 238,
+          "pixel_x": 576.1298217773438,
+          "pixel_y": 42.62474060058594
+        },
+        {
+          "local_row": 0,
+          "local_col": 20,
+          "master_row": 18,
+          "master_col": 239,
+          "pixel_x": 604.4176025390625,
+          "pixel_y": 44.23793029785156
+        },
+        {
+          "local_row": 1,
+          "local_col": 0,
+          "master_row": 19,
+          "master_col": 219,
+          "pixel_x": 40.979278564453125,
+          "pixel_y": 41.83905029296875
+        },
+        {
+          "local_row": 1,
+          "local_col": 1,
+          "master_row": 19,
+          "master_col": 220,
+          "pixel_x": 67.6751708984375,
+          "pixel_y": 42.42051696777344
+        },
+        {
+          "local_row": 1,
+          "local_col": 2,
+          "master_row": 19,
+          "master_col": 221,
+          "pixel_x": 94.6361083984375,
+          "pixel_y": 43.049957275390625
+        },
+        {
+          "local_row": 1,
+          "local_col": 3,
+          "master_row": 19,
+          "master_col": 222,
+          "pixel_x": 121.84967041015625,
+          "pixel_y": 43.729888916015625
+        },
+        {
+          "local_row": 1,
+          "local_col": 4,
+          "master_row": 19,
+          "master_col": 223,
+          "pixel_x": 149.30140686035156,
+          "pixel_y": 44.46258544921875
+        },
+        {
+          "local_row": 1,
+          "local_col": 5,
+          "master_row": 19,
+          "master_col": 224,
+          "pixel_x": 176.97483825683594,
+          "pixel_y": 45.24992370605469
+        },
+        {
+          "local_row": 1,
+          "local_col": 6,
+          "master_row": 19,
+          "master_col": 225,
+          "pixel_x": 204.85171508789062,
+          "pixel_y": 46.09346008300781
+        },
+        {
+          "local_row": 1,
+          "local_col": 7,
+          "master_row": 19,
+          "master_col": 226,
+          "pixel_x": 232.91220092773438,
+          "pixel_y": 46.99436950683594
+        },
+        {
+          "local_row": 1,
+          "local_col": 8,
+          "master_row": 19,
+          "master_col": 227,
+          "pixel_x": 261.1350402832031,
+          "pixel_y": 47.95353698730469
+        },
+        {
+          "local_row": 1,
+          "local_col": 9,
+          "master_row": 19,
+          "master_col": 228,
+          "pixel_x": 289.4978332519531,
+          "pixel_y": 48.97145080566406
+        },
+        {
+          "local_row": 1,
+          "local_col": 10,
+          "master_row": 19,
+          "master_col": 229,
+          "pixel_x": 317.97711181640625,
+          "pixel_y": 50.04833984375
+        },
+        {
+          "local_row": 1,
+          "local_col": 11,
+          "master_row": 19,
+          "master_col": 230,
+          "pixel_x": 346.5487365722656,
+          "pixel_y": 51.1839599609375
+        },
+        {
+          "local_row": 1,
+          "local_col": 12,
+          "master_row": 19,
+          "master_col": 231,
+          "pixel_x": 375.18798828125,
+          "pixel_y": 52.377777099609375
+        },
+        {
+          "local_row": 1,
+          "local_col": 13,
+          "master_row": 19,
+          "master_col": 232,
+          "pixel_x": 403.8699035644531,
+          "pixel_y": 53.62895202636719
+        },
+        {
+          "local_row": 1,
+          "local_col": 14,
+          "master_row": 19,
+          "master_col": 233,
+          "pixel_x": 432.5695495605469,
+          "pixel_y": 54.93620300292969
+        },
+        {
+          "local_row": 1,
+          "local_col": 15,
+          "master_row": 19,
+          "master_col": 234,
+          "pixel_x": 461.26220703125,
+          "pixel_y": 56.29798889160156
+        },
+        {
+          "local_row": 1,
+          "local_col": 16,
+          "master_row": 19,
+          "master_col": 235,
+          "pixel_x": 489.9237365722656,
+          "pixel_y": 57.71241760253906
+        },
+        {
+          "local_row": 1,
+          "local_col": 17,
+          "master_row": 19,
+          "master_col": 236,
+          "pixel_x": 518.5308837890625,
+          "pixel_y": 59.17713928222656
+        },
+        {
+          "local_row": 1,
+          "local_col": 18,
+          "master_row": 19,
+          "master_col": 237,
+          "pixel_x": 547.0614013671875,
+          "pixel_y": 60.6895751953125
+        },
+        {
+          "local_row": 1,
+          "local_col": 19,
+          "master_row": 19,
+          "master_col": 238,
+          "pixel_x": 575.4947509765625,
+          "pixel_y": 62.246734619140625
+        },
+        {
+          "local_row": 1,
+          "local_col": 20,
+          "master_row": 19,
+          "master_col": 239,
+          "pixel_x": 603.81201171875,
+          "pixel_y": 63.8453369140625
+        },
+        {
+          "local_row": 2,
+          "local_col": 0,
+          "master_row": 20,
+          "master_col": 219,
+          "pixel_x": 39.778564453125,
+          "pixel_y": 60.88995361328125
+        },
+        {
+          "local_row": 2,
+          "local_col": 1,
+          "master_row": 20,
+          "master_col": 220,
+          "pixel_x": 66.4918212890625,
+          "pixel_y": 61.54524230957031
+        },
+        {
+          "local_row": 2,
+          "local_col": 2,
+          "master_row": 20,
+          "master_col": 221,
+          "pixel_x": 93.47227478027344,
+          "pixel_y": 62.24528503417969
+        },
+        {
+          "local_row": 2,
+          "local_col": 3,
+          "master_row": 20,
+          "master_col": 222,
+          "pixel_x": 120.7073974609375,
+          "pixel_y": 62.9923095703125
+        },
+        {
+          "local_row": 2,
+          "local_col": 4,
+          "master_row": 20,
+          "master_col": 223,
+          "pixel_x": 148.1825714111328,
+          "pixel_y": 63.788238525390625
+        },
+        {
+          "local_row": 2,
+          "local_col": 5,
+          "master_row": 20,
+          "master_col": 224,
+          "pixel_x": 175.881103515625,
+          "pixel_y": 64.63467407226562
+        },
+        {
+          "local_row": 2,
+          "local_col": 6,
+          "master_row": 20,
+          "master_col": 225,
+          "pixel_x": 203.78463745117188,
+          "pixel_y": 65.53288269042969
+        },
+        {
+          "local_row": 2,
+          "local_col": 7,
+          "master_row": 20,
+          "master_col": 226,
+          "pixel_x": 231.87313842773438,
+          "pixel_y": 66.48388671875
+        },
+        {
+          "local_row": 2,
+          "local_col": 8,
+          "master_row": 20,
+          "master_col": 227,
+          "pixel_x": 260.12518310546875,
+          "pixel_y": 67.48831176757812
+        },
+        {
+          "local_row": 2,
+          "local_col": 9,
+          "master_row": 20,
+          "master_col": 228,
+          "pixel_x": 288.5181884765625,
+          "pixel_y": 68.54652404785156
+        },
+        {
+          "local_row": 2,
+          "local_col": 10,
+          "master_row": 20,
+          "master_col": 229,
+          "pixel_x": 317.0284729003906,
+          "pixel_y": 69.65855407714844
+        },
+        {
+          "local_row": 2,
+          "local_col": 11,
+          "master_row": 20,
+          "master_col": 230,
+          "pixel_x": 345.6317443847656,
+          "pixel_y": 70.82406616210938
+        },
+        {
+          "local_row": 2,
+          "local_col": 12,
+          "master_row": 20,
+          "master_col": 231,
+          "pixel_x": 374.30303955078125,
+          "pixel_y": 72.04248046875
+        },
+        {
+          "local_row": 2,
+          "local_col": 13,
+          "master_row": 20,
+          "master_col": 232,
+          "pixel_x": 403.0171813964844,
+          "pixel_y": 73.31288146972656
+        },
+        {
+          "local_row": 2,
+          "local_col": 14,
+          "master_row": 20,
+          "master_col": 233,
+          "pixel_x": 431.7490234375,
+          "pixel_y": 74.63406372070312
+        },
+        {
+          "local_row": 2,
+          "local_col": 15,
+          "master_row": 20,
+          "master_col": 234,
+          "pixel_x": 460.4736022949219,
+          "pixel_y": 76.00444030761719
+        },
+        {
+          "local_row": 2,
+          "local_col": 16,
+          "master_row": 20,
+          "master_col": 235,
+          "pixel_x": 489.16656494140625,
+          "pixel_y": 77.42216491699219
+        },
+        {
+          "local_row": 2,
+          "local_col": 17,
+          "master_row": 20,
+          "master_col": 236,
+          "pixel_x": 517.8043212890625,
+          "pixel_y": 78.8851318359375
+        },
+        {
+          "local_row": 2,
+          "local_col": 18,
+          "master_row": 20,
+          "master_col": 237,
+          "pixel_x": 546.364501953125,
+          "pixel_y": 80.39080810546875
+        },
+        {
+          "local_row": 2,
+          "local_col": 19,
+          "master_row": 20,
+          "master_col": 238,
+          "pixel_x": 574.826171875,
+          "pixel_y": 81.93643188476562
+        },
+        {
+          "local_row": 2,
+          "local_col": 20,
+          "master_row": 20,
+          "master_col": 239,
+          "pixel_x": 603.1702880859375,
+          "pixel_y": 83.51899719238281
+        },
+        {
+          "local_row": 3,
+          "local_col": 0,
+          "master_row": 21,
+          "master_col": 219,
+          "pixel_x": 38.6085205078125,
+          "pixel_y": 79.99818420410156
+        },
+        {
+          "local_row": 3,
+          "local_col": 1,
+          "master_row": 21,
+          "master_col": 220,
+          "pixel_x": 65.33670043945312,
+          "pixel_y": 80.72869873046875
+        },
+        {
+          "local_row": 3,
+          "local_col": 2,
+          "master_row": 21,
+          "master_col": 221,
+          "pixel_x": 92.33399963378906,
+          "pixel_y": 81.50064086914062
+        },
+        {
+          "local_row": 3,
+          "local_col": 3,
+          "master_row": 21,
+          "master_col": 222,
+          "pixel_x": 119.58778381347656,
+          "pixel_y": 82.31590270996094
+        },
+        {
+          "local_row": 3,
+          "local_col": 4,
+          "master_row": 21,
+          "master_col": 223,
+          "pixel_x": 147.08326721191406,
+          "pixel_y": 83.17607116699219
+        },
+        {
+          "local_row": 3,
+          "local_col": 5,
+          "master_row": 21,
+          "master_col": 224,
+          "pixel_x": 174.8036651611328,
+          "pixel_y": 84.08248901367188
+        },
+        {
+          "local_row": 3,
+          "local_col": 6,
+          "master_row": 21,
+          "master_col": 225,
+          "pixel_x": 202.73045349121094,
+          "pixel_y": 85.03617858886719
+        },
+        {
+          "local_row": 3,
+          "local_col": 7,
+          "master_row": 21,
+          "master_col": 226,
+          "pixel_x": 230.84347534179688,
+          "pixel_y": 86.03791809082031
+        },
+        {
+          "local_row": 3,
+          "local_col": 8,
+          "master_row": 21,
+          "master_col": 227,
+          "pixel_x": 259.12109375,
+          "pixel_y": 87.08808898925781
+        },
+        {
+          "local_row": 3,
+          "local_col": 9,
+          "master_row": 21,
+          "master_col": 228,
+          "pixel_x": 287.54058837890625,
+          "pixel_y": 88.18693542480469
+        },
+        {
+          "local_row": 3,
+          "local_col": 10,
+          "master_row": 21,
+          "master_col": 229,
+          "pixel_x": 316.0781555175781,
+          "pixel_y": 89.33430480957031
+        },
+        {
+          "local_row": 3,
+          "local_col": 11,
+          "master_row": 21,
+          "master_col": 230,
+          "pixel_x": 344.709228515625,
+          "pixel_y": 90.52980041503906
+        },
+        {
+          "local_row": 3,
+          "local_col": 12,
+          "master_row": 21,
+          "master_col": 231,
+          "pixel_x": 373.40875244140625,
+          "pixel_y": 91.77273559570312
+        },
+        {
+          "local_row": 3,
+          "local_col": 13,
+          "master_row": 21,
+          "master_col": 232,
+          "pixel_x": 402.15130615234375,
+          "pixel_y": 93.06219482421875
+        },
+        {
+          "local_row": 3,
+          "local_col": 14,
+          "master_row": 21,
+          "master_col": 233,
+          "pixel_x": 430.9115905761719,
+          "pixel_y": 94.39689636230469
+        },
+        {
+          "local_row": 3,
+          "local_col": 15,
+          "master_row": 21,
+          "master_col": 234,
+          "pixel_x": 459.6644287109375,
+          "pixel_y": 95.77532958984375
+        },
+        {
+          "local_row": 3,
+          "local_col": 16,
+          "master_row": 21,
+          "master_col": 235,
+          "pixel_x": 488.38519287109375,
+          "pixel_y": 97.19577026367188
+        },
+        {
+          "local_row": 3,
+          "local_col": 17,
+          "master_row": 21,
+          "master_col": 236,
+          "pixel_x": 517.0501098632812,
+          "pixel_y": 98.65608215332031
+        },
+        {
+          "local_row": 3,
+          "local_col": 18,
+          "master_row": 21,
+          "master_col": 237,
+          "pixel_x": 545.63671875,
+          "pixel_y": 100.154052734375
+        },
+        {
+          "local_row": 3,
+          "local_col": 19,
+          "master_row": 21,
+          "master_col": 238,
+          "pixel_x": 574.12353515625,
+          "pixel_y": 101.68707275390625
+        },
+        {
+          "local_row": 3,
+          "local_col": 20,
+          "master_row": 21,
+          "master_col": 239,
+          "pixel_x": 602.491455078125,
+          "pixel_y": 103.25233459472656
+        },
+        {
+          "local_row": 4,
+          "local_col": 0,
+          "master_row": 22,
+          "master_col": 219,
+          "pixel_x": 37.4703369140625,
+          "pixel_y": 99.15753173828125
+        },
+        {
+          "local_row": 4,
+          "local_col": 1,
+          "master_row": 22,
+          "master_col": 220,
+          "pixel_x": 64.21090698242188,
+          "pixel_y": 99.9644775390625
+        },
+        {
+          "local_row": 4,
+          "local_col": 2,
+          "master_row": 22,
+          "master_col": 221,
+          "pixel_x": 91.22230529785156,
+          "pixel_y": 100.80941772460938
+        },
+        {
+          "local_row": 4,
+          "local_col": 3,
+          "master_row": 22,
+          "master_col": 222,
+          "pixel_x": 118.49177551269531,
+          "pixel_y": 101.69387817382812
+        },
+        {
+          "local_row": 4,
+          "local_col": 4,
+          "master_row": 22,
+          "master_col": 223,
+          "pixel_x": 146.00442504882812,
+          "pixel_y": 102.61918640136719
+        },
+        {
+          "local_row": 4,
+          "local_col": 5,
+          "master_row": 22,
+          "master_col": 224,
+          "pixel_x": 173.7433624267578,
+          "pixel_y": 103.58634948730469
+        },
+        {
+          "local_row": 4,
+          "local_col": 6,
+          "master_row": 22,
+          "master_col": 225,
+          "pixel_x": 201.68992614746094,
+          "pixel_y": 104.59616088867188
+        },
+        {
+          "local_row": 4,
+          "local_col": 7,
+          "master_row": 22,
+          "master_col": 226,
+          "pixel_x": 229.8238067626953,
+          "pixel_y": 105.64912414550781
+        },
+        {
+          "local_row": 4,
+          "local_col": 8,
+          "master_row": 22,
+          "master_col": 227,
+          "pixel_x": 258.123291015625,
+          "pixel_y": 106.74549865722656
+        },
+        {
+          "local_row": 4,
+          "local_col": 9,
+          "master_row": 22,
+          "master_col": 228,
+          "pixel_x": 286.56549072265625,
+          "pixel_y": 107.88525390625
+        },
+        {
+          "local_row": 4,
+          "local_col": 10,
+          "master_row": 22,
+          "master_col": 229,
+          "pixel_x": 315.12646484375,
+          "pixel_y": 109.06813049316406
+        },
+        {
+          "local_row": 4,
+          "local_col": 11,
+          "master_row": 22,
+          "master_col": 230,
+          "pixel_x": 343.7814636230469,
+          "pixel_y": 110.29365539550781
+        },
+        {
+          "local_row": 4,
+          "local_col": 12,
+          "master_row": 22,
+          "master_col": 231,
+          "pixel_x": 372.5052795410156,
+          "pixel_y": 111.56106567382812
+        },
+        {
+          "local_row": 4,
+          "local_col": 13,
+          "master_row": 22,
+          "master_col": 232,
+          "pixel_x": 401.2724304199219,
+          "pixel_y": 112.86932373046875
+        },
+        {
+          "local_row": 4,
+          "local_col": 14,
+          "master_row": 22,
+          "master_col": 233,
+          "pixel_x": 430.0572509765625,
+          "pixel_y": 114.21720886230469
+        },
+        {
+          "local_row": 4,
+          "local_col": 15,
+          "master_row": 22,
+          "master_col": 234,
+          "pixel_x": 458.83453369140625,
+          "pixel_y": 115.60326385498047
+        },
+        {
+          "local_row": 4,
+          "local_col": 16,
+          "master_row": 22,
+          "master_col": 235,
+          "pixel_x": 487.5794677734375,
+          "pixel_y": 117.02576446533203
+        },
+        {
+          "local_row": 4,
+          "local_col": 17,
+          "master_row": 22,
+          "master_col": 236,
+          "pixel_x": 516.2680053710938,
+          "pixel_y": 118.4827880859375
+        },
+        {
+          "local_row": 4,
+          "local_col": 18,
+          "master_row": 22,
+          "master_col": 237,
+          "pixel_x": 544.87744140625,
+          "pixel_y": 119.97216033935547
+        },
+        {
+          "local_row": 4,
+          "local_col": 19,
+          "master_row": 22,
+          "master_col": 238,
+          "pixel_x": 573.3862915039062,
+          "pixel_y": 121.49153900146484
+        },
+        {
+          "local_row": 4,
+          "local_col": 20,
+          "master_row": 22,
+          "master_col": 239,
+          "pixel_x": 601.7750854492188,
+          "pixel_y": 123.038330078125
+        },
+        {
+          "local_row": 5,
+          "local_col": 0,
+          "master_row": 23,
+          "master_col": 219,
+          "pixel_x": 36.36517333984375,
+          "pixel_y": 118.36139678955078
+        },
+        {
+          "local_row": 5,
+          "local_col": 1,
+          "master_row": 23,
+          "master_col": 220,
+          "pixel_x": 63.115478515625,
+          "pixel_y": 119.24581146240234
+        },
+        {
+          "local_row": 5,
+          "local_col": 2,
+          "master_row": 23,
+          "master_col": 221,
+          "pixel_x": 90.13813781738281,
+          "pixel_y": 120.1646728515625
+        },
+        {
+          "local_row": 5,
+          "local_col": 3,
+          "master_row": 23,
+          "master_col": 222,
+          "pixel_x": 117.42027282714844,
+          "pixel_y": 121.11919403076172
+        },
+        {
+          "local_row": 5,
+          "local_col": 4,
+          "master_row": 23,
+          "master_col": 223,
+          "pixel_x": 144.94683837890625,
+          "pixel_y": 122.11035919189453
+        },
+        {
+          "local_row": 5,
+          "local_col": 5,
+          "master_row": 23,
+          "master_col": 224,
+          "pixel_x": 172.70091247558594,
+          "pixel_y": 123.13890838623047
+        },
+        {
+          "local_row": 5,
+          "local_col": 6,
+          "master_row": 23,
+          "master_col": 225,
+          "pixel_x": 200.6636962890625,
+          "pixel_y": 124.20536041259766
+        },
+        {
+          "local_row": 5,
+          "local_col": 7,
+          "master_row": 23,
+          "master_col": 226,
+          "pixel_x": 228.81480407714844,
+          "pixel_y": 125.30998992919922
+        },
+        {
+          "local_row": 5,
+          "local_col": 8,
+          "master_row": 23,
+          "master_col": 227,
+          "pixel_x": 257.13238525390625,
+          "pixel_y": 126.45285034179688
+        },
+        {
+          "local_row": 5,
+          "local_col": 9,
+          "master_row": 23,
+          "master_col": 228,
+          "pixel_x": 285.5934143066406,
+          "pixel_y": 127.63375091552734
+        },
+        {
+          "local_row": 5,
+          "local_col": 10,
+          "master_row": 23,
+          "master_col": 229,
+          "pixel_x": 314.173828125,
+          "pixel_y": 128.852294921875
+        },
+        {
+          "local_row": 5,
+          "local_col": 11,
+          "master_row": 23,
+          "master_col": 230,
+          "pixel_x": 342.8487854003906,
+          "pixel_y": 130.10784912109375
+        },
+        {
+          "local_row": 5,
+          "local_col": 12,
+          "master_row": 23,
+          "master_col": 231,
+          "pixel_x": 371.59295654296875,
+          "pixel_y": 131.39956665039062
+        },
+        {
+          "local_row": 5,
+          "local_col": 13,
+          "master_row": 23,
+          "master_col": 232,
+          "pixel_x": 400.3806457519531,
+          "pixel_y": 132.7264404296875
+        },
+        {
+          "local_row": 5,
+          "local_col": 14,
+          "master_row": 23,
+          "master_col": 233,
+          "pixel_x": 429.1861267089844,
+          "pixel_y": 134.08721923828125
+        },
+        {
+          "local_row": 5,
+          "local_col": 15,
+          "master_row": 23,
+          "master_col": 234,
+          "pixel_x": 457.98394775390625,
+          "pixel_y": 135.48046875
+        },
+        {
+          "local_row": 5,
+          "local_col": 16,
+          "master_row": 23,
+          "master_col": 235,
+          "pixel_x": 486.7492370605469,
+          "pixel_y": 136.90447998046875
+        },
+        {
+          "local_row": 5,
+          "local_col": 17,
+          "master_row": 23,
+          "master_col": 236,
+          "pixel_x": 515.457763671875,
+          "pixel_y": 138.35752868652344
+        },
+        {
+          "local_row": 5,
+          "local_col": 18,
+          "master_row": 23,
+          "master_col": 237,
+          "pixel_x": 544.0865478515625,
+          "pixel_y": 139.83753967285156
+        },
+        {
+          "local_row": 5,
+          "local_col": 19,
+          "master_row": 23,
+          "master_col": 238,
+          "pixel_x": 572.6140747070312,
+          "pixel_y": 141.34239196777344
+        },
+        {
+          "local_row": 5,
+          "local_col": 20,
+          "master_row": 23,
+          "master_col": 239,
+          "pixel_x": 601.0205078125,
+          "pixel_y": 142.86972045898438
+        },
+        {
+          "local_row": 6,
+          "local_col": 0,
+          "master_row": 24,
+          "master_col": 219,
+          "pixel_x": 35.293914794921875,
+          "pixel_y": 137.60299682617188
+        },
+        {
+          "local_row": 6,
+          "local_col": 1,
+          "master_row": 24,
+          "master_col": 220,
+          "pixel_x": 62.05133056640625,
+          "pixel_y": 138.5657196044922
+        },
+        {
+          "local_row": 6,
+          "local_col": 2,
+          "master_row": 24,
+          "master_col": 221,
+          "pixel_x": 89.08235168457031,
+          "pixel_y": 139.5592498779297
+        },
+        {
+          "local_row": 6,
+          "local_col": 3,
+          "master_row": 24,
+          "master_col": 222,
+          "pixel_x": 116.37405395507812,
+          "pixel_y": 140.58450317382812
+        },
+        {
+          "local_row": 6,
+          "local_col": 4,
+          "master_row": 24,
+          "master_col": 223,
+          "pixel_x": 143.9113006591797,
+          "pixel_y": 141.64212036132812
+        },
+        {
+          "local_row": 6,
+          "local_col": 5,
+          "master_row": 24,
+          "master_col": 224,
+          "pixel_x": 171.67706298828125,
+          "pixel_y": 142.73255920410156
+        },
+        {
+          "local_row": 6,
+          "local_col": 6,
+          "master_row": 24,
+          "master_col": 225,
+          "pixel_x": 199.65249633789062,
+          "pixel_y": 143.8560791015625
+        },
+        {
+          "local_row": 6,
+          "local_col": 7,
+          "master_row": 24,
+          "master_col": 226,
+          "pixel_x": 227.81704711914062,
+          "pixel_y": 145.0126953125
+        },
+        {
+          "local_row": 6,
+          "local_col": 8,
+          "master_row": 24,
+          "master_col": 227,
+          "pixel_x": 256.14886474609375,
+          "pixel_y": 146.2022705078125
+        },
+        {
+          "local_row": 6,
+          "local_col": 9,
+          "master_row": 24,
+          "master_col": 228,
+          "pixel_x": 284.62481689453125,
+          "pixel_y": 147.4244842529297
+        },
+        {
+          "local_row": 6,
+          "local_col": 10,
+          "master_row": 24,
+          "master_col": 229,
+          "pixel_x": 313.2206726074219,
+          "pixel_y": 148.67872619628906
+        },
+        {
+          "local_row": 6,
+          "local_col": 11,
+          "master_row": 24,
+          "master_col": 230,
+          "pixel_x": 341.91156005859375,
+          "pixel_y": 149.9642791748047
+        },
+        {
+          "local_row": 6,
+          "local_col": 12,
+          "master_row": 24,
+          "master_col": 231,
+          "pixel_x": 370.6719970703125,
+          "pixel_y": 151.28024291992188
+        },
+        {
+          "local_row": 6,
+          "local_col": 13,
+          "master_row": 24,
+          "master_col": 232,
+          "pixel_x": 399.4761657714844,
+          "pixel_y": 152.6255340576172
+        },
+        {
+          "local_row": 6,
+          "local_col": 14,
+          "master_row": 24,
+          "master_col": 233,
+          "pixel_x": 428.29827880859375,
+          "pixel_y": 153.99887084960938
+        },
+        {
+          "local_row": 6,
+          "local_col": 15,
+          "master_row": 24,
+          "master_col": 234,
+          "pixel_x": 457.11279296875,
+          "pixel_y": 155.39889526367188
+        },
+        {
+          "local_row": 6,
+          "local_col": 16,
+          "master_row": 24,
+          "master_col": 235,
+          "pixel_x": 485.89453125,
+          "pixel_y": 156.823974609375
+        },
+        {
+          "local_row": 6,
+          "local_col": 17,
+          "master_row": 24,
+          "master_col": 236,
+          "pixel_x": 514.6192626953125,
+          "pixel_y": 158.27243041992188
+        },
+        {
+          "local_row": 6,
+          "local_col": 18,
+          "master_row": 24,
+          "master_col": 237,
+          "pixel_x": 543.2638549804688,
+          "pixel_y": 159.74241638183594
+        },
+        {
+          "local_row": 6,
+          "local_col": 19,
+          "master_row": 24,
+          "master_col": 238,
+          "pixel_x": 571.806640625,
+          "pixel_y": 161.23194885253906
+        },
+        {
+          "local_row": 6,
+          "local_col": 20,
+          "master_row": 24,
+          "master_col": 239,
+          "pixel_x": 600.2275390625,
+          "pixel_y": 162.7389373779297
+        },
+        {
+          "local_row": 7,
+          "local_col": 0,
+          "master_row": 25,
+          "master_col": 219,
+          "pixel_x": 34.2574462890625,
+          "pixel_y": 156.8753204345703
+        },
+        {
+          "local_row": 7,
+          "local_col": 1,
+          "master_row": 25,
+          "master_col": 220,
+          "pixel_x": 61.019317626953125,
+          "pixel_y": 157.9169921875
+        },
+        {
+          "local_row": 7,
+          "local_col": 2,
+          "master_row": 25,
+          "master_col": 221,
+          "pixel_x": 88.05580139160156,
+          "pixel_y": 158.98580932617188
+        },
+        {
+          "local_row": 7,
+          "local_col": 3,
+          "master_row": 25,
+          "master_col": 222,
+          "pixel_x": 115.35391235351562,
+          "pixel_y": 160.082275390625
+        },
+        {
+          "local_row": 7,
+          "local_col": 4,
+          "master_row": 25,
+          "master_col": 223,
+          "pixel_x": 142.89849853515625,
+          "pixel_y": 161.20680236816406
+        },
+        {
+          "local_row": 7,
+          "local_col": 5,
+          "master_row": 25,
+          "master_col": 224,
+          "pixel_x": 170.67245483398438,
+          "pixel_y": 162.3594970703125
+        },
+        {
+          "local_row": 7,
+          "local_col": 6,
+          "master_row": 25,
+          "master_col": 225,
+          "pixel_x": 198.65682983398438,
+          "pixel_y": 163.54037475585938
+        },
+        {
+          "local_row": 7,
+          "local_col": 7,
+          "master_row": 25,
+          "master_col": 226,
+          "pixel_x": 226.83111572265625,
+          "pixel_y": 164.74923706054688
+        },
+        {
+          "local_row": 7,
+          "local_col": 8,
+          "master_row": 25,
+          "master_col": 227,
+          "pixel_x": 255.1732635498047,
+          "pixel_y": 165.98568725585938
+        },
+        {
+          "local_row": 7,
+          "local_col": 9,
+          "master_row": 25,
+          "master_col": 228,
+          "pixel_x": 283.66009521484375,
+          "pixel_y": 167.24925231933594
+        },
+        {
+          "local_row": 7,
+          "local_col": 10,
+          "master_row": 25,
+          "master_col": 229,
+          "pixel_x": 312.26739501953125,
+          "pixel_y": 168.53921508789062
+        },
+        {
+          "local_row": 7,
+          "local_col": 11,
+          "master_row": 25,
+          "master_col": 230,
+          "pixel_x": 340.9701232910156,
+          "pixel_y": 169.85472106933594
+        },
+        {
+          "local_row": 7,
+          "local_col": 12,
+          "master_row": 25,
+          "master_col": 231,
+          "pixel_x": 369.7427062988281,
+          "pixel_y": 171.19476318359375
+        },
+        {
+          "local_row": 7,
+          "local_col": 13,
+          "master_row": 25,
+          "master_col": 232,
+          "pixel_x": 398.559326171875,
+          "pixel_y": 172.55825805664062
+        },
+        {
+          "local_row": 7,
+          "local_col": 14,
+          "master_row": 25,
+          "master_col": 233,
+          "pixel_x": 427.3940124511719,
+          "pixel_y": 173.94390869140625
+        },
+        {
+          "local_row": 7,
+          "local_col": 15,
+          "master_row": 25,
+          "master_col": 234,
+          "pixel_x": 456.2210998535156,
+          "pixel_y": 175.35031127929688
+        },
+        {
+          "local_row": 7,
+          "local_col": 16,
+          "master_row": 25,
+          "master_col": 235,
+          "pixel_x": 485.0154113769531,
+          "pixel_y": 176.77601623535156
+        },
+        {
+          "local_row": 7,
+          "local_col": 17,
+          "master_row": 25,
+          "master_col": 236,
+          "pixel_x": 513.7525634765625,
+          "pixel_y": 178.2194061279297
+        },
+        {
+          "local_row": 7,
+          "local_col": 18,
+          "master_row": 25,
+          "master_col": 237,
+          "pixel_x": 542.4093017578125,
+          "pixel_y": 179.67874145507812
+        },
+        {
+          "local_row": 7,
+          "local_col": 19,
+          "master_row": 25,
+          "master_col": 238,
+          "pixel_x": 570.9637451171875,
+          "pixel_y": 181.15231323242188
+        },
+        {
+          "local_row": 7,
+          "local_col": 20,
+          "master_row": 25,
+          "master_col": 239,
+          "pixel_x": 599.3959350585938,
+          "pixel_y": 182.63821411132812
+        },
+        {
+          "local_row": 8,
+          "local_col": 0,
+          "master_row": 26,
+          "master_col": 219,
+          "pixel_x": 33.256561279296875,
+          "pixel_y": 176.17117309570312
+        },
+        {
+          "local_row": 8,
+          "local_col": 1,
+          "master_row": 26,
+          "master_col": 220,
+          "pixel_x": 60.020111083984375,
+          "pixel_y": 177.29229736328125
+        },
+        {
+          "local_row": 8,
+          "local_col": 2,
+          "master_row": 26,
+          "master_col": 221,
+          "pixel_x": 87.05912780761719,
+          "pixel_y": 178.43679809570312
+        },
+        {
+          "local_row": 8,
+          "local_col": 3,
+          "master_row": 26,
+          "master_col": 222,
+          "pixel_x": 114.3604736328125,
+          "pixel_y": 179.6048583984375
+        },
+        {
+          "local_row": 8,
+          "local_col": 4,
+          "master_row": 26,
+          "master_col": 223,
+          "pixel_x": 141.90904235839844,
+          "pixel_y": 180.7965545654297
+        },
+        {
+          "local_row": 8,
+          "local_col": 5,
+          "master_row": 26,
+          "master_col": 224,
+          "pixel_x": 169.6876678466797,
+          "pixel_y": 182.01174926757812
+        },
+        {
+          "local_row": 8,
+          "local_col": 6,
+          "master_row": 26,
+          "master_col": 225,
+          "pixel_x": 197.6773681640625,
+          "pixel_y": 183.25015258789062
+        },
+        {
+          "local_row": 8,
+          "local_col": 7,
+          "master_row": 26,
+          "master_col": 226,
+          "pixel_x": 225.85751342773438,
+          "pixel_y": 184.51136779785156
+        },
+        {
+          "local_row": 8,
+          "local_col": 8,
+          "master_row": 26,
+          "master_col": 227,
+          "pixel_x": 254.20606994628906,
+          "pixel_y": 185.7947998046875
+        },
+        {
+          "local_row": 8,
+          "local_col": 9,
+          "master_row": 26,
+          "master_col": 228,
+          "pixel_x": 282.6997985839844,
+          "pixel_y": 187.09974670410156
+        },
+        {
+          "local_row": 8,
+          "local_col": 10,
+          "master_row": 26,
+          "master_col": 229,
+          "pixel_x": 311.31439208984375,
+          "pixel_y": 188.4253692626953
+        },
+        {
+          "local_row": 8,
+          "local_col": 11,
+          "master_row": 26,
+          "master_col": 230,
+          "pixel_x": 340.0248718261719,
+          "pixel_y": 189.7707061767578
+        },
+        {
+          "local_row": 8,
+          "local_col": 12,
+          "master_row": 26,
+          "master_col": 231,
+          "pixel_x": 368.8054504394531,
+          "pixel_y": 191.13470458984375
+        },
+        {
+          "local_row": 8,
+          "local_col": 13,
+          "master_row": 26,
+          "master_col": 232,
+          "pixel_x": 397.6303405761719,
+          "pixel_y": 192.5161590576172
+        },
+        {
+          "local_row": 8,
+          "local_col": 14,
+          "master_row": 26,
+          "master_col": 233,
+          "pixel_x": 426.4734802246094,
+          "pixel_y": 193.913818359375
+        },
+        {
+          "local_row": 8,
+          "local_col": 15,
+          "master_row": 26,
+          "master_col": 234,
+          "pixel_x": 455.30914306640625,
+          "pixel_y": 195.32632446289062
+        },
+        {
+          "local_row": 8,
+          "local_col": 16,
+          "master_row": 26,
+          "master_col": 235,
+          "pixel_x": 484.112060546875,
+          "pixel_y": 196.75225830078125
+        },
+        {
+          "local_row": 8,
+          "local_col": 17,
+          "master_row": 26,
+          "master_col": 236,
+          "pixel_x": 512.8577880859375,
+          "pixel_y": 198.1901092529297
+        },
+        {
+          "local_row": 8,
+          "local_col": 18,
+          "master_row": 26,
+          "master_col": 237,
+          "pixel_x": 541.52294921875,
+          "pixel_y": 199.63833618164062
+        },
+        {
+          "local_row": 8,
+          "local_col": 19,
+          "master_row": 26,
+          "master_col": 238,
+          "pixel_x": 570.0855712890625,
+          "pixel_y": 201.09536743164062
+        },
+        {
+          "local_row": 8,
+          "local_col": 20,
+          "master_row": 26,
+          "master_col": 239,
+          "pixel_x": 598.525634765625,
+          "pixel_y": 202.55955505371094
+        },
+        {
+          "local_row": 9,
+          "local_col": 0,
+          "master_row": 27,
+          "master_col": 219,
+          "pixel_x": 32.291900634765625,
+          "pixel_y": 195.4832763671875
+        },
+        {
+          "local_row": 9,
+          "local_col": 1,
+          "master_row": 27,
+          "master_col": 220,
+          "pixel_x": 59.054443359375,
+          "pixel_y": 196.68411254882812
+        },
+        {
+          "local_row": 9,
+          "local_col": 2,
+          "master_row": 27,
+          "master_col": 221,
+          "pixel_x": 86.09295654296875,
+          "pixel_y": 197.90452575683594
+        },
+        {
+          "local_row": 9,
+          "local_col": 3,
+          "master_row": 27,
+          "master_col": 222,
+          "pixel_x": 113.3944091796875,
+          "pixel_y": 199.14439392089844
+        },
+        {
+          "local_row": 9,
+          "local_col": 4,
+          "master_row": 27,
+          "master_col": 223,
+          "pixel_x": 140.94357299804688,
+          "pixel_y": 200.40342712402344
+        },
+        {
+          "local_row": 9,
+          "local_col": 5,
+          "master_row": 27,
+          "master_col": 224,
+          "pixel_x": 168.72328186035156,
+          "pixel_y": 201.68121337890625
+        },
+        {
+          "local_row": 9,
+          "local_col": 6,
+          "master_row": 27,
+          "master_col": 225,
+          "pixel_x": 196.71453857421875,
+          "pixel_y": 202.9772186279297
+        },
+        {
+          "local_row": 9,
+          "local_col": 7,
+          "master_row": 27,
+          "master_col": 226,
+          "pixel_x": 224.896728515625,
+          "pixel_y": 204.29080200195312
+        },
+        {
+          "local_row": 9,
+          "local_col": 8,
+          "master_row": 27,
+          "master_col": 227,
+          "pixel_x": 253.24774169921875,
+          "pixel_y": 205.62118530273438
+        },
+        {
+          "local_row": 9,
+          "local_col": 9,
+          "master_row": 27,
+          "master_col": 228,
+          "pixel_x": 281.7443542480469,
+          "pixel_y": 206.96743774414062
+        },
+        {
+          "local_row": 9,
+          "local_col": 10,
+          "master_row": 27,
+          "master_col": 229,
+          "pixel_x": 310.3621520996094,
+          "pixel_y": 208.32864379882812
+        },
+        {
+          "local_row": 9,
+          "local_col": 11,
+          "master_row": 27,
+          "master_col": 230,
+          "pixel_x": 339.0761413574219,
+          "pixel_y": 209.70367431640625
+        },
+        {
+          "local_row": 9,
+          "local_col": 12,
+          "master_row": 27,
+          "master_col": 231,
+          "pixel_x": 367.8605651855469,
+          "pixel_y": 211.09141540527344
+        },
+        {
+          "local_row": 9,
+          "local_col": 13,
+          "master_row": 27,
+          "master_col": 232,
+          "pixel_x": 396.6895751953125,
+          "pixel_y": 212.4906463623047
+        },
+        {
+          "local_row": 9,
+          "local_col": 14,
+          "master_row": 27,
+          "master_col": 233,
+          "pixel_x": 425.5369873046875,
+          "pixel_y": 213.9000701904297
+        },
+        {
+          "local_row": 9,
+          "local_col": 15,
+          "master_row": 27,
+          "master_col": 234,
+          "pixel_x": 454.37713623046875,
+          "pixel_y": 215.31837463378906
+        },
+        {
+          "local_row": 9,
+          "local_col": 16,
+          "master_row": 27,
+          "master_col": 235,
+          "pixel_x": 483.18463134765625,
+          "pixel_y": 216.74420166015625
+        },
+        {
+          "local_row": 9,
+          "local_col": 17,
+          "master_row": 27,
+          "master_col": 236,
+          "pixel_x": 511.9349365234375,
+          "pixel_y": 218.1761474609375
+        },
+        {
+          "local_row": 9,
+          "local_col": 18,
+          "master_row": 27,
+          "master_col": 237,
+          "pixel_x": 540.6047973632812,
+          "pixel_y": 219.61282348632812
+        },
+        {
+          "local_row": 9,
+          "local_col": 19,
+          "master_row": 27,
+          "master_col": 238,
+          "pixel_x": 569.1720581054688,
+          "pixel_y": 221.05287170410156
+        },
+        {
+          "local_row": 9,
+          "local_col": 20,
+          "master_row": 27,
+          "master_col": 239,
+          "pixel_x": 597.6166381835938,
+          "pixel_y": 222.49488830566406
+        },
+        {
+          "local_row": 10,
+          "local_col": 0,
+          "master_row": 28,
+          "master_col": 219,
+          "pixel_x": 31.363983154296875,
+          "pixel_y": 214.80422973632812
+        },
+        {
+          "local_row": 10,
+          "local_col": 1,
+          "master_row": 28,
+          "master_col": 220,
+          "pixel_x": 58.122772216796875,
+          "pixel_y": 216.0848846435547
+        },
+        {
+          "local_row": 10,
+          "local_col": 2,
+          "master_row": 28,
+          "master_col": 221,
+          "pixel_x": 85.1578369140625,
+          "pixel_y": 217.38128662109375
+        },
+        {
+          "local_row": 10,
+          "local_col": 3,
+          "master_row": 28,
+          "master_col": 222,
+          "pixel_x": 112.4561767578125,
+          "pixel_y": 218.6929473876953
+        },
+        {
+          "local_row": 10,
+          "local_col": 4,
+          "master_row": 28,
+          "master_col": 223,
+          "pixel_x": 140.0025634765625,
+          "pixel_y": 220.01931762695312
+        },
+        {
+          "local_row": 10,
+          "local_col": 5,
+          "master_row": 28,
+          "master_col": 224,
+          "pixel_x": 167.77978515625,
+          "pixel_y": 221.35968017578125
+        },
+        {
+          "local_row": 10,
+          "local_col": 6,
+          "master_row": 28,
+          "master_col": 225,
+          "pixel_x": 195.7689208984375,
+          "pixel_y": 222.7132568359375
+        },
+        {
+          "local_row": 10,
+          "local_col": 7,
+          "master_row": 28,
+          "master_col": 226,
+          "pixel_x": 223.94924926757812,
+          "pixel_y": 224.07913208007812
+        },
+        {
+          "local_row": 10,
+          "local_col": 8,
+          "master_row": 28,
+          "master_col": 227,
+          "pixel_x": 252.2987518310547,
+          "pixel_y": 225.45632934570312
+        },
+        {
+          "local_row": 10,
+          "local_col": 9,
+          "master_row": 28,
+          "master_col": 228,
+          "pixel_x": 280.79412841796875,
+          "pixel_y": 226.8437957763672
+        },
+        {
+          "local_row": 10,
+          "local_col": 10,
+          "master_row": 28,
+          "master_col": 229,
+          "pixel_x": 309.4110412597656,
+          "pixel_y": 228.2404022216797
+        },
+        {
+          "local_row": 10,
+          "local_col": 11,
+          "master_row": 28,
+          "master_col": 230,
+          "pixel_x": 338.1243591308594,
+          "pixel_y": 229.64495849609375
+        },
+        {
+          "local_row": 10,
+          "local_col": 12,
+          "master_row": 28,
+          "master_col": 231,
+          "pixel_x": 366.908447265625,
+          "pixel_y": 231.05625915527344
+        },
+        {
+          "local_row": 10,
+          "local_col": 13,
+          "master_row": 28,
+          "master_col": 232,
+          "pixel_x": 395.7373046875,
+          "pixel_y": 232.4730224609375
+        },
+        {
+          "local_row": 10,
+          "local_col": 14,
+          "master_row": 28,
+          "master_col": 233,
+          "pixel_x": 424.58489990234375,
+          "pixel_y": 233.8939666748047
+        },
+        {
+          "local_row": 10,
+          "local_col": 15,
+          "master_row": 28,
+          "master_col": 234,
+          "pixel_x": 453.4253845214844,
+          "pixel_y": 235.3177947998047
+        },
+        {
+          "local_row": 10,
+          "local_col": 16,
+          "master_row": 28,
+          "master_col": 235,
+          "pixel_x": 482.23345947265625,
+          "pixel_y": 236.7432098388672
+        },
+        {
+          "local_row": 10,
+          "local_col": 17,
+          "master_row": 28,
+          "master_col": 236,
+          "pixel_x": 510.9845275878906,
+          "pixel_y": 238.16897583007812
+        },
+        {
+          "local_row": 10,
+          "local_col": 18,
+          "master_row": 28,
+          "master_col": 237,
+          "pixel_x": 539.6552734375,
+          "pixel_y": 239.59381103515625
+        },
+        {
+          "local_row": 10,
+          "local_col": 19,
+          "master_row": 28,
+          "master_col": 238,
+          "pixel_x": 568.2235107421875,
+          "pixel_y": 241.01651000976562
+        },
+        {
+          "local_row": 10,
+          "local_col": 20,
+          "master_row": 28,
+          "master_col": 239,
+          "pixel_x": 596.669189453125,
+          "pixel_y": 242.4359893798828
+        },
+        {
+          "local_row": 11,
+          "local_col": 0,
+          "master_row": 29,
+          "master_col": 219,
+          "pixel_x": 30.473297119140625,
+          "pixel_y": 234.1265869140625
+        },
+        {
+          "local_row": 11,
+          "local_col": 1,
+          "master_row": 29,
+          "master_col": 220,
+          "pixel_x": 57.22552490234375,
+          "pixel_y": 235.4869384765625
+        },
+        {
+          "local_row": 11,
+          "local_col": 2,
+          "master_row": 29,
+          "master_col": 221,
+          "pixel_x": 84.25419616699219,
+          "pixel_y": 236.8592071533203
+        },
+        {
+          "local_row": 11,
+          "local_col": 3,
+          "master_row": 29,
+          "master_col": 222,
+          "pixel_x": 111.54620361328125,
+          "pixel_y": 238.24256896972656
+        },
+        {
+          "local_row": 11,
+          "local_col": 4,
+          "master_row": 29,
+          "master_col": 223,
+          "pixel_x": 139.08639526367188,
+          "pixel_y": 239.63613891601562
+        },
+        {
+          "local_row": 11,
+          "local_col": 5,
+          "master_row": 29,
+          "master_col": 224,
+          "pixel_x": 166.8576202392578,
+          "pixel_y": 241.03892517089844
+        },
+        {
+          "local_row": 11,
+          "local_col": 6,
+          "master_row": 29,
+          "master_col": 225,
+          "pixel_x": 194.84085083007812,
+          "pixel_y": 242.4498748779297
+        },
+        {
+          "local_row": 11,
+          "local_col": 7,
+          "master_row": 29,
+          "master_col": 226,
+          "pixel_x": 223.01553344726562,
+          "pixel_y": 243.86785888671875
+        },
+        {
+          "local_row": 11,
+          "local_col": 8,
+          "master_row": 29,
+          "master_col": 227,
+          "pixel_x": 251.35952758789062,
+          "pixel_y": 245.2917022705078
+        },
+        {
+          "local_row": 11,
+          "local_col": 9,
+          "master_row": 29,
+          "master_col": 228,
+          "pixel_x": 279.849609375,
+          "pixel_y": 246.7201690673828
+        },
+        {
+          "local_row": 11,
+          "local_col": 10,
+          "master_row": 29,
+          "master_col": 229,
+          "pixel_x": 308.4614562988281,
+          "pixel_y": 248.15199279785156
+        },
+        {
+          "local_row": 11,
+          "local_col": 11,
+          "master_row": 29,
+          "master_col": 230,
+          "pixel_x": 337.16998291015625,
+          "pixel_y": 249.58584594726562
+        },
+        {
+          "local_row": 11,
+          "local_col": 12,
+          "master_row": 29,
+          "master_col": 231,
+          "pixel_x": 365.94952392578125,
+          "pixel_y": 251.0204620361328
+        },
+        {
+          "local_row": 11,
+          "local_col": 13,
+          "master_row": 29,
+          "master_col": 232,
+          "pixel_x": 394.7740783691406,
+          "pixel_y": 252.4545440673828
+        },
+        {
+          "local_row": 11,
+          "local_col": 14,
+          "master_row": 29,
+          "master_col": 233,
+          "pixel_x": 423.61761474609375,
+          "pixel_y": 253.88677978515625
+        },
+        {
+          "local_row": 11,
+          "local_col": 15,
+          "master_row": 29,
+          "master_col": 234,
+          "pixel_x": 452.454345703125,
+          "pixel_y": 255.31590270996094
+        },
+        {
+          "local_row": 11,
+          "local_col": 16,
+          "master_row": 29,
+          "master_col": 235,
+          "pixel_x": 481.2588806152344,
+          "pixel_y": 256.7406921386719
+        },
+        {
+          "local_row": 11,
+          "local_col": 17,
+          "master_row": 29,
+          "master_col": 236,
+          "pixel_x": 510.0068359375,
+          "pixel_y": 258.1600341796875
+        },
+        {
+          "local_row": 11,
+          "local_col": 18,
+          "master_row": 29,
+          "master_col": 237,
+          "pixel_x": 538.674560546875,
+          "pixel_y": 259.57275390625
+        },
+        {
+          "local_row": 11,
+          "local_col": 19,
+          "master_row": 29,
+          "master_col": 238,
+          "pixel_x": 567.240234375,
+          "pixel_y": 260.9779052734375
+        },
+        {
+          "local_row": 11,
+          "local_col": 20,
+          "master_row": 29,
+          "master_col": 239,
+          "pixel_x": 595.68359375,
+          "pixel_y": 262.3746032714844
+        },
+        {
+          "local_row": 12,
+          "local_col": 0,
+          "master_row": 30,
+          "master_col": 219,
+          "pixel_x": 29.620147705078125,
+          "pixel_y": 253.44287109375
+        },
+        {
+          "local_row": 12,
+          "local_col": 1,
+          "master_row": 30,
+          "master_col": 220,
+          "pixel_x": 56.363128662109375,
+          "pixel_y": 254.88267517089844
+        },
+        {
+          "local_row": 12,
+          "local_col": 2,
+          "master_row": 30,
+          "master_col": 221,
+          "pixel_x": 83.38235473632812,
+          "pixel_y": 256.3305358886719
+        },
+        {
+          "local_row": 12,
+          "local_col": 3,
+          "master_row": 30,
+          "master_col": 222,
+          "pixel_x": 110.66487121582031,
+          "pixel_y": 257.7852783203125
+        },
+        {
+          "local_row": 12,
+          "local_col": 4,
+          "master_row": 30,
+          "master_col": 223,
+          "pixel_x": 138.1955108642578,
+          "pixel_y": 259.2457275390625
+        },
+        {
+          "local_row": 12,
+          "local_col": 5,
+          "master_row": 30,
+          "master_col": 224,
+          "pixel_x": 165.95713806152344,
+          "pixel_y": 260.7106628417969
+        },
+        {
+          "local_row": 12,
+          "local_col": 6,
+          "master_row": 30,
+          "master_col": 225,
+          "pixel_x": 193.9307861328125,
+          "pixel_y": 262.1787109375
+        },
+        {
+          "local_row": 12,
+          "local_col": 7,
+          "master_row": 30,
+          "master_col": 226,
+          "pixel_x": 222.0959014892578,
+          "pixel_y": 263.6485595703125
+        },
+        {
+          "local_row": 12,
+          "local_col": 8,
+          "master_row": 30,
+          "master_col": 227,
+          "pixel_x": 250.4304656982422,
+          "pixel_y": 265.1187438964844
+        },
+        {
+          "local_row": 12,
+          "local_col": 9,
+          "master_row": 30,
+          "master_col": 228,
+          "pixel_x": 278.9112243652344,
+          "pixel_y": 266.5879211425781
+        },
+        {
+          "local_row": 12,
+          "local_col": 10,
+          "master_row": 30,
+          "master_col": 229,
+          "pixel_x": 307.5138854980469,
+          "pixel_y": 268.0546875
+        },
+        {
+          "local_row": 12,
+          "local_col": 11,
+          "master_row": 30,
+          "master_col": 230,
+          "pixel_x": 336.2134094238281,
+          "pixel_y": 269.5176086425781
+        },
+        {
+          "local_row": 12,
+          "local_col": 12,
+          "master_row": 30,
+          "master_col": 231,
+          "pixel_x": 364.984130859375,
+          "pixel_y": 270.9753112792969
+        },
+        {
+          "local_row": 12,
+          "local_col": 13,
+          "master_row": 30,
+          "master_col": 232,
+          "pixel_x": 393.8001708984375,
+          "pixel_y": 272.42645263671875
+        },
+        {
+          "local_row": 12,
+          "local_col": 14,
+          "master_row": 30,
+          "master_col": 233,
+          "pixel_x": 422.635498046875,
+          "pixel_y": 273.8697814941406
+        },
+        {
+          "local_row": 12,
+          "local_col": 15,
+          "master_row": 30,
+          "master_col": 234,
+          "pixel_x": 451.46435546875,
+          "pixel_y": 275.30401611328125
+        },
+        {
+          "local_row": 12,
+          "local_col": 16,
+          "master_row": 30,
+          "master_col": 235,
+          "pixel_x": 480.26141357421875,
+          "pixel_y": 276.7279968261719
+        },
+        {
+          "local_row": 12,
+          "local_col": 17,
+          "master_row": 30,
+          "master_col": 236,
+          "pixel_x": 509.002197265625,
+          "pixel_y": 278.1407165527344
+        },
+        {
+          "local_row": 12,
+          "local_col": 18,
+          "master_row": 30,
+          "master_col": 237,
+          "pixel_x": 537.663330078125,
+          "pixel_y": 279.54119873046875
+        },
+        {
+          "local_row": 12,
+          "local_col": 19,
+          "master_row": 30,
+          "master_col": 238,
+          "pixel_x": 566.2227172851562,
+          "pixel_y": 280.9286804199219
+        },
+        {
+          "local_row": 12,
+          "local_col": 20,
+          "master_row": 30,
+          "master_col": 239,
+          "pixel_x": 594.6602172851562,
+          "pixel_y": 282.302490234375
+        },
+        {
+          "local_row": 13,
+          "local_col": 0,
+          "master_row": 31,
+          "master_col": 219,
+          "pixel_x": 28.80474853515625,
+          "pixel_y": 272.74566650390625
+        },
+        {
+          "local_row": 13,
+          "local_col": 1,
+          "master_row": 31,
+          "master_col": 220,
+          "pixel_x": 55.535736083984375,
+          "pixel_y": 274.264404296875
+        },
+        {
+          "local_row": 13,
+          "local_col": 2,
+          "master_row": 31,
+          "master_col": 221,
+          "pixel_x": 82.54263305664062,
+          "pixel_y": 275.787353515625
+        },
+        {
+          "local_row": 13,
+          "local_col": 3,
+          "master_row": 31,
+          "master_col": 222,
+          "pixel_x": 109.81245422363281,
+          "pixel_y": 277.3130798339844
+        },
+        {
+          "local_row": 13,
+          "local_col": 4,
+          "master_row": 31,
+          "master_col": 223,
+          "pixel_x": 137.33016967773438,
+          "pixel_y": 278.8400573730469
+        },
+        {
+          "local_row": 13,
+          "local_col": 5,
+          "master_row": 31,
+          "master_col": 224,
+          "pixel_x": 165.0786590576172,
+          "pixel_y": 280.3666687011719
+        },
+        {
+          "local_row": 13,
+          "local_col": 6,
+          "master_row": 31,
+          "master_col": 225,
+          "pixel_x": 193.03903198242188,
+          "pixel_y": 281.89141845703125
+        },
+        {
+          "local_row": 13,
+          "local_col": 7,
+          "master_row": 31,
+          "master_col": 226,
+          "pixel_x": 221.19076538085938,
+          "pixel_y": 283.4126892089844
+        },
+        {
+          "local_row": 13,
+          "local_col": 8,
+          "master_row": 31,
+          "master_col": 227,
+          "pixel_x": 249.51193237304688,
+          "pixel_y": 284.9289245605469
+        },
+        {
+          "local_row": 13,
+          "local_col": 9,
+          "master_row": 31,
+          "master_col": 228,
+          "pixel_x": 277.9792785644531,
+          "pixel_y": 286.4384765625
+        },
+        {
+          "local_row": 13,
+          "local_col": 10,
+          "master_row": 31,
+          "master_col": 229,
+          "pixel_x": 306.5686340332031,
+          "pixel_y": 287.93988037109375
+        },
+        {
+          "local_row": 13,
+          "local_col": 11,
+          "master_row": 31,
+          "master_col": 230,
+          "pixel_x": 335.2550048828125,
+          "pixel_y": 289.4315490722656
+        },
+        {
+          "local_row": 13,
+          "local_col": 12,
+          "master_row": 31,
+          "master_col": 231,
+          "pixel_x": 364.0127868652344,
+          "pixel_y": 290.912109375
+        },
+        {
+          "local_row": 13,
+          "local_col": 13,
+          "master_row": 31,
+          "master_col": 232,
+          "pixel_x": 392.816162109375,
+          "pixel_y": 292.3800964355469
+        },
+        {
+          "local_row": 13,
+          "local_col": 14,
+          "master_row": 31,
+          "master_col": 233,
+          "pixel_x": 421.63909912109375,
+          "pixel_y": 293.83428955078125
+        },
+        {
+          "local_row": 13,
+          "local_col": 15,
+          "master_row": 31,
+          "master_col": 234,
+          "pixel_x": 450.4559631347656,
+          "pixel_y": 295.2734375
+        },
+        {
+          "local_row": 13,
+          "local_col": 16,
+          "master_row": 31,
+          "master_col": 235,
+          "pixel_x": 479.2414855957031,
+          "pixel_y": 296.69647216796875
+        },
+        {
+          "local_row": 13,
+          "local_col": 17,
+          "master_row": 31,
+          "master_col": 236,
+          "pixel_x": 507.97125244140625,
+          "pixel_y": 298.1025085449219
+        },
+        {
+          "local_row": 13,
+          "local_col": 18,
+          "master_row": 31,
+          "master_col": 237,
+          "pixel_x": 536.621826171875,
+          "pixel_y": 299.49072265625
+        },
+        {
+          "local_row": 13,
+          "local_col": 19,
+          "master_row": 31,
+          "master_col": 238,
+          "pixel_x": 565.17138671875,
+          "pixel_y": 300.8605041503906
+        },
+        {
+          "local_row": 13,
+          "local_col": 20,
+          "master_row": 31,
+          "master_col": 239,
+          "pixel_x": 593.5997314453125,
+          "pixel_y": 302.21148681640625
+        },
+        {
+          "local_row": 14,
+          "local_col": 0,
+          "master_row": 32,
+          "master_col": 219,
+          "pixel_x": 28.027191162109375,
+          "pixel_y": 292.0274963378906
+        },
+        {
+          "local_row": 14,
+          "local_col": 1,
+          "master_row": 32,
+          "master_col": 220,
+          "pixel_x": 54.743499755859375,
+          "pixel_y": 293.62457275390625
+        },
+        {
+          "local_row": 14,
+          "local_col": 2,
+          "master_row": 32,
+          "master_col": 221,
+          "pixel_x": 81.735107421875,
+          "pixel_y": 295.2220458984375
+        },
+        {
+          "local_row": 14,
+          "local_col": 3,
+          "master_row": 32,
+          "master_col": 222,
+          "pixel_x": 108.9891357421875,
+          "pixel_y": 296.8181457519531
+        },
+        {
+          "local_row": 14,
+          "local_col": 4,
+          "master_row": 32,
+          "master_col": 223,
+          "pixel_x": 136.49058532714844,
+          "pixel_y": 298.4109802246094
+        },
+        {
+          "local_row": 14,
+          "local_col": 5,
+          "master_row": 32,
+          "master_col": 224,
+          "pixel_x": 164.22244262695312,
+          "pixel_y": 299.9988098144531
+        },
+        {
+          "local_row": 14,
+          "local_col": 6,
+          "master_row": 32,
+          "master_col": 225,
+          "pixel_x": 192.16586303710938,
+          "pixel_y": 301.5797424316406
+        },
+        {
+          "local_row": 14,
+          "local_col": 7,
+          "master_row": 32,
+          "master_col": 226,
+          "pixel_x": 220.30043029785156,
+          "pixel_y": 303.1519775390625
+        },
+        {
+          "local_row": 14,
+          "local_col": 8,
+          "master_row": 32,
+          "master_col": 227,
+          "pixel_x": 248.604248046875,
+          "pixel_y": 304.7137451171875
+        },
+        {
+          "local_row": 14,
+          "local_col": 9,
+          "master_row": 32,
+          "master_col": 228,
+          "pixel_x": 277.0542297363281,
+          "pixel_y": 306.2633056640625
+        },
+        {
+          "local_row": 14,
+          "local_col": 10,
+          "master_row": 32,
+          "master_col": 229,
+          "pixel_x": 305.6261901855469,
+          "pixel_y": 307.7989501953125
+        },
+        {
+          "local_row": 14,
+          "local_col": 11,
+          "master_row": 32,
+          "master_col": 230,
+          "pixel_x": 334.2952880859375,
+          "pixel_y": 309.319091796875
+        },
+        {
+          "local_row": 14,
+          "local_col": 12,
+          "master_row": 32,
+          "master_col": 231,
+          "pixel_x": 363.0359802246094,
+          "pixel_y": 310.8221740722656
+        },
+        {
+          "local_row": 14,
+          "local_col": 13,
+          "master_row": 32,
+          "master_col": 232,
+          "pixel_x": 391.82244873046875,
+          "pixel_y": 312.3067626953125
+        },
+        {
+          "local_row": 14,
+          "local_col": 14,
+          "master_row": 32,
+          "master_col": 233,
+          "pixel_x": 420.6289367675781,
+          "pixel_y": 313.7716369628906
+        },
+        {
+          "local_row": 14,
+          "local_col": 15,
+          "master_row": 32,
+          "master_col": 234,
+          "pixel_x": 449.4297180175781,
+          "pixel_y": 315.215576171875
+        },
+        {
+          "local_row": 14,
+          "local_col": 16,
+          "master_row": 32,
+          "master_col": 235,
+          "pixel_x": 478.19970703125,
+          "pixel_y": 316.63763427734375
+        },
+        {
+          "local_row": 14,
+          "local_col": 17,
+          "master_row": 32,
+          "master_col": 236,
+          "pixel_x": 506.91448974609375,
+          "pixel_y": 318.03692626953125
+        },
+        {
+          "local_row": 14,
+          "local_col": 18,
+          "master_row": 32,
+          "master_col": 237,
+          "pixel_x": 535.5509033203125,
+          "pixel_y": 319.41290283203125
+        },
+        {
+          "local_row": 14,
+          "local_col": 19,
+          "master_row": 32,
+          "master_col": 238,
+          "pixel_x": 564.0869140625,
+          "pixel_y": 320.7651062011719
+        },
+        {
+          "local_row": 14,
+          "local_col": 20,
+          "master_row": 32,
+          "master_col": 239,
+          "pixel_x": 592.502685546875,
+          "pixel_y": 322.0933837890625
+        },
+        {
+          "local_row": 15,
+          "local_col": 0,
+          "master_row": 33,
+          "master_col": 219,
+          "pixel_x": 27.2874755859375,
+          "pixel_y": 311.2811584472656
+        },
+        {
+          "local_row": 15,
+          "local_col": 1,
+          "master_row": 33,
+          "master_col": 220,
+          "pixel_x": 53.986419677734375,
+          "pixel_y": 312.95574951171875
+        },
+        {
+          "local_row": 15,
+          "local_col": 2,
+          "master_row": 33,
+          "master_col": 221,
+          "pixel_x": 80.95988464355469,
+          "pixel_y": 314.6269226074219
+        },
+        {
+          "local_row": 15,
+          "local_col": 3,
+          "master_row": 33,
+          "master_col": 222,
+          "pixel_x": 108.19500732421875,
+          "pixel_y": 316.2926025390625
+        },
+        {
+          "local_row": 15,
+          "local_col": 4,
+          "master_row": 33,
+          "master_col": 223,
+          "pixel_x": 135.67691040039062,
+          "pixel_y": 317.9506530761719
+        },
+        {
+          "local_row": 15,
+          "local_col": 5,
+          "master_row": 33,
+          "master_col": 224,
+          "pixel_x": 163.38865661621094,
+          "pixel_y": 319.59893798828125
+        },
+        {
+          "local_row": 15,
+          "local_col": 6,
+          "master_row": 33,
+          "master_col": 225,
+          "pixel_x": 191.3115234375,
+          "pixel_y": 321.2354736328125
+        },
+        {
+          "local_row": 15,
+          "local_col": 7,
+          "master_row": 33,
+          "master_col": 226,
+          "pixel_x": 219.42514038085938,
+          "pixel_y": 322.85809326171875
+        },
+        {
+          "local_row": 15,
+          "local_col": 8,
+          "master_row": 33,
+          "master_col": 227,
+          "pixel_x": 247.707763671875,
+          "pixel_y": 324.46490478515625
+        },
+        {
+          "local_row": 15,
+          "local_col": 9,
+          "master_row": 33,
+          "master_col": 228,
+          "pixel_x": 276.1363525390625,
+          "pixel_y": 326.053955078125
+        },
+        {
+          "local_row": 15,
+          "local_col": 10,
+          "master_row": 33,
+          "master_col": 229,
+          "pixel_x": 304.6868896484375,
+          "pixel_y": 327.6234130859375
+        },
+        {
+          "local_row": 15,
+          "local_col": 11,
+          "master_row": 33,
+          "master_col": 230,
+          "pixel_x": 333.3346252441406,
+          "pixel_y": 329.171630859375
+        },
+        {
+          "local_row": 15,
+          "local_col": 12,
+          "master_row": 33,
+          "master_col": 231,
+          "pixel_x": 362.0540771484375,
+          "pixel_y": 330.69696044921875
+        },
+        {
+          "local_row": 15,
+          "local_col": 13,
+          "master_row": 33,
+          "master_col": 232,
+          "pixel_x": 390.8196105957031,
+          "pixel_y": 332.197998046875
+        },
+        {
+          "local_row": 15,
+          "local_col": 14,
+          "master_row": 33,
+          "master_col": 233,
+          "pixel_x": 419.6054992675781,
+          "pixel_y": 333.67340087890625
+        },
+        {
+          "local_row": 15,
+          "local_col": 15,
+          "master_row": 33,
+          "master_col": 234,
+          "pixel_x": 448.38616943359375,
+          "pixel_y": 335.1220397949219
+        },
+        {
+          "local_row": 15,
+          "local_col": 16,
+          "master_row": 33,
+          "master_col": 235,
+          "pixel_x": 477.13665771484375,
+          "pixel_y": 336.54302978515625
+        },
+        {
+          "local_row": 15,
+          "local_col": 17,
+          "master_row": 33,
+          "master_col": 236,
+          "pixel_x": 505.8326721191406,
+          "pixel_y": 337.9356689453125
+        },
+        {
+          "local_row": 15,
+          "local_col": 18,
+          "master_row": 33,
+          "master_col": 237,
+          "pixel_x": 534.4511108398438,
+          "pixel_y": 339.2994689941406
+        },
+        {
+          "local_row": 15,
+          "local_col": 19,
+          "master_row": 33,
+          "master_col": 238,
+          "pixel_x": 562.97021484375,
+          "pixel_y": 340.6343078613281
+        },
+        {
+          "local_row": 15,
+          "local_col": 20,
+          "master_row": 33,
+          "master_col": 239,
+          "pixel_x": 591.3699951171875,
+          "pixel_y": 341.9402160644531
+        },
+        {
+          "local_row": 16,
+          "local_col": 0,
+          "master_row": 34,
+          "master_col": 219,
+          "pixel_x": 26.585418701171875,
+          "pixel_y": 330.49945068359375
+        },
+        {
+          "local_row": 16,
+          "local_col": 1,
+          "master_row": 34,
+          "master_col": 220,
+          "pixel_x": 53.26446533203125,
+          "pixel_y": 332.25054931640625
+        },
+        {
+          "local_row": 16,
+          "local_col": 2,
+          "master_row": 34,
+          "master_col": 221,
+          "pixel_x": 80.21690368652344,
+          "pixel_y": 333.99444580078125
+        },
+        {
+          "local_row": 16,
+          "local_col": 3,
+          "master_row": 34,
+          "master_col": 222,
+          "pixel_x": 107.43009948730469,
+          "pixel_y": 335.72882080078125
+        },
+        {
+          "local_row": 16,
+          "local_col": 4,
+          "master_row": 34,
+          "master_col": 223,
+          "pixel_x": 134.88922119140625,
+          "pixel_y": 337.45123291015625
+        },
+        {
+          "local_row": 16,
+          "local_col": 5,
+          "master_row": 34,
+          "master_col": 224,
+          "pixel_x": 162.5774383544922,
+          "pixel_y": 339.15924072265625
+        },
+        {
+          "local_row": 16,
+          "local_col": 6,
+          "master_row": 34,
+          "master_col": 225,
+          "pixel_x": 190.47616577148438,
+          "pixel_y": 340.8505554199219
+        },
+        {
+          "local_row": 16,
+          "local_col": 7,
+          "master_row": 34,
+          "master_col": 226,
+          "pixel_x": 218.5651397705078,
+          "pixel_y": 342.52288818359375
+        },
+        {
+          "local_row": 16,
+          "local_col": 8,
+          "master_row": 34,
+          "master_col": 227,
+          "pixel_x": 246.82272338867188,
+          "pixel_y": 344.17413330078125
+        },
+        {
+          "local_row": 16,
+          "local_col": 9,
+          "master_row": 34,
+          "master_col": 228,
+          "pixel_x": 275.22601318359375,
+          "pixel_y": 345.8021545410156
+        },
+        {
+          "local_row": 16,
+          "local_col": 10,
+          "master_row": 34,
+          "master_col": 229,
+          "pixel_x": 303.7511901855469,
+          "pixel_y": 347.405029296875
+        },
+        {
+          "local_row": 16,
+          "local_col": 11,
+          "master_row": 34,
+          "master_col": 230,
+          "pixel_x": 332.37347412109375,
+          "pixel_y": 348.98089599609375
+        },
+        {
+          "local_row": 16,
+          "local_col": 12,
+          "master_row": 34,
+          "master_col": 231,
+          "pixel_x": 361.067626953125,
+          "pixel_y": 350.5281982421875
+        },
+        {
+          "local_row": 16,
+          "local_col": 13,
+          "master_row": 34,
+          "master_col": 232,
+          "pixel_x": 389.8081359863281,
+          "pixel_y": 352.0453796386719
+        },
+        {
+          "local_row": 16,
+          "local_col": 14,
+          "master_row": 34,
+          "master_col": 233,
+          "pixel_x": 418.56939697265625,
+          "pixel_y": 353.5311279296875
+        },
+        {
+          "local_row": 16,
+          "local_col": 15,
+          "master_row": 34,
+          "master_col": 234,
+          "pixel_x": 447.3260192871094,
+          "pixel_y": 354.98443603515625
+        },
+        {
+          "local_row": 16,
+          "local_col": 16,
+          "master_row": 34,
+          "master_col": 235,
+          "pixel_x": 476.0530700683594,
+          "pixel_y": 356.4044189453125
+        },
+        {
+          "local_row": 16,
+          "local_col": 17,
+          "master_row": 34,
+          "master_col": 236,
+          "pixel_x": 504.72650146484375,
+          "pixel_y": 357.79052734375
+        },
+        {
+          "local_row": 16,
+          "local_col": 18,
+          "master_row": 34,
+          "master_col": 237,
+          "pixel_x": 533.3233032226562,
+          "pixel_y": 359.1424255371094
+        },
+        {
+          "local_row": 16,
+          "local_col": 19,
+          "master_row": 34,
+          "master_col": 238,
+          "pixel_x": 561.8218994140625,
+          "pixel_y": 360.460205078125
+        },
+        {
+          "local_row": 16,
+          "local_col": 20,
+          "master_row": 34,
+          "master_col": 239,
+          "pixel_x": 590.202392578125,
+          "pixel_y": 361.744140625
+        },
+        {
+          "local_row": 17,
+          "local_col": 0,
+          "master_row": 35,
+          "master_col": 219,
+          "pixel_x": 25.92083740234375,
+          "pixel_y": 349.6754455566406
+        },
+        {
+          "local_row": 17,
+          "local_col": 1,
+          "master_row": 35,
+          "master_col": 220,
+          "pixel_x": 52.577392578125,
+          "pixel_y": 351.5018005371094
+        },
+        {
+          "local_row": 17,
+          "local_col": 2,
+          "master_row": 35,
+          "master_col": 221,
+          "pixel_x": 79.50607299804688,
+          "pixel_y": 353.3173522949219
+        },
+        {
+          "local_row": 17,
+          "local_col": 3,
+          "master_row": 35,
+          "master_col": 222,
+          "pixel_x": 106.69435119628906,
+          "pixel_y": 355.119384765625
+        },
+        {
+          "local_row": 17,
+          "local_col": 4,
+          "master_row": 35,
+          "master_col": 223,
+          "pixel_x": 134.12747192382812,
+          "pixel_y": 356.90509033203125
+        },
+        {
+          "local_row": 17,
+          "local_col": 5,
+          "master_row": 35,
+          "master_col": 224,
+          "pixel_x": 161.788818359375,
+          "pixel_y": 358.671875
+        },
+        {
+          "local_row": 17,
+          "local_col": 6,
+          "master_row": 35,
+          "master_col": 225,
+          "pixel_x": 189.65988159179688,
+          "pixel_y": 360.41717529296875
+        },
+        {
+          "local_row": 17,
+          "local_col": 7,
+          "master_row": 35,
+          "master_col": 226,
+          "pixel_x": 217.72056579589844,
+          "pixel_y": 362.13848876953125
+        },
+        {
+          "local_row": 17,
+          "local_col": 8,
+          "master_row": 35,
+          "master_col": 227,
+          "pixel_x": 245.94937133789062,
+          "pixel_y": 363.8334655761719
+        },
+        {
+          "local_row": 17,
+          "local_col": 9,
+          "master_row": 35,
+          "master_col": 228,
+          "pixel_x": 274.32354736328125,
+          "pixel_y": 365.4998474121094
+        },
+        {
+          "local_row": 17,
+          "local_col": 10,
+          "master_row": 35,
+          "master_col": 229,
+          "pixel_x": 302.8193359375,
+          "pixel_y": 367.13555908203125
+        },
+        {
+          "local_row": 17,
+          "local_col": 11,
+          "master_row": 35,
+          "master_col": 230,
+          "pixel_x": 331.4122314453125,
+          "pixel_y": 368.73876953125
+        },
+        {
+          "local_row": 17,
+          "local_col": 12,
+          "master_row": 35,
+          "master_col": 231,
+          "pixel_x": 360.0771179199219,
+          "pixel_y": 370.3076477050781
+        },
+        {
+          "local_row": 17,
+          "local_col": 13,
+          "master_row": 35,
+          "master_col": 232,
+          "pixel_x": 388.78863525390625,
+          "pixel_y": 371.84075927734375
+        },
+        {
+          "local_row": 17,
+          "local_col": 14,
+          "master_row": 35,
+          "master_col": 233,
+          "pixel_x": 417.52130126953125,
+          "pixel_y": 373.3367919921875
+        },
+        {
+          "local_row": 17,
+          "local_col": 15,
+          "master_row": 35,
+          "master_col": 234,
+          "pixel_x": 446.2498779296875,
+          "pixel_y": 374.794677734375
+        },
+        {
+          "local_row": 17,
+          "local_col": 16,
+          "master_row": 35,
+          "master_col": 235,
+          "pixel_x": 474.94970703125,
+          "pixel_y": 376.2137451171875
+        },
+        {
+          "local_row": 17,
+          "local_col": 17,
+          "master_row": 35,
+          "master_col": 236,
+          "pixel_x": 503.5968017578125,
+          "pixel_y": 377.593505859375
+        },
+        {
+          "local_row": 17,
+          "local_col": 18,
+          "master_row": 35,
+          "master_col": 237,
+          "pixel_x": 532.1683959960938,
+          "pixel_y": 378.9338684082031
+        },
+        {
+          "local_row": 17,
+          "local_col": 19,
+          "master_row": 35,
+          "master_col": 238,
+          "pixel_x": 560.6430053710938,
+          "pixel_y": 380.2349853515625
+        },
+        {
+          "local_row": 17,
+          "local_col": 20,
+          "master_row": 35,
+          "master_col": 239,
+          "pixel_x": 589.0010986328125,
+          "pixel_y": 381.49755859375
+        },
+        {
+          "local_row": 18,
+          "local_col": 0,
+          "master_row": 36,
+          "master_col": 219,
+          "pixel_x": 25.293304443359375,
+          "pixel_y": 368.80230712890625
+        },
+        {
+          "local_row": 18,
+          "local_col": 1,
+          "master_row": 36,
+          "master_col": 220,
+          "pixel_x": 51.9249267578125,
+          "pixel_y": 370.70257568359375
+        },
+        {
+          "local_row": 18,
+          "local_col": 2,
+          "master_row": 36,
+          "master_col": 221,
+          "pixel_x": 78.8271484375,
+          "pixel_y": 372.5885009765625
+        },
+        {
+          "local_row": 18,
+          "local_col": 3,
+          "master_row": 36,
+          "master_col": 222,
+          "pixel_x": 105.98756408691406,
+          "pixel_y": 374.4569091796875
+        },
+        {
+          "local_row": 18,
+          "local_col": 4,
+          "master_row": 36,
+          "master_col": 223,
+          "pixel_x": 133.3916015625,
+          "pixel_y": 376.30487060546875
+        },
+        {
+          "local_row": 18,
+          "local_col": 5,
+          "master_row": 36,
+          "master_col": 224,
+          "pixel_x": 161.02279663085938,
+          "pixel_y": 378.12939453125
+        },
+        {
+          "local_row": 18,
+          "local_col": 6,
+          "master_row": 36,
+          "master_col": 225,
+          "pixel_x": 188.86276245117188,
+          "pixel_y": 379.927734375
+        },
+        {
+          "local_row": 18,
+          "local_col": 7,
+          "master_row": 36,
+          "master_col": 226,
+          "pixel_x": 216.89157104492188,
+          "pixel_y": 381.6971130371094
+        },
+        {
+          "local_row": 18,
+          "local_col": 8,
+          "master_row": 36,
+          "master_col": 227,
+          "pixel_x": 245.08792114257812,
+          "pixel_y": 383.43505859375
+        },
+        {
+          "local_row": 18,
+          "local_col": 9,
+          "master_row": 36,
+          "master_col": 228,
+          "pixel_x": 273.4291687011719,
+          "pixel_y": 385.13916015625
+        },
+        {
+          "local_row": 18,
+          "local_col": 10,
+          "master_row": 36,
+          "master_col": 229,
+          "pixel_x": 301.89178466796875,
+          "pixel_y": 386.8072204589844
+        },
+        {
+          "local_row": 18,
+          "local_col": 11,
+          "master_row": 36,
+          "master_col": 230,
+          "pixel_x": 330.4513854980469,
+          "pixel_y": 388.4372253417969
+        },
+        {
+          "local_row": 18,
+          "local_col": 12,
+          "master_row": 36,
+          "master_col": 231,
+          "pixel_x": 359.0830383300781,
+          "pixel_y": 390.02740478515625
+        },
+        {
+          "local_row": 18,
+          "local_col": 13,
+          "master_row": 36,
+          "master_col": 232,
+          "pixel_x": 387.7615966796875,
+          "pixel_y": 391.57623291015625
+        },
+        {
+          "local_row": 18,
+          "local_col": 14,
+          "master_row": 36,
+          "master_col": 233,
+          "pixel_x": 416.4617919921875,
+          "pixel_y": 393.0823974609375
+        },
+        {
+          "local_row": 18,
+          "local_col": 15,
+          "master_row": 36,
+          "master_col": 234,
+          "pixel_x": 445.1585388183594,
+          "pixel_y": 394.5449523925781
+        },
+        {
+          "local_row": 18,
+          "local_col": 16,
+          "master_row": 36,
+          "master_col": 235,
+          "pixel_x": 473.82733154296875,
+          "pixel_y": 395.9632568359375
+        },
+        {
+          "local_row": 18,
+          "local_col": 17,
+          "master_row": 36,
+          "master_col": 236,
+          "pixel_x": 502.4444580078125,
+          "pixel_y": 397.33697509765625
+        },
+        {
+          "local_row": 18,
+          "local_col": 18,
+          "master_row": 36,
+          "master_col": 237,
+          "pixel_x": 530.9872436523438,
+          "pixel_y": 398.6661376953125
+        },
+        {
+          "local_row": 18,
+          "local_col": 19,
+          "master_row": 36,
+          "master_col": 238,
+          "pixel_x": 559.4345703125,
+          "pixel_y": 399.951171875
+        },
+        {
+          "local_row": 18,
+          "local_col": 20,
+          "master_row": 36,
+          "master_col": 239,
+          "pixel_x": 587.7669677734375,
+          "pixel_y": 401.19305419921875
+        },
+        {
+          "local_row": 19,
+          "local_col": 0,
+          "master_row": 37,
+          "master_col": 219,
+          "pixel_x": 24.70233154296875,
+          "pixel_y": 387.8735046386719
+        },
+        {
+          "local_row": 19,
+          "local_col": 1,
+          "master_row": 37,
+          "master_col": 220,
+          "pixel_x": 51.306610107421875,
+          "pixel_y": 389.8461608886719
+        },
+        {
+          "local_row": 19,
+          "local_col": 2,
+          "master_row": 37,
+          "master_col": 221,
+          "pixel_x": 78.17974853515625,
+          "pixel_y": 391.80096435546875
+        },
+        {
+          "local_row": 19,
+          "local_col": 3,
+          "master_row": 37,
+          "master_col": 222,
+          "pixel_x": 105.30949401855469,
+          "pixel_y": 393.7344970703125
+        },
+        {
+          "local_row": 19,
+          "local_col": 4,
+          "master_row": 37,
+          "master_col": 223,
+          "pixel_x": 132.68142700195312,
+          "pixel_y": 395.64337158203125
+        },
+        {
+          "local_row": 19,
+          "local_col": 5,
+          "master_row": 37,
+          "master_col": 224,
+          "pixel_x": 160.27923583984375,
+          "pixel_y": 397.5245056152344
+        },
+        {
+          "local_row": 19,
+          "local_col": 6,
+          "master_row": 37,
+          "master_col": 225,
+          "pixel_x": 188.08477783203125,
+          "pixel_y": 399.37481689453125
+        },
+        {
+          "local_row": 19,
+          "local_col": 7,
+          "master_row": 37,
+          "master_col": 226,
+          "pixel_x": 216.0782470703125,
+          "pixel_y": 401.19134521484375
+        },
+        {
+          "local_row": 19,
+          "local_col": 8,
+          "master_row": 37,
+          "master_col": 227,
+          "pixel_x": 244.23849487304688,
+          "pixel_y": 402.9714660644531
+        },
+        {
+          "local_row": 19,
+          "local_col": 9,
+          "master_row": 37,
+          "master_col": 228,
+          "pixel_x": 272.54315185546875,
+          "pixel_y": 404.7125549316406
+        },
+        {
+          "local_row": 19,
+          "local_col": 10,
+          "master_row": 37,
+          "master_col": 229,
+          "pixel_x": 300.9687805175781,
+          "pixel_y": 406.4123229980469
+        },
+        {
+          "local_row": 19,
+          "local_col": 11,
+          "master_row": 37,
+          "master_col": 230,
+          "pixel_x": 329.4913024902344,
+          "pixel_y": 408.06866455078125
+        },
+        {
+          "local_row": 19,
+          "local_col": 12,
+          "master_row": 37,
+          "master_col": 231,
+          "pixel_x": 358.0859375,
+          "pixel_y": 409.6797790527344
+        },
+        {
+          "local_row": 19,
+          "local_col": 13,
+          "master_row": 37,
+          "master_col": 232,
+          "pixel_x": 386.72772216796875,
+          "pixel_y": 411.2441101074219
+        },
+        {
+          "local_row": 19,
+          "local_col": 14,
+          "master_row": 37,
+          "master_col": 233,
+          "pixel_x": 415.3916015625,
+          "pixel_y": 412.76031494140625
+        },
+        {
+          "local_row": 19,
+          "local_col": 15,
+          "master_row": 37,
+          "master_col": 234,
+          "pixel_x": 444.052734375,
+          "pixel_y": 414.2276306152344
+        },
+        {
+          "local_row": 19,
+          "local_col": 16,
+          "master_row": 37,
+          "master_col": 235,
+          "pixel_x": 472.68682861328125,
+          "pixel_y": 415.6453857421875
+        },
+        {
+          "local_row": 19,
+          "local_col": 17,
+          "master_row": 37,
+          "master_col": 236,
+          "pixel_x": 501.2704162597656,
+          "pixel_y": 417.01336669921875
+        },
+        {
+          "local_row": 19,
+          "local_col": 18,
+          "master_row": 37,
+          "master_col": 237,
+          "pixel_x": 529.781005859375,
+          "pixel_y": 418.3318786621094
+        },
+        {
+          "local_row": 19,
+          "local_col": 19,
+          "master_row": 37,
+          "master_col": 238,
+          "pixel_x": 558.19775390625,
+          "pixel_y": 419.6015625
+        },
+        {
+          "local_row": 19,
+          "local_col": 20,
+          "master_row": 37,
+          "master_col": 239,
+          "pixel_x": 586.5013427734375,
+          "pixel_y": 420.82354736328125
+        },
+        {
+          "local_row": 20,
+          "local_col": 0,
+          "master_row": 38,
+          "master_col": 219,
+          "pixel_x": 24.147308349609375,
+          "pixel_y": 406.88275146484375
+        },
+        {
+          "local_row": 20,
+          "local_col": 1,
+          "master_row": 38,
+          "master_col": 220,
+          "pixel_x": 50.721954345703125,
+          "pixel_y": 408.9261169433594
+        },
+        {
+          "local_row": 20,
+          "local_col": 2,
+          "master_row": 38,
+          "master_col": 221,
+          "pixel_x": 77.5634765625,
+          "pixel_y": 410.9482421875
+        },
+        {
+          "local_row": 20,
+          "local_col": 3,
+          "master_row": 38,
+          "master_col": 222,
+          "pixel_x": 104.6597900390625,
+          "pixel_y": 412.9453125
+        },
+        {
+          "local_row": 20,
+          "local_col": 4,
+          "master_row": 38,
+          "master_col": 223,
+          "pixel_x": 131.99671936035156,
+          "pixel_y": 414.9137878417969
+        },
+        {
+          "local_row": 20,
+          "local_col": 5,
+          "master_row": 38,
+          "master_col": 224,
+          "pixel_x": 159.55804443359375,
+          "pixel_y": 416.8502197265625
+        },
+        {
+          "local_row": 20,
+          "local_col": 6,
+          "master_row": 38,
+          "master_col": 225,
+          "pixel_x": 187.32586669921875,
+          "pixel_y": 418.7513427734375
+        },
+        {
+          "local_row": 20,
+          "local_col": 7,
+          "master_row": 38,
+          "master_col": 226,
+          "pixel_x": 215.2805938720703,
+          "pixel_y": 420.6140441894531
+        },
+        {
+          "local_row": 20,
+          "local_col": 8,
+          "master_row": 38,
+          "master_col": 227,
+          "pixel_x": 243.40126037597656,
+          "pixel_y": 422.4353942871094
+        },
+        {
+          "local_row": 20,
+          "local_col": 9,
+          "master_row": 38,
+          "master_col": 228,
+          "pixel_x": 271.66571044921875,
+          "pixel_y": 424.21270751953125
+        },
+        {
+          "local_row": 20,
+          "local_col": 10,
+          "master_row": 38,
+          "master_col": 229,
+          "pixel_x": 300.05072021484375,
+          "pixel_y": 425.94354248046875
+        },
+        {
+          "local_row": 20,
+          "local_col": 11,
+          "master_row": 38,
+          "master_col": 230,
+          "pixel_x": 328.53240966796875,
+          "pixel_y": 427.62579345703125
+        },
+        {
+          "local_row": 20,
+          "local_col": 12,
+          "master_row": 38,
+          "master_col": 231,
+          "pixel_x": 357.0862731933594,
+          "pixel_y": 429.2574462890625
+        },
+        {
+          "local_row": 20,
+          "local_col": 13,
+          "master_row": 38,
+          "master_col": 232,
+          "pixel_x": 385.6875305175781,
+          "pixel_y": 430.8370666503906
+        },
+        {
+          "local_row": 20,
+          "local_col": 14,
+          "master_row": 38,
+          "master_col": 233,
+          "pixel_x": 414.3114013671875,
+          "pixel_y": 432.3633728027344
+        },
+        {
+          "local_row": 20,
+          "local_col": 15,
+          "master_row": 38,
+          "master_col": 234,
+          "pixel_x": 442.93328857421875,
+          "pixel_y": 433.83544921875
+        },
+        {
+          "local_row": 20,
+          "local_col": 16,
+          "master_row": 38,
+          "master_col": 235,
+          "pixel_x": 471.52911376953125,
+          "pixel_y": 435.2529296875
+        },
+        {
+          "local_row": 20,
+          "local_col": 17,
+          "master_row": 38,
+          "master_col": 236,
+          "pixel_x": 500.0756530761719,
+          "pixel_y": 436.61566162109375
+        },
+        {
+          "local_row": 20,
+          "local_col": 18,
+          "master_row": 38,
+          "master_col": 237,
+          "pixel_x": 528.55078125,
+          "pixel_y": 437.9241638183594
+        },
+        {
+          "local_row": 20,
+          "local_col": 19,
+          "master_row": 38,
+          "master_col": 238,
+          "pixel_x": 556.9337158203125,
+          "pixel_y": 439.17926025390625
+        },
+        {
+          "local_row": 20,
+          "local_col": 20,
+          "master_row": 38,
+          "master_col": 239,
+          "pixel_x": 585.2056274414062,
+          "pixel_y": 440.38238525390625
+        }
+      ]
+    },
+    {
+      "name": "author_like_foreshortened",
+      "seed": 49154,
+      "rows": 20,
+      "cols": 20,
+      "origin_row": 30,
+      "origin_col": 8,
+      "texture_px_per_square": 54,
+      "image_width": 640,
+      "image_height": 480,
+      "quad": [
+        [
+          128.0,
+          4.0
+        ],
+        [
+          566.0,
+          32.0
+        ],
+        [
+          632.0,
+          470.0
+        ],
+        [
+          24.0,
+          392.0
+        ]
+      ],
+      "k1": -0.115,
+      "k2": 0.032,
+      "blur_sigma": 0.95,
+      "noise_sigma": 2.8,
+      "vignette": 0.24,
+      "brightness": 1.0,
+      "contrast": 0.96,
+      "jpeg_quality": 90,
+      "image": "author_like_foreshortened.png",
+      "corners": [
+        {
+          "local_row": 0,
+          "local_col": 0,
+          "master_row": 30,
+          "master_col": 8,
+          "pixel_x": 132.64353942871094,
+          "pixel_y": 9.710464477539062
+        },
+        {
+          "local_row": 0,
+          "local_col": 1,
+          "master_row": 30,
+          "master_col": 9,
+          "pixel_x": 152.3536376953125,
+          "pixel_y": 10.525436401367188
+        },
+        {
+          "local_row": 0,
+          "local_col": 2,
+          "master_row": 30,
+          "master_col": 10,
+          "pixel_x": 172.30543518066406,
+          "pixel_y": 11.39544677734375
+        },
+        {
+          "local_row": 0,
+          "local_col": 3,
+          "master_row": 30,
+          "master_col": 11,
+          "pixel_x": 192.49136352539062,
+          "pixel_y": 12.322433471679688
+        },
+        {
+          "local_row": 0,
+          "local_col": 4,
+          "master_row": 30,
+          "master_col": 12,
+          "pixel_x": 212.90286254882812,
+          "pixel_y": 13.308151245117188
+        },
+        {
+          "local_row": 0,
+          "local_col": 5,
+          "master_row": 30,
+          "master_col": 13,
+          "pixel_x": 233.53025817871094,
+          "pixel_y": 14.354171752929688
+        },
+        {
+          "local_row": 0,
+          "local_col": 6,
+          "master_row": 30,
+          "master_col": 14,
+          "pixel_x": 254.36285400390625,
+          "pixel_y": 15.46185302734375
+        },
+        {
+          "local_row": 0,
+          "local_col": 7,
+          "master_row": 30,
+          "master_col": 15,
+          "pixel_x": 275.3890075683594,
+          "pixel_y": 16.632400512695312
+        },
+        {
+          "local_row": 0,
+          "local_col": 8,
+          "master_row": 30,
+          "master_col": 16,
+          "pixel_x": 296.5961608886719,
+          "pixel_y": 17.866714477539062
+        },
+        {
+          "local_row": 0,
+          "local_col": 9,
+          "master_row": 30,
+          "master_col": 17,
+          "pixel_x": 317.9709167480469,
+          "pixel_y": 19.165542602539062
+        },
+        {
+          "local_row": 0,
+          "local_col": 10,
+          "master_row": 30,
+          "master_col": 18,
+          "pixel_x": 339.4990539550781,
+          "pixel_y": 20.529342651367188
+        },
+        {
+          "local_row": 0,
+          "local_col": 11,
+          "master_row": 30,
+          "master_col": 19,
+          "pixel_x": 361.16571044921875,
+          "pixel_y": 21.958358764648438
+        },
+        {
+          "local_row": 0,
+          "local_col": 12,
+          "master_row": 30,
+          "master_col": 20,
+          "pixel_x": 382.9553527832031,
+          "pixel_y": 23.452560424804688
+        },
+        {
+          "local_row": 0,
+          "local_col": 13,
+          "master_row": 30,
+          "master_col": 21,
+          "pixel_x": 404.8519592285156,
+          "pixel_y": 25.011672973632812
+        },
+        {
+          "local_row": 0,
+          "local_col": 14,
+          "master_row": 30,
+          "master_col": 22,
+          "pixel_x": 426.83917236328125,
+          "pixel_y": 26.6351318359375
+        },
+        {
+          "local_row": 0,
+          "local_col": 15,
+          "master_row": 30,
+          "master_col": 23,
+          "pixel_x": 448.90032958984375,
+          "pixel_y": 28.322097778320312
+        },
+        {
+          "local_row": 0,
+          "local_col": 16,
+          "master_row": 30,
+          "master_col": 24,
+          "pixel_x": 471.01861572265625,
+          "pixel_y": 30.071441650390625
+        },
+        {
+          "local_row": 0,
+          "local_col": 17,
+          "master_row": 30,
+          "master_col": 25,
+          "pixel_x": 493.17724609375,
+          "pixel_y": 31.881683349609375
+        },
+        {
+          "local_row": 0,
+          "local_col": 18,
+          "master_row": 30,
+          "master_col": 26,
+          "pixel_x": 515.3597412109375,
+          "pixel_y": 33.75111389160156
+        },
+        {
+          "local_row": 0,
+          "local_col": 19,
+          "master_row": 30,
+          "master_col": 27,
+          "pixel_x": 537.5499267578125,
+          "pixel_y": 35.67765808105469
+        },
+        {
+          "local_row": 0,
+          "local_col": 20,
+          "master_row": 30,
+          "master_col": 28,
+          "pixel_x": 559.7322998046875,
+          "pixel_y": 37.65885925292969
+        },
+        {
+          "local_row": 1,
+          "local_col": 0,
+          "master_row": 31,
+          "master_col": 8,
+          "pixel_x": 128.65415954589844,
+          "pixel_y": 23.409713745117188
+        },
+        {
+          "local_row": 1,
+          "local_col": 1,
+          "master_row": 31,
+          "master_col": 9,
+          "pixel_x": 148.63531494140625,
+          "pixel_y": 24.302703857421875
+        },
+        {
+          "local_row": 1,
+          "local_col": 2,
+          "master_row": 31,
+          "master_col": 10,
+          "pixel_x": 168.8677215576172,
+          "pixel_y": 25.2503662109375
+        },
+        {
+          "local_row": 1,
+          "local_col": 3,
+          "master_row": 31,
+          "master_col": 11,
+          "pixel_x": 189.34352111816406,
+          "pixel_y": 26.254592895507812
+        },
+        {
+          "local_row": 1,
+          "local_col": 4,
+          "master_row": 31,
+          "master_col": 12,
+          "pixel_x": 210.0538330078125,
+          "pixel_y": 27.31707763671875
+        },
+        {
+          "local_row": 1,
+          "local_col": 5,
+          "master_row": 31,
+          "master_col": 13,
+          "pixel_x": 230.988525390625,
+          "pixel_y": 28.439315795898438
+        },
+        {
+          "local_row": 1,
+          "local_col": 6,
+          "master_row": 31,
+          "master_col": 14,
+          "pixel_x": 252.13645935058594,
+          "pixel_y": 29.622573852539062
+        },
+        {
+          "local_row": 1,
+          "local_col": 7,
+          "master_row": 31,
+          "master_col": 15,
+          "pixel_x": 273.48541259765625,
+          "pixel_y": 30.867904663085938
+        },
+        {
+          "local_row": 1,
+          "local_col": 8,
+          "master_row": 31,
+          "master_col": 16,
+          "pixel_x": 295.022216796875,
+          "pixel_y": 32.17619323730469
+        },
+        {
+          "local_row": 1,
+          "local_col": 9,
+          "master_row": 31,
+          "master_col": 17,
+          "pixel_x": 316.7327575683594,
+          "pixel_y": 33.54803466796875
+        },
+        {
+          "local_row": 1,
+          "local_col": 10,
+          "master_row": 31,
+          "master_col": 18,
+          "pixel_x": 338.6021728515625,
+          "pixel_y": 34.983795166015625
+        },
+        {
+          "local_row": 1,
+          "local_col": 11,
+          "master_row": 31,
+          "master_col": 19,
+          "pixel_x": 360.6146545410156,
+          "pixel_y": 36.48365783691406
+        },
+        {
+          "local_row": 1,
+          "local_col": 12,
+          "master_row": 31,
+          "master_col": 20,
+          "pixel_x": 382.75396728515625,
+          "pixel_y": 38.04743957519531
+        },
+        {
+          "local_row": 1,
+          "local_col": 13,
+          "master_row": 31,
+          "master_col": 21,
+          "pixel_x": 405.0032043457031,
+          "pixel_y": 39.67478942871094
+        },
+        {
+          "local_row": 1,
+          "local_col": 14,
+          "master_row": 31,
+          "master_col": 22,
+          "pixel_x": 427.3450622558594,
+          "pixel_y": 41.36500549316406
+        },
+        {
+          "local_row": 1,
+          "local_col": 15,
+          "master_row": 31,
+          "master_col": 23,
+          "pixel_x": 449.761962890625,
+          "pixel_y": 43.117218017578125
+        },
+        {
+          "local_row": 1,
+          "local_col": 16,
+          "master_row": 31,
+          "master_col": 24,
+          "pixel_x": 472.23614501953125,
+          "pixel_y": 44.93013000488281
+        },
+        {
+          "local_row": 1,
+          "local_col": 17,
+          "master_row": 31,
+          "master_col": 25,
+          "pixel_x": 494.75,
+          "pixel_y": 46.80218505859375
+        },
+        {
+          "local_row": 1,
+          "local_col": 18,
+          "master_row": 31,
+          "master_col": 26,
+          "pixel_x": 517.2860107421875,
+          "pixel_y": 48.73158264160156
+        },
+        {
+          "local_row": 1,
+          "local_col": 19,
+          "master_row": 31,
+          "master_col": 27,
+          "pixel_x": 539.8271484375,
+          "pixel_y": 50.71614074707031
+        },
+        {
+          "local_row": 1,
+          "local_col": 20,
+          "master_row": 31,
+          "master_col": 28,
+          "pixel_x": 562.3571166992188,
+          "pixel_y": 52.75335693359375
+        },
+        {
+          "local_row": 2,
+          "local_col": 0,
+          "master_row": 32,
+          "master_col": 8,
+          "pixel_x": 124.56370544433594,
+          "pixel_y": 37.551788330078125
+        },
+        {
+          "local_row": 2,
+          "local_col": 1,
+          "master_row": 32,
+          "master_col": 9,
+          "pixel_x": 144.82119750976562,
+          "pixel_y": 38.52867126464844
+        },
+        {
+          "local_row": 2,
+          "local_col": 2,
+          "master_row": 32,
+          "master_col": 10,
+          "pixel_x": 165.33985900878906,
+          "pixel_y": 39.559814453125
+        },
+        {
+          "local_row": 2,
+          "local_col": 3,
+          "master_row": 32,
+          "master_col": 11,
+          "pixel_x": 186.1116485595703,
+          "pixel_y": 40.646942138671875
+        },
+        {
+          "local_row": 2,
+          "local_col": 4,
+          "master_row": 32,
+          "master_col": 12,
+          "pixel_x": 207.1272430419922,
+          "pixel_y": 41.79167175292969
+        },
+        {
+          "local_row": 2,
+          "local_col": 5,
+          "master_row": 32,
+          "master_col": 13,
+          "pixel_x": 228.37612915039062,
+          "pixel_y": 42.995361328125
+        },
+        {
+          "local_row": 2,
+          "local_col": 6,
+          "master_row": 32,
+          "master_col": 14,
+          "pixel_x": 249.84661865234375,
+          "pixel_y": 44.25923156738281
+        },
+        {
+          "local_row": 2,
+          "local_col": 7,
+          "master_row": 32,
+          "master_col": 15,
+          "pixel_x": 271.52593994140625,
+          "pixel_y": 45.58421325683594
+        },
+        {
+          "local_row": 2,
+          "local_col": 8,
+          "master_row": 32,
+          "master_col": 16,
+          "pixel_x": 293.4002990722656,
+          "pixel_y": 46.971038818359375
+        },
+        {
+          "local_row": 2,
+          "local_col": 9,
+          "master_row": 32,
+          "master_col": 17,
+          "pixel_x": 315.4548034667969,
+          "pixel_y": 48.42021179199219
+        },
+        {
+          "local_row": 2,
+          "local_col": 10,
+          "master_row": 32,
+          "master_col": 18,
+          "pixel_x": 337.673828125,
+          "pixel_y": 49.9320068359375
+        },
+        {
+          "local_row": 2,
+          "local_col": 11,
+          "master_row": 32,
+          "master_col": 19,
+          "pixel_x": 360.0408020019531,
+          "pixel_y": 51.50645446777344
+        },
+        {
+          "local_row": 2,
+          "local_col": 12,
+          "master_row": 32,
+          "master_col": 20,
+          "pixel_x": 382.5385437011719,
+          "pixel_y": 53.14324951171875
+        },
+        {
+          "local_row": 2,
+          "local_col": 13,
+          "master_row": 32,
+          "master_col": 21,
+          "pixel_x": 405.14923095703125,
+          "pixel_y": 54.84193420410156
+        },
+        {
+          "local_row": 2,
+          "local_col": 14,
+          "master_row": 32,
+          "master_col": 22,
+          "pixel_x": 427.8545837402344,
+          "pixel_y": 56.60173034667969
+        },
+        {
+          "local_row": 2,
+          "local_col": 15,
+          "master_row": 32,
+          "master_col": 23,
+          "pixel_x": 450.6360778808594,
+          "pixel_y": 58.42155456542969
+        },
+        {
+          "local_row": 2,
+          "local_col": 16,
+          "master_row": 32,
+          "master_col": 24,
+          "pixel_x": 473.4750061035156,
+          "pixel_y": 60.300048828125
+        },
+        {
+          "local_row": 2,
+          "local_col": 17,
+          "master_row": 32,
+          "master_col": 25,
+          "pixel_x": 496.3526916503906,
+          "pixel_y": 62.23561096191406
+        },
+        {
+          "local_row": 2,
+          "local_col": 18,
+          "master_row": 32,
+          "master_col": 26,
+          "pixel_x": 519.2507934570312,
+          "pixel_y": 64.22622680664062
+        },
+        {
+          "local_row": 2,
+          "local_col": 19,
+          "master_row": 32,
+          "master_col": 27,
+          "pixel_x": 542.1511840820312,
+          "pixel_y": 66.26974487304688
+        },
+        {
+          "local_row": 2,
+          "local_col": 20,
+          "master_row": 32,
+          "master_col": 28,
+          "pixel_x": 565.0368041992188,
+          "pixel_y": 68.36349487304688
+        },
+        {
+          "local_row": 3,
+          "local_col": 0,
+          "master_row": 33,
+          "master_col": 8,
+          "pixel_x": 120.37019348144531,
+          "pixel_y": 52.15379333496094
+        },
+        {
+          "local_row": 3,
+          "local_col": 1,
+          "master_row": 33,
+          "master_col": 9,
+          "pixel_x": 140.9092559814453,
+          "pixel_y": 53.22090148925781
+        },
+        {
+          "local_row": 3,
+          "local_col": 2,
+          "master_row": 33,
+          "master_col": 10,
+          "pixel_x": 161.71990966796875,
+          "pixel_y": 54.341644287109375
+        },
+        {
+          "local_row": 3,
+          "local_col": 3,
+          "master_row": 33,
+          "master_col": 11,
+          "pixel_x": 182.79379272460938,
+          "pixel_y": 55.517669677734375
+        },
+        {
+          "local_row": 3,
+          "local_col": 4,
+          "master_row": 33,
+          "master_col": 12,
+          "pixel_x": 204.1212158203125,
+          "pixel_y": 56.750457763671875
+        },
+        {
+          "local_row": 3,
+          "local_col": 5,
+          "master_row": 33,
+          "master_col": 13,
+          "pixel_x": 225.6912384033203,
+          "pixel_y": 58.041290283203125
+        },
+        {
+          "local_row": 3,
+          "local_col": 6,
+          "master_row": 33,
+          "master_col": 14,
+          "pixel_x": 247.49163818359375,
+          "pixel_y": 59.391143798828125
+        },
+        {
+          "local_row": 3,
+          "local_col": 7,
+          "master_row": 33,
+          "master_col": 15,
+          "pixel_x": 269.5090026855469,
+          "pixel_y": 60.80091857910156
+        },
+        {
+          "local_row": 3,
+          "local_col": 8,
+          "master_row": 33,
+          "master_col": 16,
+          "pixel_x": 291.7288513183594,
+          "pixel_y": 62.27113342285156
+        },
+        {
+          "local_row": 3,
+          "local_col": 9,
+          "master_row": 33,
+          "master_col": 17,
+          "pixel_x": 314.1356506347656,
+          "pixel_y": 63.80224609375
+        },
+        {
+          "local_row": 3,
+          "local_col": 10,
+          "master_row": 33,
+          "master_col": 18,
+          "pixel_x": 336.7127685546875,
+          "pixel_y": 65.39434814453125
+        },
+        {
+          "local_row": 3,
+          "local_col": 11,
+          "master_row": 33,
+          "master_col": 19,
+          "pixel_x": 359.44293212890625,
+          "pixel_y": 67.04728698730469
+        },
+        {
+          "local_row": 3,
+          "local_col": 12,
+          "master_row": 33,
+          "master_col": 20,
+          "pixel_x": 382.30792236328125,
+          "pixel_y": 68.76072692871094
+        },
+        {
+          "local_row": 3,
+          "local_col": 13,
+          "master_row": 33,
+          "master_col": 21,
+          "pixel_x": 405.2889709472656,
+          "pixel_y": 70.53398132324219
+        },
+        {
+          "local_row": 3,
+          "local_col": 14,
+          "master_row": 33,
+          "master_col": 22,
+          "pixel_x": 428.3668518066406,
+          "pixel_y": 72.36618041992188
+        },
+        {
+          "local_row": 3,
+          "local_col": 15,
+          "master_row": 33,
+          "master_col": 23,
+          "pixel_x": 451.5219421386719,
+          "pixel_y": 74.25608825683594
+        },
+        {
+          "local_row": 3,
+          "local_col": 16,
+          "master_row": 33,
+          "master_col": 24,
+          "pixel_x": 474.7344970703125,
+          "pixel_y": 76.2022705078125
+        },
+        {
+          "local_row": 3,
+          "local_col": 17,
+          "master_row": 33,
+          "master_col": 25,
+          "pixel_x": 497.98486328125,
+          "pixel_y": 78.20295715332031
+        },
+        {
+          "local_row": 3,
+          "local_col": 18,
+          "master_row": 33,
+          "master_col": 26,
+          "pixel_x": 521.2535400390625,
+          "pixel_y": 80.25607299804688
+        },
+        {
+          "local_row": 3,
+          "local_col": 19,
+          "master_row": 33,
+          "master_col": 27,
+          "pixel_x": 544.521728515625,
+          "pixel_y": 82.35934448242188
+        },
+        {
+          "local_row": 3,
+          "local_col": 20,
+          "master_row": 33,
+          "master_col": 28,
+          "pixel_x": 567.7711791992188,
+          "pixel_y": 84.51002502441406
+        },
+        {
+          "local_row": 4,
+          "local_col": 0,
+          "master_row": 34,
+          "master_col": 8,
+          "pixel_x": 116.07168579101562,
+          "pixel_y": 67.23309326171875
+        },
+        {
+          "local_row": 4,
+          "local_col": 1,
+          "master_row": 34,
+          "master_col": 9,
+          "pixel_x": 136.8976593017578,
+          "pixel_y": 68.39723205566406
+        },
+        {
+          "local_row": 4,
+          "local_col": 2,
+          "master_row": 34,
+          "master_col": 10,
+          "pixel_x": 158.00596618652344,
+          "pixel_y": 69.61419677734375
+        },
+        {
+          "local_row": 4,
+          "local_col": 3,
+          "master_row": 34,
+          "master_col": 11,
+          "pixel_x": 179.38809204101562,
+          "pixel_y": 70.88557434082031
+        },
+        {
+          "local_row": 4,
+          "local_col": 4,
+          "master_row": 34,
+          "master_col": 12,
+          "pixel_x": 201.03390502929688,
+          "pixel_y": 72.21263122558594
+        },
+        {
+          "local_row": 4,
+          "local_col": 5,
+          "master_row": 34,
+          "master_col": 13,
+          "pixel_x": 222.93203735351562,
+          "pixel_y": 73.59652709960938
+        },
+        {
+          "local_row": 4,
+          "local_col": 6,
+          "master_row": 34,
+          "master_col": 14,
+          "pixel_x": 245.0697021484375,
+          "pixel_y": 75.03814697265625
+        },
+        {
+          "local_row": 4,
+          "local_col": 7,
+          "master_row": 34,
+          "master_col": 15,
+          "pixel_x": 267.432861328125,
+          "pixel_y": 76.53813171386719
+        },
+        {
+          "local_row": 4,
+          "local_col": 8,
+          "master_row": 34,
+          "master_col": 16,
+          "pixel_x": 290.00634765625,
+          "pixel_y": 78.09698486328125
+        },
+        {
+          "local_row": 4,
+          "local_col": 9,
+          "master_row": 34,
+          "master_col": 17,
+          "pixel_x": 312.7737121582031,
+          "pixel_y": 79.71487426757812
+        },
+        {
+          "local_row": 4,
+          "local_col": 10,
+          "master_row": 34,
+          "master_col": 18,
+          "pixel_x": 335.7176208496094,
+          "pixel_y": 81.39175415039062
+        },
+        {
+          "local_row": 4,
+          "local_col": 11,
+          "master_row": 34,
+          "master_col": 19,
+          "pixel_x": 358.8197326660156,
+          "pixel_y": 83.12736511230469
+        },
+        {
+          "local_row": 4,
+          "local_col": 12,
+          "master_row": 34,
+          "master_col": 20,
+          "pixel_x": 382.06097412109375,
+          "pixel_y": 84.92118835449219
+        },
+        {
+          "local_row": 4,
+          "local_col": 13,
+          "master_row": 34,
+          "master_col": 21,
+          "pixel_x": 405.42144775390625,
+          "pixel_y": 86.77239990234375
+        },
+        {
+          "local_row": 4,
+          "local_col": 14,
+          "master_row": 34,
+          "master_col": 22,
+          "pixel_x": 428.88092041015625,
+          "pixel_y": 88.67991638183594
+        },
+        {
+          "local_row": 4,
+          "local_col": 15,
+          "master_row": 34,
+          "master_col": 23,
+          "pixel_x": 452.4186706542969,
+          "pixel_y": 90.6424560546875
+        },
+        {
+          "local_row": 4,
+          "local_col": 16,
+          "master_row": 34,
+          "master_col": 24,
+          "pixel_x": 476.01385498046875,
+          "pixel_y": 92.65838623046875
+        },
+        {
+          "local_row": 4,
+          "local_col": 17,
+          "master_row": 34,
+          "master_col": 25,
+          "pixel_x": 499.645751953125,
+          "pixel_y": 94.725830078125
+        },
+        {
+          "local_row": 4,
+          "local_col": 18,
+          "master_row": 34,
+          "master_col": 26,
+          "pixel_x": 523.2938232421875,
+          "pixel_y": 96.84263610839844
+        },
+        {
+          "local_row": 4,
+          "local_col": 19,
+          "master_row": 34,
+          "master_col": 27,
+          "pixel_x": 546.9381103515625,
+          "pixel_y": 99.00633239746094
+        },
+        {
+          "local_row": 4,
+          "local_col": 20,
+          "master_row": 34,
+          "master_col": 28,
+          "pixel_x": 570.5595703125,
+          "pixel_y": 101.21421813964844
+        },
+        {
+          "local_row": 5,
+          "local_col": 0,
+          "master_row": 35,
+          "master_col": 8,
+          "pixel_x": 111.66647338867188,
+          "pixel_y": 82.8076171875
+        },
+        {
+          "local_row": 5,
+          "local_col": 1,
+          "master_row": 35,
+          "master_col": 9,
+          "pixel_x": 132.78453063964844,
+          "pixel_y": 84.075927734375
+        },
+        {
+          "local_row": 5,
+          "local_col": 2,
+          "master_row": 35,
+          "master_col": 10,
+          "pixel_x": 154.19625854492188,
+          "pixel_y": 85.39617919921875
+        },
+        {
+          "local_row": 5,
+          "local_col": 3,
+          "master_row": 35,
+          "master_col": 11,
+          "pixel_x": 175.8927459716797,
+          "pixel_y": 86.76971435546875
+        },
+        {
+          "local_row": 5,
+          "local_col": 4,
+          "master_row": 35,
+          "master_col": 12,
+          "pixel_x": 197.86358642578125,
+          "pixel_y": 88.19769287109375
+        },
+        {
+          "local_row": 5,
+          "local_col": 5,
+          "master_row": 35,
+          "master_col": 13,
+          "pixel_x": 220.09683227539062,
+          "pixel_y": 89.68104553222656
+        },
+        {
+          "local_row": 5,
+          "local_col": 6,
+          "master_row": 35,
+          "master_col": 14,
+          "pixel_x": 242.5791778564453,
+          "pixel_y": 91.22048950195312
+        },
+        {
+          "local_row": 5,
+          "local_col": 7,
+          "master_row": 35,
+          "master_col": 15,
+          "pixel_x": 265.2959289550781,
+          "pixel_y": 92.81655883789062
+        },
+        {
+          "local_row": 5,
+          "local_col": 8,
+          "master_row": 35,
+          "master_col": 16,
+          "pixel_x": 288.2311096191406,
+          "pixel_y": 94.46946716308594
+        },
+        {
+          "local_row": 5,
+          "local_col": 9,
+          "master_row": 35,
+          "master_col": 17,
+          "pixel_x": 311.3675537109375,
+          "pixel_y": 96.17922973632812
+        },
+        {
+          "local_row": 5,
+          "local_col": 10,
+          "master_row": 35,
+          "master_col": 18,
+          "pixel_x": 334.6868591308594,
+          "pixel_y": 97.9456787109375
+        },
+        {
+          "local_row": 5,
+          "local_col": 11,
+          "master_row": 35,
+          "master_col": 19,
+          "pixel_x": 358.1698913574219,
+          "pixel_y": 99.768310546875
+        },
+        {
+          "local_row": 5,
+          "local_col": 12,
+          "master_row": 35,
+          "master_col": 20,
+          "pixel_x": 381.79638671875,
+          "pixel_y": 101.64643859863281
+        },
+        {
+          "local_row": 5,
+          "local_col": 13,
+          "master_row": 35,
+          "master_col": 21,
+          "pixel_x": 405.5454406738281,
+          "pixel_y": 103.57908630371094
+        },
+        {
+          "local_row": 5,
+          "local_col": 14,
+          "master_row": 35,
+          "master_col": 22,
+          "pixel_x": 429.39569091796875,
+          "pixel_y": 105.56498718261719
+        },
+        {
+          "local_row": 5,
+          "local_col": 15,
+          "master_row": 35,
+          "master_col": 23,
+          "pixel_x": 453.3252258300781,
+          "pixel_y": 107.60272216796875
+        },
+        {
+          "local_row": 5,
+          "local_col": 16,
+          "master_row": 35,
+          "master_col": 24,
+          "pixel_x": 477.3121337890625,
+          "pixel_y": 109.69047546386719
+        },
+        {
+          "local_row": 5,
+          "local_col": 17,
+          "master_row": 35,
+          "master_col": 25,
+          "pixel_x": 501.33447265625,
+          "pixel_y": 111.82625579833984
+        },
+        {
+          "local_row": 5,
+          "local_col": 18,
+          "master_row": 35,
+          "master_col": 26,
+          "pixel_x": 525.37060546875,
+          "pixel_y": 114.0077896118164
+        },
+        {
+          "local_row": 5,
+          "local_col": 19,
+          "master_row": 35,
+          "master_col": 27,
+          "pixel_x": 549.3995971679688,
+          "pixel_y": 116.2325439453125
+        },
+        {
+          "local_row": 5,
+          "local_col": 20,
+          "master_row": 35,
+          "master_col": 28,
+          "pixel_x": 573.4013671875,
+          "pixel_y": 118.49771118164062
+        },
+        {
+          "local_row": 6,
+          "local_col": 0,
+          "master_row": 36,
+          "master_col": 8,
+          "pixel_x": 107.15296936035156,
+          "pixel_y": 98.89541625976562
+        },
+        {
+          "local_row": 6,
+          "local_col": 1,
+          "master_row": 36,
+          "master_col": 9,
+          "pixel_x": 128.56834411621094,
+          "pixel_y": 100.27560424804688
+        },
+        {
+          "local_row": 6,
+          "local_col": 2,
+          "master_row": 36,
+          "master_col": 10,
+          "pixel_x": 150.2891387939453,
+          "pixel_y": 101.70661926269531
+        },
+        {
+          "local_row": 6,
+          "local_col": 3,
+          "master_row": 36,
+          "master_col": 11,
+          "pixel_x": 172.30615234375,
+          "pixel_y": 103.18962097167969
+        },
+        {
+          "local_row": 6,
+          "local_col": 4,
+          "master_row": 36,
+          "master_col": 12,
+          "pixel_x": 194.60855102539062,
+          "pixel_y": 104.72552490234375
+        },
+        {
+          "local_row": 6,
+          "local_col": 5,
+          "master_row": 36,
+          "master_col": 13,
+          "pixel_x": 217.18394470214844,
+          "pixel_y": 106.31513977050781
+        },
+        {
+          "local_row": 6,
+          "local_col": 6,
+          "master_row": 36,
+          "master_col": 14,
+          "pixel_x": 240.01841735839844,
+          "pixel_y": 107.95890808105469
+        },
+        {
+          "local_row": 6,
+          "local_col": 7,
+          "master_row": 36,
+          "master_col": 15,
+          "pixel_x": 263.0965881347656,
+          "pixel_y": 109.65716552734375
+        },
+        {
+          "local_row": 6,
+          "local_col": 8,
+          "master_row": 36,
+          "master_col": 16,
+          "pixel_x": 286.40167236328125,
+          "pixel_y": 111.409912109375
+        },
+        {
+          "local_row": 6,
+          "local_col": 9,
+          "master_row": 36,
+          "master_col": 17,
+          "pixel_x": 309.91558837890625,
+          "pixel_y": 113.21700286865234
+        },
+        {
+          "local_row": 6,
+          "local_col": 10,
+          "master_row": 36,
+          "master_col": 18,
+          "pixel_x": 333.6191101074219,
+          "pixel_y": 115.07798767089844
+        },
+        {
+          "local_row": 6,
+          "local_col": 11,
+          "master_row": 36,
+          "master_col": 19,
+          "pixel_x": 357.491943359375,
+          "pixel_y": 116.99221801757812
+        },
+        {
+          "local_row": 6,
+          "local_col": 12,
+          "master_row": 36,
+          "master_col": 20,
+          "pixel_x": 381.5127868652344,
+          "pixel_y": 118.958740234375
+        },
+        {
+          "local_row": 6,
+          "local_col": 13,
+          "master_row": 36,
+          "master_col": 21,
+          "pixel_x": 405.65960693359375,
+          "pixel_y": 120.97642517089844
+        },
+        {
+          "local_row": 6,
+          "local_col": 14,
+          "master_row": 36,
+          "master_col": 22,
+          "pixel_x": 429.9098205566406,
+          "pixel_y": 123.04383850097656
+        },
+        {
+          "local_row": 6,
+          "local_col": 15,
+          "master_row": 36,
+          "master_col": 23,
+          "pixel_x": 454.2403869628906,
+          "pixel_y": 125.15931701660156
+        },
+        {
+          "local_row": 6,
+          "local_col": 16,
+          "master_row": 36,
+          "master_col": 24,
+          "pixel_x": 478.62811279296875,
+          "pixel_y": 127.32096862792969
+        },
+        {
+          "local_row": 6,
+          "local_col": 17,
+          "master_row": 36,
+          "master_col": 25,
+          "pixel_x": 503.0498046875,
+          "pixel_y": 129.526611328125
+        },
+        {
+          "local_row": 6,
+          "local_col": 18,
+          "master_row": 36,
+          "master_col": 26,
+          "pixel_x": 527.4827880859375,
+          "pixel_y": 131.77389526367188
+        },
+        {
+          "local_row": 6,
+          "local_col": 19,
+          "master_row": 36,
+          "master_col": 27,
+          "pixel_x": 551.9049682617188,
+          "pixel_y": 134.06011962890625
+        },
+        {
+          "local_row": 6,
+          "local_col": 20,
+          "master_row": 36,
+          "master_col": 28,
+          "pixel_x": 576.295166015625,
+          "pixel_y": 136.38246154785156
+        },
+        {
+          "local_row": 7,
+          "local_col": 0,
+          "master_row": 37,
+          "master_col": 8,
+          "pixel_x": 102.52975463867188,
+          "pixel_y": 115.51486206054688
+        },
+        {
+          "local_row": 7,
+          "local_col": 1,
+          "master_row": 37,
+          "master_col": 9,
+          "pixel_x": 124.24763488769531,
+          "pixel_y": 117.01509857177734
+        },
+        {
+          "local_row": 7,
+          "local_col": 2,
+          "master_row": 37,
+          "master_col": 10,
+          "pixel_x": 146.2831268310547,
+          "pixel_y": 118.56483459472656
+        },
+        {
+          "local_row": 7,
+          "local_col": 3,
+          "master_row": 37,
+          "master_col": 11,
+          "pixel_x": 168.62673950195312,
+          "pixel_y": 120.1650161743164
+        },
+        {
+          "local_row": 7,
+          "local_col": 4,
+          "master_row": 37,
+          "master_col": 12,
+          "pixel_x": 191.2672882080078,
+          "pixel_y": 121.81639099121094
+        },
+        {
+          "local_row": 7,
+          "local_col": 5,
+          "master_row": 37,
+          "master_col": 13,
+          "pixel_x": 214.19183349609375,
+          "pixel_y": 123.51941680908203
+        },
+        {
+          "local_row": 7,
+          "local_col": 6,
+          "master_row": 37,
+          "master_col": 14,
+          "pixel_x": 237.3858642578125,
+          "pixel_y": 125.27438354492188
+        },
+        {
+          "local_row": 7,
+          "local_col": 7,
+          "master_row": 37,
+          "master_col": 15,
+          "pixel_x": 260.833251953125,
+          "pixel_y": 127.08132934570312
+        },
+        {
+          "local_row": 7,
+          "local_col": 8,
+          "master_row": 37,
+          "master_col": 16,
+          "pixel_x": 284.51641845703125,
+          "pixel_y": 128.9400634765625
+        },
+        {
+          "local_row": 7,
+          "local_col": 9,
+          "master_row": 37,
+          "master_col": 17,
+          "pixel_x": 308.4163818359375,
+          "pixel_y": 130.85015869140625
+        },
+        {
+          "local_row": 7,
+          "local_col": 10,
+          "master_row": 37,
+          "master_col": 18,
+          "pixel_x": 332.51287841796875,
+          "pixel_y": 132.8109130859375
+        },
+        {
+          "local_row": 7,
+          "local_col": 11,
+          "master_row": 37,
+          "master_col": 19,
+          "pixel_x": 356.7844543457031,
+          "pixel_y": 134.82147216796875
+        },
+        {
+          "local_row": 7,
+          "local_col": 12,
+          "master_row": 37,
+          "master_col": 20,
+          "pixel_x": 381.20880126953125,
+          "pixel_y": 136.88067626953125
+        },
+        {
+          "local_row": 7,
+          "local_col": 13,
+          "master_row": 37,
+          "master_col": 21,
+          "pixel_x": 405.76263427734375,
+          "pixel_y": 138.98712158203125
+        },
+        {
+          "local_row": 7,
+          "local_col": 14,
+          "master_row": 37,
+          "master_col": 22,
+          "pixel_x": 430.4220275878906,
+          "pixel_y": 141.13922119140625
+        },
+        {
+          "local_row": 7,
+          "local_col": 15,
+          "master_row": 37,
+          "master_col": 23,
+          "pixel_x": 455.16278076171875,
+          "pixel_y": 143.3350830078125
+        },
+        {
+          "local_row": 7,
+          "local_col": 16,
+          "master_row": 37,
+          "master_col": 24,
+          "pixel_x": 479.96038818359375,
+          "pixel_y": 145.57266235351562
+        },
+        {
+          "local_row": 7,
+          "local_col": 17,
+          "master_row": 37,
+          "master_col": 25,
+          "pixel_x": 504.79046630859375,
+          "pixel_y": 147.84963989257812
+        },
+        {
+          "local_row": 7,
+          "local_col": 18,
+          "master_row": 37,
+          "master_col": 26,
+          "pixel_x": 529.6290283203125,
+          "pixel_y": 150.16348266601562
+        },
+        {
+          "local_row": 7,
+          "local_col": 19,
+          "master_row": 37,
+          "master_col": 27,
+          "pixel_x": 554.4528198242188,
+          "pixel_y": 152.51145935058594
+        },
+        {
+          "local_row": 7,
+          "local_col": 20,
+          "master_row": 37,
+          "master_col": 28,
+          "pixel_x": 579.23974609375,
+          "pixel_y": 154.89068603515625
+        },
+        {
+          "local_row": 8,
+          "local_col": 0,
+          "master_row": 38,
+          "master_col": 8,
+          "pixel_x": 97.79574584960938,
+          "pixel_y": 132.68446350097656
+        },
+        {
+          "local_row": 8,
+          "local_col": 1,
+          "master_row": 38,
+          "master_col": 9,
+          "pixel_x": 119.82118225097656,
+          "pixel_y": 134.31338500976562
+        },
+        {
+          "local_row": 8,
+          "local_col": 2,
+          "master_row": 38,
+          "master_col": 10,
+          "pixel_x": 142.17694091796875,
+          "pixel_y": 135.9903106689453
+        },
+        {
+          "local_row": 8,
+          "local_col": 3,
+          "master_row": 38,
+          "master_col": 11,
+          "pixel_x": 164.85321044921875,
+          "pixel_y": 137.71591186523438
+        },
+        {
+          "local_row": 8,
+          "local_col": 4,
+          "master_row": 38,
+          "master_col": 12,
+          "pixel_x": 187.83840942382812,
+          "pixel_y": 139.49066162109375
+        },
+        {
+          "local_row": 8,
+          "local_col": 5,
+          "master_row": 38,
+          "master_col": 13,
+          "pixel_x": 211.1190948486328,
+          "pixel_y": 141.31472778320312
+        },
+        {
+          "local_row": 8,
+          "local_col": 6,
+          "master_row": 38,
+          "master_col": 14,
+          "pixel_x": 234.6800537109375,
+          "pixel_y": 143.18814086914062
+        },
+        {
+          "local_row": 8,
+          "local_col": 7,
+          "master_row": 38,
+          "master_col": 15,
+          "pixel_x": 258.50445556640625,
+          "pixel_y": 145.1106719970703
+        },
+        {
+          "local_row": 8,
+          "local_col": 8,
+          "master_row": 38,
+          "master_col": 16,
+          "pixel_x": 282.5738830566406,
+          "pixel_y": 147.08181762695312
+        },
+        {
+          "local_row": 8,
+          "local_col": 9,
+          "master_row": 38,
+          "master_col": 17,
+          "pixel_x": 306.86834716796875,
+          "pixel_y": 149.10089111328125
+        },
+        {
+          "local_row": 8,
+          "local_col": 10,
+          "master_row": 38,
+          "master_col": 18,
+          "pixel_x": 331.3665466308594,
+          "pixel_y": 151.1669464111328
+        },
+        {
+          "local_row": 8,
+          "local_col": 11,
+          "master_row": 38,
+          "master_col": 19,
+          "pixel_x": 356.0458984375,
+          "pixel_y": 153.27880859375
+        },
+        {
+          "local_row": 8,
+          "local_col": 12,
+          "master_row": 38,
+          "master_col": 20,
+          "pixel_x": 380.8828430175781,
+          "pixel_y": 155.4351043701172
+        },
+        {
+          "local_row": 8,
+          "local_col": 13,
+          "master_row": 38,
+          "master_col": 21,
+          "pixel_x": 405.85284423828125,
+          "pixel_y": 157.6341552734375
+        },
+        {
+          "local_row": 8,
+          "local_col": 14,
+          "master_row": 38,
+          "master_col": 22,
+          "pixel_x": 430.9306945800781,
+          "pixel_y": 159.8741455078125
+        },
+        {
+          "local_row": 8,
+          "local_col": 15,
+          "master_row": 38,
+          "master_col": 23,
+          "pixel_x": 456.0908203125,
+          "pixel_y": 162.15301513671875
+        },
+        {
+          "local_row": 8,
+          "local_col": 16,
+          "master_row": 38,
+          "master_col": 24,
+          "pixel_x": 481.3074035644531,
+          "pixel_y": 164.468505859375
+        },
+        {
+          "local_row": 8,
+          "local_col": 17,
+          "master_row": 38,
+          "master_col": 25,
+          "pixel_x": 506.5546875,
+          "pixel_y": 166.81814575195312
+        },
+        {
+          "local_row": 8,
+          "local_col": 18,
+          "master_row": 38,
+          "master_col": 26,
+          "pixel_x": 531.8075561523438,
+          "pixel_y": 169.19927978515625
+        },
+        {
+          "local_row": 8,
+          "local_col": 19,
+          "master_row": 38,
+          "master_col": 27,
+          "pixel_x": 557.0414428710938,
+          "pixel_y": 171.60910034179688
+        },
+        {
+          "local_row": 8,
+          "local_col": 20,
+          "master_row": 38,
+          "master_col": 28,
+          "pixel_x": 582.233154296875,
+          "pixel_y": 174.04464721679688
+        },
+        {
+          "local_row": 9,
+          "local_col": 0,
+          "master_row": 39,
+          "master_col": 8,
+          "pixel_x": 92.94996643066406,
+          "pixel_y": 150.4228057861328
+        },
+        {
+          "local_row": 9,
+          "local_col": 1,
+          "master_row": 39,
+          "master_col": 9,
+          "pixel_x": 115.28804016113281,
+          "pixel_y": 152.1895751953125
+        },
+        {
+          "local_row": 9,
+          "local_col": 2,
+          "master_row": 39,
+          "master_col": 10,
+          "pixel_x": 137.96954345703125,
+          "pixel_y": 154.00265502929688
+        },
+        {
+          "local_row": 9,
+          "local_col": 3,
+          "master_row": 39,
+          "master_col": 11,
+          "pixel_x": 160.98443603515625,
+          "pixel_y": 155.86236572265625
+        },
+        {
+          "local_row": 9,
+          "local_col": 4,
+          "master_row": 39,
+          "master_col": 12,
+          "pixel_x": 184.32070922851562,
+          "pixel_y": 157.76885986328125
+        },
+        {
+          "local_row": 9,
+          "local_col": 5,
+          "master_row": 39,
+          "master_col": 13,
+          "pixel_x": 207.9644012451172,
+          "pixel_y": 159.7220458984375
+        },
+        {
+          "local_row": 9,
+          "local_col": 6,
+          "master_row": 39,
+          "master_col": 14,
+          "pixel_x": 231.899658203125,
+          "pixel_y": 161.72158813476562
+        },
+        {
+          "local_row": 9,
+          "local_col": 7,
+          "master_row": 39,
+          "master_col": 15,
+          "pixel_x": 256.1088562011719,
+          "pixel_y": 163.76690673828125
+        },
+        {
+          "local_row": 9,
+          "local_col": 8,
+          "master_row": 39,
+          "master_col": 16,
+          "pixel_x": 280.5726623535156,
+          "pixel_y": 165.85726928710938
+        },
+        {
+          "local_row": 9,
+          "local_col": 9,
+          "master_row": 39,
+          "master_col": 17,
+          "pixel_x": 305.2700500488281,
+          "pixel_y": 167.99160766601562
+        },
+        {
+          "local_row": 9,
+          "local_col": 10,
+          "master_row": 39,
+          "master_col": 18,
+          "pixel_x": 330.1786193847656,
+          "pixel_y": 170.16867065429688
+        },
+        {
+          "local_row": 9,
+          "local_col": 11,
+          "master_row": 39,
+          "master_col": 19,
+          "pixel_x": 355.2746887207031,
+          "pixel_y": 172.38702392578125
+        },
+        {
+          "local_row": 9,
+          "local_col": 12,
+          "master_row": 39,
+          "master_col": 20,
+          "pixel_x": 380.5332946777344,
+          "pixel_y": 174.64492797851562
+        },
+        {
+          "local_row": 9,
+          "local_col": 13,
+          "master_row": 39,
+          "master_col": 21,
+          "pixel_x": 405.9285888671875,
+          "pixel_y": 176.94053649902344
+        },
+        {
+          "local_row": 9,
+          "local_col": 14,
+          "master_row": 39,
+          "master_col": 22,
+          "pixel_x": 431.4341125488281,
+          "pixel_y": 179.271728515625
+        },
+        {
+          "local_row": 9,
+          "local_col": 15,
+          "master_row": 39,
+          "master_col": 23,
+          "pixel_x": 457.022705078125,
+          "pixel_y": 181.63621520996094
+        },
+        {
+          "local_row": 9,
+          "local_col": 16,
+          "master_row": 39,
+          "master_col": 24,
+          "pixel_x": 482.6672058105469,
+          "pixel_y": 184.03152465820312
+        },
+        {
+          "local_row": 9,
+          "local_col": 17,
+          "master_row": 39,
+          "master_col": 25,
+          "pixel_x": 508.340576171875,
+          "pixel_y": 186.45504760742188
+        },
+        {
+          "local_row": 9,
+          "local_col": 18,
+          "master_row": 39,
+          "master_col": 26,
+          "pixel_x": 534.0162353515625,
+          "pixel_y": 188.9040069580078
+        },
+        {
+          "local_row": 9,
+          "local_col": 19,
+          "master_row": 39,
+          "master_col": 27,
+          "pixel_x": 559.6685791015625,
+          "pixel_y": 191.3755340576172
+        },
+        {
+          "local_row": 9,
+          "local_col": 20,
+          "master_row": 39,
+          "master_col": 28,
+          "pixel_x": 585.2733154296875,
+          "pixel_y": 193.86663818359375
+        },
+        {
+          "local_row": 10,
+          "local_col": 0,
+          "master_row": 40,
+          "master_col": 8,
+          "pixel_x": 87.99189758300781,
+          "pixel_y": 168.74844360351562
+        },
+        {
+          "local_row": 10,
+          "local_col": 1,
+          "master_row": 40,
+          "master_col": 9,
+          "pixel_x": 110.64750671386719,
+          "pixel_y": 170.66275024414062
+        },
+        {
+          "local_row": 10,
+          "local_col": 2,
+          "master_row": 40,
+          "master_col": 10,
+          "pixel_x": 133.66014099121094,
+          "pixel_y": 172.62139892578125
+        },
+        {
+          "local_row": 10,
+          "local_col": 3,
+          "master_row": 40,
+          "master_col": 11,
+          "pixel_x": 157.01951599121094,
+          "pixel_y": 174.6243896484375
+        },
+        {
+          "local_row": 10,
+          "local_col": 4,
+          "master_row": 40,
+          "master_col": 12,
+          "pixel_x": 180.71322631835938,
+          "pixel_y": 176.67152404785156
+        },
+        {
+          "local_row": 10,
+          "local_col": 5,
+          "master_row": 40,
+          "master_col": 13,
+          "pixel_x": 204.72671508789062,
+          "pixel_y": 178.7622833251953
+        },
+        {
+          "local_row": 10,
+          "local_col": 6,
+          "master_row": 40,
+          "master_col": 14,
+          "pixel_x": 229.0435028076172,
+          "pixel_y": 180.89601135253906
+        },
+        {
+          "local_row": 10,
+          "local_col": 7,
+          "master_row": 40,
+          "master_col": 15,
+          "pixel_x": 253.64512634277344,
+          "pixel_y": 183.07179260253906
+        },
+        {
+          "local_row": 10,
+          "local_col": 8,
+          "master_row": 40,
+          "master_col": 16,
+          "pixel_x": 278.51129150390625,
+          "pixel_y": 185.28846740722656
+        },
+        {
+          "local_row": 10,
+          "local_col": 9,
+          "master_row": 40,
+          "master_col": 17,
+          "pixel_x": 303.6199645996094,
+          "pixel_y": 187.5446319580078
+        },
+        {
+          "local_row": 10,
+          "local_col": 10,
+          "master_row": 40,
+          "master_col": 18,
+          "pixel_x": 328.9476013183594,
+          "pixel_y": 189.8386993408203
+        },
+        {
+          "local_row": 10,
+          "local_col": 11,
+          "master_row": 40,
+          "master_col": 19,
+          "pixel_x": 354.4691467285156,
+          "pixel_y": 192.16885375976562
+        },
+        {
+          "local_row": 10,
+          "local_col": 12,
+          "master_row": 40,
+          "master_col": 20,
+          "pixel_x": 380.15838623046875,
+          "pixel_y": 194.53314208984375
+        },
+        {
+          "local_row": 10,
+          "local_col": 13,
+          "master_row": 40,
+          "master_col": 21,
+          "pixel_x": 405.98809814453125,
+          "pixel_y": 196.92929077148438
+        },
+        {
+          "local_row": 10,
+          "local_col": 14,
+          "master_row": 40,
+          "master_col": 22,
+          "pixel_x": 431.93023681640625,
+          "pixel_y": 199.35496520996094
+        },
+        {
+          "local_row": 10,
+          "local_col": 15,
+          "master_row": 40,
+          "master_col": 23,
+          "pixel_x": 457.95635986328125,
+          "pixel_y": 201.80763244628906
+        },
+        {
+          "local_row": 10,
+          "local_col": 16,
+          "master_row": 40,
+          "master_col": 24,
+          "pixel_x": 484.0377502441406,
+          "pixel_y": 204.28460693359375
+        },
+        {
+          "local_row": 10,
+          "local_col": 17,
+          "master_row": 40,
+          "master_col": 25,
+          "pixel_x": 510.1459045410156,
+          "pixel_y": 206.78311157226562
+        },
+        {
+          "local_row": 10,
+          "local_col": 18,
+          "master_row": 40,
+          "master_col": 26,
+          "pixel_x": 536.2529296875,
+          "pixel_y": 209.30027770996094
+        },
+        {
+          "local_row": 10,
+          "local_col": 19,
+          "master_row": 40,
+          "master_col": 27,
+          "pixel_x": 562.3319091796875,
+          "pixel_y": 211.83316040039062
+        },
+        {
+          "local_row": 10,
+          "local_col": 20,
+          "master_row": 40,
+          "master_col": 28,
+          "pixel_x": 588.357421875,
+          "pixel_y": 214.37875366210938
+        },
+        {
+          "local_row": 11,
+          "local_col": 0,
+          "master_row": 41,
+          "master_col": 8,
+          "pixel_x": 82.92123413085938,
+          "pixel_y": 187.6797332763672
+        },
+        {
+          "local_row": 11,
+          "local_col": 1,
+          "master_row": 41,
+          "master_col": 9,
+          "pixel_x": 105.89918518066406,
+          "pixel_y": 189.75180053710938
+        },
+        {
+          "local_row": 11,
+          "local_col": 2,
+          "master_row": 41,
+          "master_col": 10,
+          "pixel_x": 129.24822998046875,
+          "pixel_y": 191.86598205566406
+        },
+        {
+          "local_row": 11,
+          "local_col": 3,
+          "master_row": 41,
+          "master_col": 11,
+          "pixel_x": 152.95782470703125,
+          "pixel_y": 194.02194213867188
+        },
+        {
+          "local_row": 11,
+          "local_col": 4,
+          "master_row": 41,
+          "master_col": 12,
+          "pixel_x": 177.01515197753906,
+          "pixel_y": 196.21897888183594
+        },
+        {
+          "local_row": 11,
+          "local_col": 5,
+          "master_row": 41,
+          "master_col": 13,
+          "pixel_x": 201.40512084960938,
+          "pixel_y": 198.45628356933594
+        },
+        {
+          "local_row": 11,
+          "local_col": 6,
+          "master_row": 41,
+          "master_col": 14,
+          "pixel_x": 226.11056518554688,
+          "pixel_y": 200.73269653320312
+        },
+        {
+          "local_row": 11,
+          "local_col": 7,
+          "master_row": 41,
+          "master_col": 15,
+          "pixel_x": 251.11212158203125,
+          "pixel_y": 203.04689025878906
+        },
+        {
+          "local_row": 11,
+          "local_col": 8,
+          "master_row": 41,
+          "master_col": 16,
+          "pixel_x": 276.3885498046875,
+          "pixel_y": 205.39730834960938
+        },
+        {
+          "local_row": 11,
+          "local_col": 9,
+          "master_row": 41,
+          "master_col": 17,
+          "pixel_x": 301.916748046875,
+          "pixel_y": 207.7821502685547
+        },
+        {
+          "local_row": 11,
+          "local_col": 10,
+          "master_row": 41,
+          "master_col": 18,
+          "pixel_x": 327.671875,
+          "pixel_y": 210.19943237304688
+        },
+        {
+          "local_row": 11,
+          "local_col": 11,
+          "master_row": 41,
+          "master_col": 19,
+          "pixel_x": 353.6276550292969,
+          "pixel_y": 212.64695739746094
+        },
+        {
+          "local_row": 11,
+          "local_col": 12,
+          "master_row": 41,
+          "master_col": 20,
+          "pixel_x": 379.7563781738281,
+          "pixel_y": 215.12237548828125
+        },
+        {
+          "local_row": 11,
+          "local_col": 13,
+          "master_row": 41,
+          "master_col": 21,
+          "pixel_x": 406.02935791015625,
+          "pixel_y": 217.6231689453125
+        },
+        {
+          "local_row": 11,
+          "local_col": 14,
+          "master_row": 41,
+          "master_col": 22,
+          "pixel_x": 432.4171142578125,
+          "pixel_y": 220.14663696289062
+        },
+        {
+          "local_row": 11,
+          "local_col": 15,
+          "master_row": 41,
+          "master_col": 23,
+          "pixel_x": 458.8895263671875,
+          "pixel_y": 222.69000244140625
+        },
+        {
+          "local_row": 11,
+          "local_col": 16,
+          "master_row": 41,
+          "master_col": 24,
+          "pixel_x": 485.41644287109375,
+          "pixel_y": 225.25038146972656
+        },
+        {
+          "local_row": 11,
+          "local_col": 17,
+          "master_row": 41,
+          "master_col": 25,
+          "pixel_x": 511.9678955078125,
+          "pixel_y": 227.8248291015625
+        },
+        {
+          "local_row": 11,
+          "local_col": 18,
+          "master_row": 41,
+          "master_col": 26,
+          "pixel_x": 538.5145874023438,
+          "pixel_y": 230.41033935546875
+        },
+        {
+          "local_row": 11,
+          "local_col": 19,
+          "master_row": 41,
+          "master_col": 27,
+          "pixel_x": 565.0283203125,
+          "pixel_y": 233.0039520263672
+        },
+        {
+          "local_row": 11,
+          "local_col": 20,
+          "master_row": 41,
+          "master_col": 28,
+          "pixel_x": 591.4825439453125,
+          "pixel_y": 235.60272216796875
+        },
+        {
+          "local_row": 12,
+          "local_col": 0,
+          "master_row": 42,
+          "master_col": 8,
+          "pixel_x": 77.73809814453125,
+          "pixel_y": 207.23483276367188
+        },
+        {
+          "local_row": 12,
+          "local_col": 1,
+          "master_row": 42,
+          "master_col": 9,
+          "pixel_x": 101.04310607910156,
+          "pixel_y": 209.47532653808594
+        },
+        {
+          "local_row": 12,
+          "local_col": 2,
+          "master_row": 42,
+          "master_col": 10,
+          "pixel_x": 124.73370361328125,
+          "pixel_y": 211.7554931640625
+        },
+        {
+          "local_row": 12,
+          "local_col": 3,
+          "master_row": 42,
+          "master_col": 11,
+          "pixel_x": 148.79908752441406,
+          "pixel_y": 214.07455444335938
+        },
+        {
+          "local_row": 12,
+          "local_col": 4,
+          "master_row": 42,
+          "master_col": 12,
+          "pixel_x": 173.22605895996094,
+          "pixel_y": 216.4313201904297
+        },
+        {
+          "local_row": 12,
+          "local_col": 5,
+          "master_row": 42,
+          "master_col": 13,
+          "pixel_x": 197.9990234375,
+          "pixel_y": 218.82449340820312
+        },
+        {
+          "local_row": 12,
+          "local_col": 6,
+          "master_row": 42,
+          "master_col": 14,
+          "pixel_x": 223.1000213623047,
+          "pixel_y": 221.25247192382812
+        },
+        {
+          "local_row": 12,
+          "local_col": 7,
+          "master_row": 42,
+          "master_col": 15,
+          "pixel_x": 248.50885009765625,
+          "pixel_y": 223.7134246826172
+        },
+        {
+          "local_row": 12,
+          "local_col": 8,
+          "master_row": 42,
+          "master_col": 16,
+          "pixel_x": 274.2032775878906,
+          "pixel_y": 226.20533752441406
+        },
+        {
+          "local_row": 12,
+          "local_col": 9,
+          "master_row": 42,
+          "master_col": 17,
+          "pixel_x": 300.15899658203125,
+          "pixel_y": 228.72596740722656
+        },
+        {
+          "local_row": 12,
+          "local_col": 10,
+          "master_row": 42,
+          "master_col": 18,
+          "pixel_x": 326.3499450683594,
+          "pixel_y": 231.2728729248047
+        },
+        {
+          "local_row": 12,
+          "local_col": 11,
+          "master_row": 42,
+          "master_col": 19,
+          "pixel_x": 352.7484130859375,
+          "pixel_y": 233.84347534179688
+        },
+        {
+          "local_row": 12,
+          "local_col": 12,
+          "master_row": 42,
+          "master_col": 20,
+          "pixel_x": 379.32525634765625,
+          "pixel_y": 236.43499755859375
+        },
+        {
+          "local_row": 12,
+          "local_col": 13,
+          "master_row": 42,
+          "master_col": 21,
+          "pixel_x": 406.0502624511719,
+          "pixel_y": 239.04452514648438
+        },
+        {
+          "local_row": 12,
+          "local_col": 14,
+          "master_row": 42,
+          "master_col": 22,
+          "pixel_x": 432.89227294921875,
+          "pixel_y": 241.66909790039062
+        },
+        {
+          "local_row": 12,
+          "local_col": 15,
+          "master_row": 42,
+          "master_col": 23,
+          "pixel_x": 459.81964111328125,
+          "pixel_y": 244.3056182861328
+        },
+        {
+          "local_row": 12,
+          "local_col": 16,
+          "master_row": 42,
+          "master_col": 24,
+          "pixel_x": 486.8006591796875,
+          "pixel_y": 246.9509735107422
+        },
+        {
+          "local_row": 12,
+          "local_col": 17,
+          "master_row": 42,
+          "master_col": 25,
+          "pixel_x": 513.8037719726562,
+          "pixel_y": 249.6020965576172
+        },
+        {
+          "local_row": 12,
+          "local_col": 18,
+          "master_row": 42,
+          "master_col": 26,
+          "pixel_x": 540.7982177734375,
+          "pixel_y": 252.25588989257812
+        },
+        {
+          "local_row": 12,
+          "local_col": 19,
+          "master_row": 42,
+          "master_col": 27,
+          "pixel_x": 567.7545166015625,
+          "pixel_y": 254.9093780517578
+        },
+        {
+          "local_row": 12,
+          "local_col": 20,
+          "master_row": 42,
+          "master_col": 28,
+          "pixel_x": 594.6452026367188,
+          "pixel_y": 257.55975341796875
+        },
+        {
+          "local_row": 13,
+          "local_col": 0,
+          "master_row": 43,
+          "master_col": 8,
+          "pixel_x": 72.44302368164062,
+          "pixel_y": 227.43141174316406
+        },
+        {
+          "local_row": 13,
+          "local_col": 1,
+          "master_row": 43,
+          "master_col": 9,
+          "pixel_x": 96.07963562011719,
+          "pixel_y": 229.8514862060547
+        },
+        {
+          "local_row": 13,
+          "local_col": 2,
+          "master_row": 43,
+          "master_col": 10,
+          "pixel_x": 120.11671447753906,
+          "pixel_y": 232.30859375
+        },
+        {
+          "local_row": 13,
+          "local_col": 3,
+          "master_row": 43,
+          "master_col": 11,
+          "pixel_x": 144.5432891845703,
+          "pixel_y": 234.80133056640625
+        },
+        {
+          "local_row": 13,
+          "local_col": 4,
+          "master_row": 43,
+          "master_col": 12,
+          "pixel_x": 169.34579467773438,
+          "pixel_y": 237.3280487060547
+        },
+        {
+          "local_row": 13,
+          "local_col": 5,
+          "master_row": 43,
+          "master_col": 13,
+          "pixel_x": 194.50802612304688,
+          "pixel_y": 239.8868865966797
+        },
+        {
+          "local_row": 13,
+          "local_col": 6,
+          "master_row": 43,
+          "master_col": 14,
+          "pixel_x": 220.01129150390625,
+          "pixel_y": 242.4756622314453
+        },
+        {
+          "local_row": 13,
+          "local_col": 7,
+          "master_row": 43,
+          "master_col": 15,
+          "pixel_x": 245.83456420898438,
+          "pixel_y": 245.09207153320312
+        },
+        {
+          "local_row": 13,
+          "local_col": 8,
+          "master_row": 43,
+          "master_col": 16,
+          "pixel_x": 271.9544372558594,
+          "pixel_y": 247.73353576660156
+        },
+        {
+          "local_row": 13,
+          "local_col": 9,
+          "master_row": 43,
+          "master_col": 17,
+          "pixel_x": 298.3454895019531,
+          "pixel_y": 250.39732360839844
+        },
+        {
+          "local_row": 13,
+          "local_col": 10,
+          "master_row": 43,
+          "master_col": 18,
+          "pixel_x": 324.98028564453125,
+          "pixel_y": 253.0804901123047
+        },
+        {
+          "local_row": 13,
+          "local_col": 11,
+          "master_row": 43,
+          "master_col": 19,
+          "pixel_x": 351.8296813964844,
+          "pixel_y": 255.77996826171875
+        },
+        {
+          "local_row": 13,
+          "local_col": 12,
+          "master_row": 43,
+          "master_col": 20,
+          "pixel_x": 378.863037109375,
+          "pixel_y": 258.4925842285156
+        },
+        {
+          "local_row": 13,
+          "local_col": 13,
+          "master_row": 43,
+          "master_col": 21,
+          "pixel_x": 406.0484619140625,
+          "pixel_y": 261.2149963378906
+        },
+        {
+          "local_row": 13,
+          "local_col": 14,
+          "master_row": 43,
+          "master_col": 22,
+          "pixel_x": 433.35321044921875,
+          "pixel_y": 263.94390869140625
+        },
+        {
+          "local_row": 13,
+          "local_col": 15,
+          "master_row": 43,
+          "master_col": 23,
+          "pixel_x": 460.743896484375,
+          "pixel_y": 266.67596435546875
+        },
+        {
+          "local_row": 13,
+          "local_col": 16,
+          "master_row": 43,
+          "master_col": 24,
+          "pixel_x": 488.18719482421875,
+          "pixel_y": 269.4078063964844
+        },
+        {
+          "local_row": 13,
+          "local_col": 17,
+          "master_row": 43,
+          "master_col": 25,
+          "pixel_x": 515.6500244140625,
+          "pixel_y": 272.1361389160156
+        },
+        {
+          "local_row": 13,
+          "local_col": 18,
+          "master_row": 43,
+          "master_col": 26,
+          "pixel_x": 543.10009765625,
+          "pixel_y": 274.85791015625
+        },
+        {
+          "local_row": 13,
+          "local_col": 19,
+          "master_row": 43,
+          "master_col": 27,
+          "pixel_x": 570.5066528320312,
+          "pixel_y": 277.5701904296875
+        },
+        {
+          "local_row": 13,
+          "local_col": 20,
+          "master_row": 43,
+          "master_col": 28,
+          "pixel_x": 597.84130859375,
+          "pixel_y": 280.2702941894531
+        },
+        {
+          "local_row": 14,
+          "local_col": 0,
+          "master_row": 44,
+          "master_col": 8,
+          "pixel_x": 67.03694152832031,
+          "pixel_y": 248.2865447998047
+        },
+        {
+          "local_row": 14,
+          "local_col": 1,
+          "master_row": 44,
+          "master_col": 9,
+          "pixel_x": 91.00953674316406,
+          "pixel_y": 250.89784240722656
+        },
+        {
+          "local_row": 14,
+          "local_col": 2,
+          "master_row": 44,
+          "master_col": 10,
+          "pixel_x": 115.39791870117188,
+          "pixel_y": 253.54324340820312
+        },
+        {
+          "local_row": 14,
+          "local_col": 3,
+          "master_row": 44,
+          "master_col": 11,
+          "pixel_x": 140.19091796875,
+          "pixel_y": 256.220703125
+        },
+        {
+          "local_row": 14,
+          "local_col": 4,
+          "master_row": 44,
+          "master_col": 12,
+          "pixel_x": 165.37457275390625,
+          "pixel_y": 258.9280090332031
+        },
+        {
+          "local_row": 14,
+          "local_col": 5,
+          "master_row": 44,
+          "master_col": 13,
+          "pixel_x": 190.93211364746094,
+          "pixel_y": 261.66265869140625
+        },
+        {
+          "local_row": 14,
+          "local_col": 6,
+          "master_row": 44,
+          "master_col": 14,
+          "pixel_x": 216.8441162109375,
+          "pixel_y": 264.421875
+        },
+        {
+          "local_row": 14,
+          "local_col": 7,
+          "master_row": 44,
+          "master_col": 15,
+          "pixel_x": 243.088623046875,
+          "pixel_y": 267.2027587890625
+        },
+        {
+          "local_row": 14,
+          "local_col": 8,
+          "master_row": 44,
+          "master_col": 16,
+          "pixel_x": 269.64117431640625,
+          "pixel_y": 270.0021057128906
+        },
+        {
+          "local_row": 14,
+          "local_col": 9,
+          "master_row": 44,
+          "master_col": 17,
+          "pixel_x": 296.47503662109375,
+          "pixel_y": 272.8166198730469
+        },
+        {
+          "local_row": 14,
+          "local_col": 10,
+          "master_row": 44,
+          "master_col": 18,
+          "pixel_x": 323.56146240234375,
+          "pixel_y": 275.642822265625
+        },
+        {
+          "local_row": 14,
+          "local_col": 11,
+          "master_row": 44,
+          "master_col": 19,
+          "pixel_x": 350.8697204589844,
+          "pixel_y": 278.4771728515625
+        },
+        {
+          "local_row": 14,
+          "local_col": 12,
+          "master_row": 44,
+          "master_col": 20,
+          "pixel_x": 378.3676452636719,
+          "pixel_y": 281.31591796875
+        },
+        {
+          "local_row": 14,
+          "local_col": 13,
+          "master_row": 44,
+          "master_col": 21,
+          "pixel_x": 406.0216064453125,
+          "pixel_y": 284.1553955078125
+        },
+        {
+          "local_row": 14,
+          "local_col": 14,
+          "master_row": 44,
+          "master_col": 22,
+          "pixel_x": 433.797119140625,
+          "pixel_y": 286.9918518066406
+        },
+        {
+          "local_row": 14,
+          "local_col": 15,
+          "master_row": 44,
+          "master_col": 23,
+          "pixel_x": 461.6591491699219,
+          "pixel_y": 289.8216552734375
+        },
+        {
+          "local_row": 14,
+          "local_col": 16,
+          "master_row": 44,
+          "master_col": 24,
+          "pixel_x": 489.5726623535156,
+          "pixel_y": 292.6412353515625
+        },
+        {
+          "local_row": 14,
+          "local_col": 17,
+          "master_row": 44,
+          "master_col": 25,
+          "pixel_x": 517.5028686523438,
+          "pixel_y": 295.44720458984375
+        },
+        {
+          "local_row": 14,
+          "local_col": 18,
+          "master_row": 44,
+          "master_col": 26,
+          "pixel_x": 545.4161376953125,
+          "pixel_y": 298.2364501953125
+        },
+        {
+          "local_row": 14,
+          "local_col": 19,
+          "master_row": 44,
+          "master_col": 27,
+          "pixel_x": 573.2805786132812,
+          "pixel_y": 301.0061340332031
+        },
+        {
+          "local_row": 14,
+          "local_col": 20,
+          "master_row": 44,
+          "master_col": 28,
+          "pixel_x": 601.0665283203125,
+          "pixel_y": 303.75384521484375
+        },
+        {
+          "local_row": 15,
+          "local_col": 0,
+          "master_row": 45,
+          "master_col": 8,
+          "pixel_x": 61.52117919921875,
+          "pixel_y": 269.81658935546875
+        },
+        {
+          "local_row": 15,
+          "local_col": 1,
+          "master_row": 45,
+          "master_col": 9,
+          "pixel_x": 85.83409118652344,
+          "pixel_y": 272.63116455078125
+        },
+        {
+          "local_row": 15,
+          "local_col": 2,
+          "master_row": 45,
+          "master_col": 10,
+          "pixel_x": 110.57838439941406,
+          "pixel_y": 275.4765930175781
+        },
+        {
+          "local_row": 15,
+          "local_col": 3,
+          "master_row": 45,
+          "master_col": 11,
+          "pixel_x": 135.74278259277344,
+          "pixel_y": 278.3502197265625
+        },
+        {
+          "local_row": 15,
+          "local_col": 4,
+          "master_row": 45,
+          "master_col": 12,
+          "pixel_x": 161.3129425048828,
+          "pixel_y": 281.2491149902344
+        },
+        {
+          "local_row": 15,
+          "local_col": 5,
+          "master_row": 45,
+          "master_col": 13,
+          "pixel_x": 187.2715606689453,
+          "pixel_y": 284.1700744628906
+        },
+        {
+          "local_row": 15,
+          "local_col": 6,
+          "master_row": 45,
+          "master_col": 14,
+          "pixel_x": 213.5984649658203,
+          "pixel_y": 287.1097106933594
+        },
+        {
+          "local_row": 15,
+          "local_col": 7,
+          "master_row": 45,
+          "master_col": 15,
+          "pixel_x": 240.27072143554688,
+          "pixel_y": 290.0643005371094
+        },
+        {
+          "local_row": 15,
+          "local_col": 8,
+          "master_row": 45,
+          "master_col": 16,
+          "pixel_x": 267.2627868652344,
+          "pixel_y": 293.03009033203125
+        },
+        {
+          "local_row": 15,
+          "local_col": 9,
+          "master_row": 45,
+          "master_col": 17,
+          "pixel_x": 294.5466003417969,
+          "pixel_y": 296.003173828125
+        },
+        {
+          "local_row": 15,
+          "local_col": 10,
+          "master_row": 45,
+          "master_col": 18,
+          "pixel_x": 322.0920104980469,
+          "pixel_y": 298.9793395996094
+        },
+        {
+          "local_row": 15,
+          "local_col": 11,
+          "master_row": 45,
+          "master_col": 19,
+          "pixel_x": 349.86676025390625,
+          "pixel_y": 301.95452880859375
+        },
+        {
+          "local_row": 15,
+          "local_col": 12,
+          "master_row": 45,
+          "master_col": 20,
+          "pixel_x": 377.8368225097656,
+          "pixel_y": 304.924560546875
+        },
+        {
+          "local_row": 15,
+          "local_col": 13,
+          "master_row": 45,
+          "master_col": 21,
+          "pixel_x": 405.967041015625,
+          "pixel_y": 307.8851318359375
+        },
+        {
+          "local_row": 15,
+          "local_col": 14,
+          "master_row": 45,
+          "master_col": 22,
+          "pixel_x": 434.2210388183594,
+          "pixel_y": 310.832275390625
+        },
+        {
+          "local_row": 15,
+          "local_col": 15,
+          "master_row": 45,
+          "master_col": 23,
+          "pixel_x": 462.56207275390625,
+          "pixel_y": 313.7619323730469
+        },
+        {
+          "local_row": 15,
+          "local_col": 16,
+          "master_row": 45,
+          "master_col": 24,
+          "pixel_x": 490.9532470703125,
+          "pixel_y": 316.67041015625
+        },
+        {
+          "local_row": 15,
+          "local_col": 17,
+          "master_row": 45,
+          "master_col": 25,
+          "pixel_x": 519.3582763671875,
+          "pixel_y": 319.5541687011719
+        },
+        {
+          "local_row": 15,
+          "local_col": 18,
+          "master_row": 45,
+          "master_col": 26,
+          "pixel_x": 547.7421264648438,
+          "pixel_y": 322.41015625
+        },
+        {
+          "local_row": 15,
+          "local_col": 19,
+          "master_row": 45,
+          "master_col": 27,
+          "pixel_x": 576.071533203125,
+          "pixel_y": 325.2357482910156
+        },
+        {
+          "local_row": 15,
+          "local_col": 20,
+          "master_row": 45,
+          "master_col": 28,
+          "pixel_x": 604.3160400390625,
+          "pixel_y": 328.0289001464844
+        },
+        {
+          "local_row": 16,
+          "local_col": 0,
+          "master_row": 46,
+          "master_col": 8,
+          "pixel_x": 55.897552490234375,
+          "pixel_y": 292.0369873046875
+        },
+        {
+          "local_row": 16,
+          "local_col": 1,
+          "master_row": 46,
+          "master_col": 9,
+          "pixel_x": 80.554931640625,
+          "pixel_y": 295.0671691894531
+        },
+        {
+          "local_row": 16,
+          "local_col": 2,
+          "master_row": 46,
+          "master_col": 10,
+          "pixel_x": 105.65957641601562,
+          "pixel_y": 298.124755859375
+        },
+        {
+          "local_row": 16,
+          "local_col": 3,
+          "master_row": 46,
+          "master_col": 11,
+          "pixel_x": 131.20013427734375,
+          "pixel_y": 301.206298828125
+        },
+        {
+          "local_row": 16,
+          "local_col": 4,
+          "master_row": 46,
+          "master_col": 12,
+          "pixel_x": 157.16189575195312,
+          "pixel_y": 304.30816650390625
+        },
+        {
+          "local_row": 16,
+          "local_col": 5,
+          "master_row": 46,
+          "master_col": 13,
+          "pixel_x": 183.5270538330078,
+          "pixel_y": 307.4262390136719
+        },
+        {
+          "local_row": 16,
+          "local_col": 6,
+          "master_row": 46,
+          "master_col": 14,
+          "pixel_x": 210.274658203125,
+          "pixel_y": 310.556396484375
+        },
+        {
+          "local_row": 16,
+          "local_col": 7,
+          "master_row": 46,
+          "master_col": 15,
+          "pixel_x": 237.38082885742188,
+          "pixel_y": 313.69427490234375
+        },
+        {
+          "local_row": 16,
+          "local_col": 8,
+          "master_row": 46,
+          "master_col": 16,
+          "pixel_x": 264.8188171386719,
+          "pixel_y": 316.8353271484375
+        },
+        {
+          "local_row": 16,
+          "local_col": 9,
+          "master_row": 46,
+          "master_col": 17,
+          "pixel_x": 292.5593566894531,
+          "pixel_y": 319.9748229980469
+        },
+        {
+          "local_row": 16,
+          "local_col": 10,
+          "master_row": 46,
+          "master_col": 18,
+          "pixel_x": 320.5706787109375,
+          "pixel_y": 323.1080322265625
+        },
+        {
+          "local_row": 16,
+          "local_col": 11,
+          "master_row": 46,
+          "master_col": 19,
+          "pixel_x": 348.8188781738281,
+          "pixel_y": 326.23016357421875
+        },
+        {
+          "local_row": 16,
+          "local_col": 12,
+          "master_row": 46,
+          "master_col": 20,
+          "pixel_x": 377.2684020996094,
+          "pixel_y": 329.3365173339844
+        },
+        {
+          "local_row": 16,
+          "local_col": 13,
+          "master_row": 46,
+          "master_col": 21,
+          "pixel_x": 405.8820495605469,
+          "pixel_y": 332.42230224609375
+        },
+        {
+          "local_row": 16,
+          "local_col": 14,
+          "master_row": 46,
+          "master_col": 22,
+          "pixel_x": 434.62176513671875,
+          "pixel_y": 335.483154296875
+        },
+        {
+          "local_row": 16,
+          "local_col": 15,
+          "master_row": 46,
+          "master_col": 23,
+          "pixel_x": 463.44891357421875,
+          "pixel_y": 338.5146789550781
+        },
+        {
+          "local_row": 16,
+          "local_col": 16,
+          "master_row": 46,
+          "master_col": 24,
+          "pixel_x": 492.324951171875,
+          "pixel_y": 341.51300048828125
+        },
+        {
+          "local_row": 16,
+          "local_col": 17,
+          "master_row": 46,
+          "master_col": 25,
+          "pixel_x": 521.2118530273438,
+          "pixel_y": 344.47454833984375
+        },
+        {
+          "local_row": 16,
+          "local_col": 18,
+          "master_row": 46,
+          "master_col": 26,
+          "pixel_x": 550.0731811523438,
+          "pixel_y": 347.39642333984375
+        },
+        {
+          "local_row": 16,
+          "local_col": 19,
+          "master_row": 46,
+          "master_col": 27,
+          "pixel_x": 578.8746337890625,
+          "pixel_y": 350.2762451171875
+        },
+        {
+          "local_row": 16,
+          "local_col": 20,
+          "master_row": 46,
+          "master_col": 28,
+          "pixel_x": 607.5848388671875,
+          "pixel_y": 353.1125183105469
+        },
+        {
+          "local_row": 17,
+          "local_col": 0,
+          "master_row": 47,
+          "master_col": 8,
+          "pixel_x": 50.168243408203125,
+          "pixel_y": 314.9621887207031
+        },
+        {
+          "local_row": 17,
+          "local_col": 1,
+          "master_row": 47,
+          "master_col": 9,
+          "pixel_x": 75.1741943359375,
+          "pixel_y": 318.22052001953125
+        },
+        {
+          "local_row": 17,
+          "local_col": 2,
+          "master_row": 47,
+          "master_col": 10,
+          "pixel_x": 100.64349365234375,
+          "pixel_y": 321.50262451171875
+        },
+        {
+          "local_row": 17,
+          "local_col": 3,
+          "master_row": 47,
+          "master_col": 11,
+          "pixel_x": 126.56468200683594,
+          "pixel_y": 324.80413818359375
+        },
+        {
+          "local_row": 17,
+          "local_col": 4,
+          "master_row": 47,
+          "master_col": 12,
+          "pixel_x": 152.92288208007812,
+          "pixel_y": 328.1204528808594
+        },
+        {
+          "local_row": 17,
+          "local_col": 5,
+          "master_row": 47,
+          "master_col": 13,
+          "pixel_x": 179.69964599609375,
+          "pixel_y": 331.44671630859375
+        },
+        {
+          "local_row": 17,
+          "local_col": 6,
+          "master_row": 47,
+          "master_col": 14,
+          "pixel_x": 206.87338256835938,
+          "pixel_y": 334.7779235839844
+        },
+        {
+          "local_row": 17,
+          "local_col": 7,
+          "master_row": 47,
+          "master_col": 15,
+          "pixel_x": 234.41915893554688,
+          "pixel_y": 338.1087646484375
+        },
+        {
+          "local_row": 17,
+          "local_col": 8,
+          "master_row": 47,
+          "master_col": 16,
+          "pixel_x": 262.3091125488281,
+          "pixel_y": 341.43389892578125
+        },
+        {
+          "local_row": 17,
+          "local_col": 9,
+          "master_row": 47,
+          "master_col": 17,
+          "pixel_x": 290.5125427246094,
+          "pixel_y": 344.74786376953125
+        },
+        {
+          "local_row": 17,
+          "local_col": 10,
+          "master_row": 47,
+          "master_col": 18,
+          "pixel_x": 318.9961853027344,
+          "pixel_y": 348.0451965332031
+        },
+        {
+          "local_row": 17,
+          "local_col": 11,
+          "master_row": 47,
+          "master_col": 19,
+          "pixel_x": 347.7244567871094,
+          "pixel_y": 351.3204040527344
+        },
+        {
+          "local_row": 17,
+          "local_col": 12,
+          "master_row": 47,
+          "master_col": 20,
+          "pixel_x": 376.6600036621094,
+          "pixel_y": 354.5680847167969
+        },
+        {
+          "local_row": 17,
+          "local_col": 13,
+          "master_row": 47,
+          "master_col": 21,
+          "pixel_x": 405.76385498046875,
+          "pixel_y": 357.7831115722656
+        },
+        {
+          "local_row": 17,
+          "local_col": 14,
+          "master_row": 47,
+          "master_col": 22,
+          "pixel_x": 434.9959716796875,
+          "pixel_y": 360.9605407714844
+        },
+        {
+          "local_row": 17,
+          "local_col": 15,
+          "master_row": 47,
+          "master_col": 23,
+          "pixel_x": 464.31591796875,
+          "pixel_y": 364.0958251953125
+        },
+        {
+          "local_row": 17,
+          "local_col": 16,
+          "master_row": 47,
+          "master_col": 24,
+          "pixel_x": 493.683349609375,
+          "pixel_y": 367.184814453125
+        },
+        {
+          "local_row": 17,
+          "local_col": 17,
+          "master_row": 47,
+          "master_col": 25,
+          "pixel_x": 523.0587768554688,
+          "pixel_y": 370.2240905761719
+        },
+        {
+          "local_row": 17,
+          "local_col": 18,
+          "master_row": 47,
+          "master_col": 26,
+          "pixel_x": 552.4042358398438,
+          "pixel_y": 373.21087646484375
+        },
+        {
+          "local_row": 17,
+          "local_col": 19,
+          "master_row": 47,
+          "master_col": 27,
+          "pixel_x": 581.6845092773438,
+          "pixel_y": 376.143310546875
+        },
+        {
+          "local_row": 17,
+          "local_col": 20,
+          "master_row": 47,
+          "master_col": 28,
+          "pixel_x": 610.86767578125,
+          "pixel_y": 379.0205078125
+        },
+        {
+          "local_row": 18,
+          "local_col": 0,
+          "master_row": 48,
+          "master_col": 8,
+          "pixel_x": 44.335784912109375,
+          "pixel_y": 338.6054382324219
+        },
+        {
+          "local_row": 18,
+          "local_col": 1,
+          "master_row": 48,
+          "master_col": 9,
+          "pixel_x": 69.69432067871094,
+          "pixel_y": 342.1046447753906
+        },
+        {
+          "local_row": 18,
+          "local_col": 2,
+          "master_row": 48,
+          "master_col": 10,
+          "pixel_x": 95.53239440917969,
+          "pixel_y": 345.62371826171875
+        },
+        {
+          "local_row": 18,
+          "local_col": 3,
+          "master_row": 48,
+          "master_col": 11,
+          "pixel_x": 121.83856201171875,
+          "pixel_y": 349.1573181152344
+        },
+        {
+          "local_row": 18,
+          "local_col": 4,
+          "master_row": 48,
+          "master_col": 12,
+          "pixel_x": 148.59765625,
+          "pixel_y": 352.6998291015625
+        },
+        {
+          "local_row": 18,
+          "local_col": 5,
+          "master_row": 48,
+          "master_col": 13,
+          "pixel_x": 175.7908172607422,
+          "pixel_y": 356.2454528808594
+        },
+        {
+          "local_row": 18,
+          "local_col": 6,
+          "master_row": 48,
+          "master_col": 14,
+          "pixel_x": 203.3956298828125,
+          "pixel_y": 359.7882080078125
+        },
+        {
+          "local_row": 18,
+          "local_col": 7,
+          "master_row": 48,
+          "master_col": 15,
+          "pixel_x": 231.3862762451172,
+          "pixel_y": 363.3218078613281
+        },
+        {
+          "local_row": 18,
+          "local_col": 8,
+          "master_row": 48,
+          "master_col": 16,
+          "pixel_x": 259.733642578125,
+          "pixel_y": 366.84002685546875
+        },
+        {
+          "local_row": 18,
+          "local_col": 9,
+          "master_row": 48,
+          "master_col": 17,
+          "pixel_x": 288.4056091308594,
+          "pixel_y": 370.3365478515625
+        },
+        {
+          "local_row": 18,
+          "local_col": 10,
+          "master_row": 48,
+          "master_col": 18,
+          "pixel_x": 317.3674011230469,
+          "pixel_y": 373.80511474609375
+        },
+        {
+          "local_row": 18,
+          "local_col": 11,
+          "master_row": 48,
+          "master_col": 19,
+          "pixel_x": 346.5817565917969,
+          "pixel_y": 377.2393798828125
+        },
+        {
+          "local_row": 18,
+          "local_col": 12,
+          "master_row": 48,
+          "master_col": 20,
+          "pixel_x": 376.0093688964844,
+          "pixel_y": 380.63348388671875
+        },
+        {
+          "local_row": 18,
+          "local_col": 13,
+          "master_row": 48,
+          "master_col": 21,
+          "pixel_x": 405.60943603515625,
+          "pixel_y": 383.98162841796875
+        },
+        {
+          "local_row": 18,
+          "local_col": 14,
+          "master_row": 48,
+          "master_col": 22,
+          "pixel_x": 435.340087890625,
+          "pixel_y": 387.2784729003906
+        },
+        {
+          "local_row": 18,
+          "local_col": 15,
+          "master_row": 48,
+          "master_col": 23,
+          "pixel_x": 465.158935546875,
+          "pixel_y": 390.51922607421875
+        },
+        {
+          "local_row": 18,
+          "local_col": 16,
+          "master_row": 48,
+          "master_col": 24,
+          "pixel_x": 495.02392578125,
+          "pixel_y": 393.69970703125
+        },
+        {
+          "local_row": 18,
+          "local_col": 17,
+          "master_row": 48,
+          "master_col": 25,
+          "pixel_x": 524.89404296875,
+          "pixel_y": 396.81658935546875
+        },
+        {
+          "local_row": 18,
+          "local_col": 18,
+          "master_row": 48,
+          "master_col": 26,
+          "pixel_x": 554.7301025390625,
+          "pixel_y": 399.867431640625
+        },
+        {
+          "local_row": 18,
+          "local_col": 19,
+          "master_row": 48,
+          "master_col": 27,
+          "pixel_x": 584.4959716796875,
+          "pixel_y": 402.85101318359375
+        },
+        {
+          "local_row": 18,
+          "local_col": 20,
+          "master_row": 48,
+          "master_col": 28,
+          "pixel_x": 614.1596069335938,
+          "pixel_y": 405.76739501953125
+        },
+        {
+          "local_row": 19,
+          "local_col": 0,
+          "master_row": 49,
+          "master_col": 8,
+          "pixel_x": 38.402862548828125,
+          "pixel_y": 362.978759765625
+        },
+        {
+          "local_row": 19,
+          "local_col": 1,
+          "master_row": 49,
+          "master_col": 9,
+          "pixel_x": 64.11810302734375,
+          "pixel_y": 366.73150634765625
+        },
+        {
+          "local_row": 19,
+          "local_col": 2,
+          "master_row": 49,
+          "master_col": 10,
+          "pixel_x": 90.32902526855469,
+          "pixel_y": 370.5
+        },
+        {
+          "local_row": 19,
+          "local_col": 3,
+          "master_row": 49,
+          "master_col": 11,
+          "pixel_x": 117.02424621582031,
+          "pixel_y": 374.27783203125
+        },
+        {
+          "local_row": 19,
+          "local_col": 4,
+          "master_row": 49,
+          "master_col": 12,
+          "pixel_x": 144.1884765625,
+          "pixel_y": 378.05828857421875
+        },
+        {
+          "local_row": 19,
+          "local_col": 5,
+          "master_row": 49,
+          "master_col": 13,
+          "pixel_x": 171.8023681640625,
+          "pixel_y": 381.83447265625
+        },
+        {
+          "local_row": 19,
+          "local_col": 6,
+          "master_row": 49,
+          "master_col": 14,
+          "pixel_x": 199.8428192138672,
+          "pixel_y": 385.59930419921875
+        },
+        {
+          "local_row": 19,
+          "local_col": 7,
+          "master_row": 49,
+          "master_col": 15,
+          "pixel_x": 228.28302001953125,
+          "pixel_y": 389.3454895019531
+        },
+        {
+          "local_row": 19,
+          "local_col": 8,
+          "master_row": 49,
+          "master_col": 16,
+          "pixel_x": 257.0926513671875,
+          "pixel_y": 393.0657958984375
+        },
+        {
+          "local_row": 19,
+          "local_col": 9,
+          "master_row": 49,
+          "master_col": 17,
+          "pixel_x": 286.23828125,
+          "pixel_y": 396.7529296875
+        },
+        {
+          "local_row": 19,
+          "local_col": 10,
+          "master_row": 49,
+          "master_col": 18,
+          "pixel_x": 315.68341064453125,
+          "pixel_y": 400.3996887207031
+        },
+        {
+          "local_row": 19,
+          "local_col": 11,
+          "master_row": 49,
+          "master_col": 19,
+          "pixel_x": 345.38909912109375,
+          "pixel_y": 403.9991455078125
+        },
+        {
+          "local_row": 19,
+          "local_col": 12,
+          "master_row": 49,
+          "master_col": 20,
+          "pixel_x": 375.314208984375,
+          "pixel_y": 407.5445251464844
+        },
+        {
+          "local_row": 19,
+          "local_col": 13,
+          "master_row": 49,
+          "master_col": 21,
+          "pixel_x": 405.4159240722656,
+          "pixel_y": 411.0295715332031
+        },
+        {
+          "local_row": 19,
+          "local_col": 14,
+          "master_row": 49,
+          "master_col": 22,
+          "pixel_x": 435.6505432128906,
+          "pixel_y": 414.4486389160156
+        },
+        {
+          "local_row": 19,
+          "local_col": 15,
+          "master_row": 49,
+          "master_col": 23,
+          "pixel_x": 465.97381591796875,
+          "pixel_y": 417.796630859375
+        },
+        {
+          "local_row": 19,
+          "local_col": 16,
+          "master_row": 49,
+          "master_col": 24,
+          "pixel_x": 496.342041015625,
+          "pixel_y": 421.0694580078125
+        },
+        {
+          "local_row": 19,
+          "local_col": 17,
+          "master_row": 49,
+          "master_col": 25,
+          "pixel_x": 526.7127075195312,
+          "pixel_y": 424.263916015625
+        },
+        {
+          "local_row": 19,
+          "local_col": 18,
+          "master_row": 49,
+          "master_col": 26,
+          "pixel_x": 557.045654296875,
+          "pixel_y": 427.37823486328125
+        },
+        {
+          "local_row": 19,
+          "local_col": 19,
+          "master_row": 49,
+          "master_col": 27,
+          "pixel_x": 587.3040771484375,
+          "pixel_y": 430.4120178222656
+        },
+        {
+          "local_row": 19,
+          "local_col": 20,
+          "master_row": 49,
+          "master_col": 28,
+          "pixel_x": 617.455810546875,
+          "pixel_y": 433.36663818359375
+        },
+        {
+          "local_row": 20,
+          "local_col": 0,
+          "master_row": 50,
+          "master_col": 8,
+          "pixel_x": 32.372283935546875,
+          "pixel_y": 388.09307861328125
+        },
+        {
+          "local_row": 20,
+          "local_col": 1,
+          "master_row": 50,
+          "master_col": 9,
+          "pixel_x": 58.448516845703125,
+          "pixel_y": 392.1116943359375
+        },
+        {
+          "local_row": 20,
+          "local_col": 2,
+          "master_row": 50,
+          "master_col": 10,
+          "pixel_x": 85.03628540039062,
+          "pixel_y": 396.1418762207031
+        },
+        {
+          "local_row": 20,
+          "local_col": 3,
+          "master_row": 50,
+          "master_col": 11,
+          "pixel_x": 112.12454223632812,
+          "pixel_y": 400.1759033203125
+        },
+        {
+          "local_row": 20,
+          "local_col": 4,
+          "master_row": 50,
+          "master_col": 12,
+          "pixel_x": 139.69781494140625,
+          "pixel_y": 404.2059631347656
+        },
+        {
+          "local_row": 20,
+          "local_col": 5,
+          "master_row": 50,
+          "master_col": 13,
+          "pixel_x": 167.7364501953125,
+          "pixel_y": 408.2237548828125
+        },
+        {
+          "local_row": 20,
+          "local_col": 6,
+          "master_row": 50,
+          "master_col": 14,
+          "pixel_x": 196.21658325195312,
+          "pixel_y": 412.22113037109375
+        },
+        {
+          "local_row": 20,
+          "local_col": 7,
+          "master_row": 50,
+          "master_col": 15,
+          "pixel_x": 225.11053466796875,
+          "pixel_y": 416.1896057128906
+        },
+        {
+          "local_row": 20,
+          "local_col": 8,
+          "master_row": 50,
+          "master_col": 16,
+          "pixel_x": 254.38677978515625,
+          "pixel_y": 420.120849609375
+        },
+        {
+          "local_row": 20,
+          "local_col": 9,
+          "master_row": 50,
+          "master_col": 17,
+          "pixel_x": 284.01043701171875,
+          "pixel_y": 424.00653076171875
+        },
+        {
+          "local_row": 20,
+          "local_col": 10,
+          "master_row": 50,
+          "master_col": 18,
+          "pixel_x": 313.94342041015625,
+          "pixel_y": 427.8385009765625
+        },
+        {
+          "local_row": 20,
+          "local_col": 11,
+          "master_row": 50,
+          "master_col": 19,
+          "pixel_x": 344.1449890136719,
+          "pixel_y": 431.60894775390625
+        },
+        {
+          "local_row": 20,
+          "local_col": 12,
+          "master_row": 50,
+          "master_col": 20,
+          "pixel_x": 374.5721740722656,
+          "pixel_y": 435.31048583984375
+        },
+        {
+          "local_row": 20,
+          "local_col": 13,
+          "master_row": 50,
+          "master_col": 21,
+          "pixel_x": 405.1802978515625,
+          "pixel_y": 438.93634033203125
+        },
+        {
+          "local_row": 20,
+          "local_col": 14,
+          "master_row": 50,
+          "master_col": 22,
+          "pixel_x": 435.9237060546875,
+          "pixel_y": 442.4803466796875
+        },
+        {
+          "local_row": 20,
+          "local_col": 15,
+          "master_row": 50,
+          "master_col": 23,
+          "pixel_x": 466.75640869140625,
+          "pixel_y": 445.93743896484375
+        },
+        {
+          "local_row": 20,
+          "local_col": 16,
+          "master_row": 50,
+          "master_col": 24,
+          "pixel_x": 497.63311767578125,
+          "pixel_y": 449.3036193847656
+        },
+        {
+          "local_row": 20,
+          "local_col": 17,
+          "master_row": 50,
+          "master_col": 25,
+          "pixel_x": 528.5099487304688,
+          "pixel_y": 452.57611083984375
+        },
+        {
+          "local_row": 20,
+          "local_col": 18,
+          "master_row": 50,
+          "master_col": 26,
+          "pixel_x": 559.3460693359375,
+          "pixel_y": 455.75396728515625
+        },
+        {
+          "local_row": 20,
+          "local_col": 19,
+          "master_row": 50,
+          "master_col": 27,
+          "pixel_x": 590.1041870117188,
+          "pixel_y": 458.83795166015625
+        },
+        {
+          "local_row": 20,
+          "local_col": 20,
+          "master_row": 50,
+          "master_col": 28,
+          "pixel_x": 620.7528076171875,
+          "pixel_y": 461.8310546875
+        }
+      ]
+    },
+    {
+      "name": "small_rotated_fragment",
+      "seed": 49155,
+      "rows": 9,
+      "cols": 9,
+      "origin_row": 453,
+      "origin_col": 376,
+      "texture_px_per_square": 72,
+      "image_width": 640,
+      "image_height": 480,
+      "quad": [
+        [
+          186.0,
+          22.0
+        ],
+        [
+          504.0,
+          84.0
+        ],
+        [
+          444.0,
+          394.0
+        ],
+        [
+          112.0,
+          320.0
+        ]
+      ],
+      "k1": -0.045,
+      "k2": 0.006,
+      "blur_sigma": 0.45,
+      "noise_sigma": 1.4,
+      "vignette": 0.1,
+      "brightness": 4.0,
+      "contrast": 1.03,
+      "jpeg_quality": 94,
+      "image": "small_rotated_fragment.png",
+      "corners": [
+        {
+          "local_row": 0,
+          "local_col": 0,
+          "master_row": 453,
+          "master_col": 376,
+          "pixel_x": 186.93496704101562,
+          "pixel_y": 23.523269653320312
+        },
+        {
+          "local_row": 0,
+          "local_col": 1,
+          "master_row": 453,
+          "master_col": 377,
+          "pixel_x": 221.1009063720703,
+          "pixel_y": 29.964004516601562
+        },
+        {
+          "local_row": 0,
+          "local_col": 2,
+          "master_row": 453,
+          "master_col": 378,
+          "pixel_x": 255.57376098632812,
+          "pixel_y": 36.51258850097656
+        },
+        {
+          "local_row": 0,
+          "local_col": 3,
+          "master_row": 453,
+          "master_col": 379,
+          "pixel_x": 290.3301696777344,
+          "pixel_y": 43.16624450683594
+        },
+        {
+          "local_row": 0,
+          "local_col": 4,
+          "master_row": 453,
+          "master_col": 380,
+          "pixel_x": 325.34527587890625,
+          "pixel_y": 49.92169189453125
+        },
+        {
+          "local_row": 0,
+          "local_col": 5,
+          "master_row": 453,
+          "master_col": 381,
+          "pixel_x": 360.59271240234375,
+          "pixel_y": 56.77510070800781
+        },
+        {
+          "local_row": 0,
+          "local_col": 6,
+          "master_row": 453,
+          "master_col": 382,
+          "pixel_x": 396.04498291015625,
+          "pixel_y": 63.72222900390625
+        },
+        {
+          "local_row": 0,
+          "local_col": 7,
+          "master_row": 453,
+          "master_col": 383,
+          "pixel_x": 431.67340087890625,
+          "pixel_y": 70.75833129882812
+        },
+        {
+          "local_row": 0,
+          "local_col": 8,
+          "master_row": 453,
+          "master_col": 384,
+          "pixel_x": 467.4488220214844,
+          "pixel_y": 77.878173828125
+        },
+        {
+          "local_row": 0,
+          "local_col": 9,
+          "master_row": 453,
+          "master_col": 385,
+          "pixel_x": 503.3414306640625,
+          "pixel_y": 85.07626342773438
+        },
+        {
+          "local_row": 1,
+          "local_col": 0,
+          "master_row": 454,
+          "master_col": 376,
+          "pixel_x": 178.9431915283203,
+          "pixel_y": 54.85804748535156
+        },
+        {
+          "local_row": 1,
+          "local_col": 1,
+          "master_row": 454,
+          "master_col": 377,
+          "pixel_x": 213.29319763183594,
+          "pixel_y": 61.47050476074219
+        },
+        {
+          "local_row": 1,
+          "local_col": 2,
+          "master_row": 454,
+          "master_col": 378,
+          "pixel_x": 247.95706176757812,
+          "pixel_y": 68.18531799316406
+        },
+        {
+          "local_row": 1,
+          "local_col": 3,
+          "master_row": 454,
+          "master_col": 379,
+          "pixel_x": 282.91107177734375,
+          "pixel_y": 74.99923706054688
+        },
+        {
+          "local_row": 1,
+          "local_col": 4,
+          "master_row": 454,
+          "master_col": 380,
+          "pixel_x": 318.1297912597656,
+          "pixel_y": 81.90863037109375
+        },
+        {
+          "local_row": 1,
+          "local_col": 5,
+          "master_row": 454,
+          "master_col": 381,
+          "pixel_x": 353.5863342285156,
+          "pixel_y": 88.90924072265625
+        },
+        {
+          "local_row": 1,
+          "local_col": 6,
+          "master_row": 454,
+          "master_col": 382,
+          "pixel_x": 389.2525939941406,
+          "pixel_y": 95.99650573730469
+        },
+        {
+          "local_row": 1,
+          "local_col": 7,
+          "master_row": 454,
+          "master_col": 383,
+          "pixel_x": 425.099365234375,
+          "pixel_y": 103.16526794433594
+        },
+        {
+          "local_row": 1,
+          "local_col": 8,
+          "master_row": 454,
+          "master_col": 384,
+          "pixel_x": 461.0966491699219,
+          "pixel_y": 110.41012573242188
+        },
+        {
+          "local_row": 1,
+          "local_col": 9,
+          "master_row": 454,
+          "master_col": 385,
+          "pixel_x": 497.2139892578125,
+          "pixel_y": 117.72521209716797
+        },
+        {
+          "local_row": 2,
+          "local_col": 0,
+          "master_row": 455,
+          "master_col": 376,
+          "pixel_x": 170.88211059570312,
+          "pixel_y": 86.63191223144531
+        },
+        {
+          "local_row": 2,
+          "local_col": 1,
+          "master_row": 455,
+          "master_col": 377,
+          "pixel_x": 205.41030883789062,
+          "pixel_y": 93.42001342773438
+        },
+        {
+          "local_row": 2,
+          "local_col": 2,
+          "master_row": 455,
+          "master_col": 378,
+          "pixel_x": 240.2592315673828,
+          "pixel_y": 100.30455017089844
+        },
+        {
+          "local_row": 2,
+          "local_col": 3,
+          "master_row": 455,
+          "master_col": 379,
+          "pixel_x": 275.4047546386719,
+          "pixel_y": 107.28189086914062
+        },
+        {
+          "local_row": 2,
+          "local_col": 4,
+          "master_row": 455,
+          "master_col": 380,
+          "pixel_x": 310.82098388671875,
+          "pixel_y": 114.347900390625
+        },
+        {
+          "local_row": 2,
+          "local_col": 5,
+          "master_row": 455,
+          "master_col": 381,
+          "pixel_x": 346.48052978515625,
+          "pixel_y": 121.49798583984375
+        },
+        {
+          "local_row": 2,
+          "local_col": 6,
+          "master_row": 455,
+          "master_col": 382,
+          "pixel_x": 382.35467529296875,
+          "pixel_y": 128.72715759277344
+        },
+        {
+          "local_row": 2,
+          "local_col": 7,
+          "master_row": 455,
+          "master_col": 383,
+          "pixel_x": 418.4136962890625,
+          "pixel_y": 136.0299530029297
+        },
+        {
+          "local_row": 2,
+          "local_col": 8,
+          "master_row": 455,
+          "master_col": 384,
+          "pixel_x": 454.62689208984375,
+          "pixel_y": 143.40060424804688
+        },
+        {
+          "local_row": 2,
+          "local_col": 9,
+          "master_row": 455,
+          "master_col": 385,
+          "pixel_x": 490.963134765625,
+          "pixel_y": 150.83303833007812
+        },
+        {
+          "local_row": 3,
+          "local_col": 0,
+          "master_row": 456,
+          "master_col": 376,
+          "pixel_x": 162.75701904296875,
+          "pixel_y": 118.83209228515625
+        },
+        {
+          "local_row": 3,
+          "local_col": 1,
+          "master_row": 456,
+          "master_col": 377,
+          "pixel_x": 197.45712280273438,
+          "pixel_y": 125.79945373535156
+        },
+        {
+          "local_row": 3,
+          "local_col": 2,
+          "master_row": 456,
+          "master_col": 378,
+          "pixel_x": 232.48468017578125,
+          "pixel_y": 132.85699462890625
+        },
+        {
+          "local_row": 3,
+          "local_col": 3,
+          "master_row": 456,
+          "master_col": 379,
+          "pixel_x": 267.8152160644531,
+          "pixel_y": 140.0006103515625
+        },
+        {
+          "local_row": 3,
+          "local_col": 4,
+          "master_row": 456,
+          "master_col": 380,
+          "pixel_x": 303.4223937988281,
+          "pixel_y": 147.22572326660156
+        },
+        {
+          "local_row": 3,
+          "local_col": 5,
+          "master_row": 456,
+          "master_col": 381,
+          "pixel_x": 339.2783508300781,
+          "pixel_y": 154.5272979736328
+        },
+        {
+          "local_row": 3,
+          "local_col": 6,
+          "master_row": 456,
+          "master_col": 382,
+          "pixel_x": 375.3538513183594,
+          "pixel_y": 161.89996337890625
+        },
+        {
+          "local_row": 3,
+          "local_col": 7,
+          "master_row": 456,
+          "master_col": 383,
+          "pixel_x": 411.6185302734375,
+          "pixel_y": 169.337890625
+        },
+        {
+          "local_row": 3,
+          "local_col": 8,
+          "master_row": 456,
+          "master_col": 384,
+          "pixel_x": 448.0411071777344,
+          "pixel_y": 176.83505249023438
+        },
+        {
+          "local_row": 3,
+          "local_col": 9,
+          "master_row": 456,
+          "master_col": 385,
+          "pixel_x": 484.5898132324219,
+          "pixel_y": 184.38507080078125
+        },
+        {
+          "local_row": 4,
+          "local_col": 0,
+          "master_row": 457,
+          "master_col": 376,
+          "pixel_x": 154.57350158691406,
+          "pixel_y": 151.4439697265625
+        },
+        {
+          "local_row": 4,
+          "local_col": 1,
+          "master_row": 457,
+          "master_col": 377,
+          "pixel_x": 189.4388427734375,
+          "pixel_y": 158.59393310546875
+        },
+        {
+          "local_row": 4,
+          "local_col": 2,
+          "master_row": 457,
+          "master_col": 378,
+          "pixel_x": 224.63824462890625,
+          "pixel_y": 165.82745361328125
+        },
+        {
+          "local_row": 4,
+          "local_col": 3,
+          "master_row": 457,
+          "master_col": 379,
+          "pixel_x": 260.1468505859375,
+          "pixel_y": 173.13992309570312
+        },
+        {
+          "local_row": 4,
+          "local_col": 4,
+          "master_row": 457,
+          "master_col": 380,
+          "pixel_x": 295.9379577636719,
+          "pixel_y": 180.52627563476562
+        },
+        {
+          "local_row": 4,
+          "local_col": 5,
+          "master_row": 457,
+          "master_col": 381,
+          "pixel_x": 331.9832763671875,
+          "pixel_y": 187.98114013671875
+        },
+        {
+          "local_row": 4,
+          "local_col": 6,
+          "master_row": 457,
+          "master_col": 382,
+          "pixel_x": 368.25299072265625,
+          "pixel_y": 195.4986572265625
+        },
+        {
+          "local_row": 4,
+          "local_col": 7,
+          "master_row": 457,
+          "master_col": 383,
+          "pixel_x": 404.71624755859375,
+          "pixel_y": 203.0727081298828
+        },
+        {
+          "local_row": 4,
+          "local_col": 8,
+          "master_row": 457,
+          "master_col": 384,
+          "pixel_x": 441.3412170410156,
+          "pixel_y": 210.6968536376953
+        },
+        {
+          "local_row": 4,
+          "local_col": 9,
+          "master_row": 457,
+          "master_col": 385,
+          "pixel_x": 478.095458984375,
+          "pixel_y": 218.364501953125
+        },
+        {
+          "local_row": 5,
+          "local_col": 0,
+          "master_row": 458,
+          "master_col": 376,
+          "pixel_x": 146.33743286132812,
+          "pixel_y": 184.451171875
+        },
+        {
+          "local_row": 5,
+          "local_col": 1,
+          "master_row": 458,
+          "master_col": 377,
+          "pixel_x": 181.36102294921875,
+          "pixel_y": 191.78671264648438
+        },
+        {
+          "local_row": 5,
+          "local_col": 2,
+          "master_row": 458,
+          "master_col": 378,
+          "pixel_x": 216.72508239746094,
+          "pixel_y": 199.1988067626953
+        },
+        {
+          "local_row": 5,
+          "local_col": 3,
+          "master_row": 458,
+          "master_col": 379,
+          "pixel_x": 252.4044647216797,
+          "pixel_y": 206.68240356445312
+        },
+        {
+          "local_row": 5,
+          "local_col": 4,
+          "master_row": 458,
+          "master_col": 380,
+          "pixel_x": 288.3720703125,
+          "pixel_y": 214.23196411132812
+        },
+        {
+          "local_row": 5,
+          "local_col": 5,
+          "master_row": 458,
+          "master_col": 381,
+          "pixel_x": 324.5992126464844,
+          "pixel_y": 221.8416290283203
+        },
+        {
+          "local_row": 5,
+          "local_col": 6,
+          "master_row": 458,
+          "master_col": 382,
+          "pixel_x": 361.05560302734375,
+          "pixel_y": 229.505126953125
+        },
+        {
+          "local_row": 5,
+          "local_col": 7,
+          "master_row": 458,
+          "master_col": 383,
+          "pixel_x": 397.70989990234375,
+          "pixel_y": 237.2159881591797
+        },
+        {
+          "local_row": 5,
+          "local_col": 8,
+          "master_row": 458,
+          "master_col": 384,
+          "pixel_x": 434.5296936035156,
+          "pixel_y": 244.9674530029297
+        },
+        {
+          "local_row": 5,
+          "local_col": 9,
+          "master_row": 458,
+          "master_col": 385,
+          "pixel_x": 471.48199462890625,
+          "pixel_y": 252.7526092529297
+        },
+        {
+          "local_row": 6,
+          "local_col": 0,
+          "master_row": 459,
+          "master_col": 376,
+          "pixel_x": 138.05502319335938,
+          "pixel_y": 217.8356475830078
+        },
+        {
+          "local_row": 6,
+          "local_col": 1,
+          "master_row": 459,
+          "master_col": 377,
+          "pixel_x": 173.22952270507812,
+          "pixel_y": 225.3593292236328
+        },
+        {
+          "local_row": 6,
+          "local_col": 2,
+          "master_row": 459,
+          "master_col": 378,
+          "pixel_x": 208.750732421875,
+          "pixel_y": 232.95230102539062
+        },
+        {
+          "local_row": 6,
+          "local_col": 3,
+          "master_row": 459,
+          "master_col": 379,
+          "pixel_x": 244.59315490722656,
+          "pixel_y": 240.60894775390625
+        },
+        {
+          "local_row": 6,
+          "local_col": 4,
+          "master_row": 459,
+          "master_col": 380,
+          "pixel_x": 280.72943115234375,
+          "pixel_y": 248.3232879638672
+        },
+        {
+          "local_row": 6,
+          "local_col": 5,
+          "master_row": 459,
+          "master_col": 381,
+          "pixel_x": 317.1304016113281,
+          "pixel_y": 256.0889587402344
+        },
+        {
+          "local_row": 6,
+          "local_col": 6,
+          "master_row": 459,
+          "master_col": 382,
+          "pixel_x": 353.7655029296875,
+          "pixel_y": 263.8993225097656
+        },
+        {
+          "local_row": 6,
+          "local_col": 7,
+          "master_row": 459,
+          "master_col": 383,
+          "pixel_x": 390.6028137207031,
+          "pixel_y": 271.7474670410156
+        },
+        {
+          "local_row": 6,
+          "local_col": 8,
+          "master_row": 459,
+          "master_col": 384,
+          "pixel_x": 427.60943603515625,
+          "pixel_y": 279.6263732910156
+        },
+        {
+          "local_row": 6,
+          "local_col": 9,
+          "master_row": 459,
+          "master_col": 385,
+          "pixel_x": 464.7519226074219,
+          "pixel_y": 287.52880859375
+        },
+        {
+          "local_row": 7,
+          "local_col": 0,
+          "master_row": 460,
+          "master_col": 376,
+          "pixel_x": 129.73265075683594,
+          "pixel_y": 251.57772827148438
+        },
+        {
+          "local_row": 7,
+          "local_col": 1,
+          "master_row": 460,
+          "master_col": 377,
+          "pixel_x": 165.0504608154297,
+          "pixel_y": 259.29168701171875
+        },
+        {
+          "local_row": 7,
+          "local_col": 2,
+          "master_row": 460,
+          "master_col": 378,
+          "pixel_x": 200.720947265625,
+          "pixel_y": 267.0673828125
+        },
+        {
+          "local_row": 7,
+          "local_col": 3,
+          "master_row": 460,
+          "master_col": 379,
+          "pixel_x": 236.7183837890625,
+          "pixel_y": 274.898681640625
+        },
+        {
+          "local_row": 7,
+          "local_col": 4,
+          "master_row": 460,
+          "master_col": 380,
+          "pixel_x": 273.0151062011719,
+          "pixel_y": 282.779052734375
+        },
+        {
+          "local_row": 7,
+          "local_col": 5,
+          "master_row": 460,
+          "master_col": 381,
+          "pixel_x": 309.5816345214844,
+          "pixel_y": 290.7016296386719
+        },
+        {
+          "local_row": 7,
+          "local_col": 6,
+          "master_row": 460,
+          "master_col": 382,
+          "pixel_x": 346.386962890625,
+          "pixel_y": 298.659423828125
+        },
+        {
+          "local_row": 7,
+          "local_col": 7,
+          "master_row": 460,
+          "master_col": 383,
+          "pixel_x": 383.3988037109375,
+          "pixel_y": 306.6451416015625
+        },
+        {
+          "local_row": 7,
+          "local_col": 8,
+          "master_row": 460,
+          "master_col": 384,
+          "pixel_x": 420.5838623046875,
+          "pixel_y": 314.6513671875
+        },
+        {
+          "local_row": 7,
+          "local_col": 9,
+          "master_row": 460,
+          "master_col": 385,
+          "pixel_x": 457.9081115722656,
+          "pixel_y": 322.6707458496094
+        },
+        {
+          "local_row": 8,
+          "local_col": 0,
+          "master_row": 461,
+          "master_col": 376,
+          "pixel_x": 121.37692260742188,
+          "pixel_y": 285.6562194824219
+        },
+        {
+          "local_row": 8,
+          "local_col": 1,
+          "master_row": 461,
+          "master_col": 377,
+          "pixel_x": 156.83016967773438,
+          "pixel_y": 293.5622253417969
+        },
+        {
+          "local_row": 8,
+          "local_col": 2,
+          "master_row": 461,
+          "master_col": 378,
+          "pixel_x": 192.64178466796875,
+          "pixel_y": 301.5220947265625
+        },
+        {
+          "local_row": 8,
+          "local_col": 3,
+          "master_row": 461,
+          "master_col": 379,
+          "pixel_x": 228.785888671875,
+          "pixel_y": 309.5291442871094
+        },
+        {
+          "local_row": 8,
+          "local_col": 4,
+          "master_row": 461,
+          "master_col": 380,
+          "pixel_x": 265.2344970703125,
+          "pixel_y": 317.5763854980469
+        },
+        {
+          "local_row": 8,
+          "local_col": 5,
+          "master_row": 461,
+          "master_col": 381,
+          "pixel_x": 301.9578552246094,
+          "pixel_y": 325.656494140625
+        },
+        {
+          "local_row": 8,
+          "local_col": 6,
+          "master_row": 461,
+          "master_col": 382,
+          "pixel_x": 338.9246520996094,
+          "pixel_y": 333.7620544433594
+        },
+        {
+          "local_row": 8,
+          "local_col": 7,
+          "master_row": 461,
+          "master_col": 383,
+          "pixel_x": 376.1022033691406,
+          "pixel_y": 341.88531494140625
+        },
+        {
+          "local_row": 8,
+          "local_col": 8,
+          "master_row": 461,
+          "master_col": 384,
+          "pixel_x": 413.456787109375,
+          "pixel_y": 350.0186462402344
+        },
+        {
+          "local_row": 8,
+          "local_col": 9,
+          "master_row": 461,
+          "master_col": 385,
+          "pixel_x": 450.9540100097656,
+          "pixel_y": 358.154296875
+        },
+        {
+          "local_row": 9,
+          "local_col": 0,
+          "master_row": 462,
+          "master_col": 376,
+          "pixel_x": 112.99446105957031,
+          "pixel_y": 320.0486755371094
+        },
+        {
+          "local_row": 9,
+          "local_col": 1,
+          "master_row": 462,
+          "master_col": 377,
+          "pixel_x": 148.5751495361328,
+          "pixel_y": 328.14788818359375
+        },
+        {
+          "local_row": 9,
+          "local_col": 2,
+          "master_row": 462,
+          "master_col": 378,
+          "pixel_x": 184.51954650878906,
+          "pixel_y": 336.29290771484375
+        },
+        {
+          "local_row": 9,
+          "local_col": 3,
+          "master_row": 462,
+          "master_col": 379,
+          "pixel_x": 220.80165100097656,
+          "pixel_y": 344.4764709472656
+        },
+        {
+          "local_row": 9,
+          "local_col": 4,
+          "master_row": 462,
+          "master_col": 380,
+          "pixel_x": 257.3932800292969,
+          "pixel_y": 352.6910705566406
+        },
+        {
+          "local_row": 9,
+          "local_col": 5,
+          "master_row": 462,
+          "master_col": 381,
+          "pixel_x": 294.26446533203125,
+          "pixel_y": 360.9289855957031
+        },
+        {
+          "local_row": 9,
+          "local_col": 6,
+          "master_row": 462,
+          "master_col": 382,
+          "pixel_x": 331.3835754394531,
+          "pixel_y": 369.1822509765625
+        },
+        {
+          "local_row": 9,
+          "local_col": 7,
+          "master_row": 462,
+          "master_col": 383,
+          "pixel_x": 368.71759033203125,
+          "pixel_y": 377.44281005859375
+        },
+        {
+          "local_row": 9,
+          "local_col": 8,
+          "master_row": 462,
+          "master_col": 384,
+          "pixel_x": 406.2325134277344,
+          "pixel_y": 385.7027282714844
+        },
+        {
+          "local_row": 9,
+          "local_col": 9,
+          "master_row": 462,
+          "master_col": 385,
+          "pixel_x": 443.8935241699219,
+          "pixel_y": 393.95404052734375
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/puzzleboard_synthetic_author_like/small_rotated_fragment.png
+++ b/testdata/puzzleboard_synthetic_author_like/small_rotated_fragment.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:50b2d6c6a0ebdd3b48996a8382a6f7ba922db5ce7b523089d321815108a10734
+size 133604


### PR DESCRIPTION
## Summary
- add deterministic author-like synthetic PuzzleBoard photo fixtures generated from the committed 501x501 maps
- add a regression that decodes those fixtures and checks BER, truth-corner agreement, and a single D4+translation relation
- document fixture regeneration with `uv` and fix the print model polarity comment to match the renderer

## Notes
The upstream author example photos are useful visual references, but they are not exact matches to the current canonical map. These fixtures are generated directly from `map_a.bin` and `map_b.bin`, so they provide a release-blocking regression for the current map search path under realistic perspective, radial distortion, blur, vignetting, noise, and JPEG compression.

Local overlay artifacts were generated but not committed:
- `crates/calib-targets-puzzleboard/report/puzzleboard_synthetic_author_like/author_like_oblique_detected_vs_truth.png`
- `crates/calib-targets-puzzleboard/report/puzzleboard_synthetic_author_like/author_like_foreshortened_detected_vs_truth.png`
- `crates/calib-targets-puzzleboard/report/puzzleboard_synthetic_author_like/small_rotated_fragment_detected_vs_truth.png`

## Validation
- `cargo fmt`
- `CARGO_TARGET_DIR=/tmp/calib-targets-target cargo clippy --workspace --all-targets -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/calib-targets-target cargo test -p calib-targets-puzzleboard --features diagnostics -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/calib-targets-target cargo test --workspace`

Synthetic fixture metrics:
- `author_like_oblique`: 361 decoded / 361 truth-matched, BER 0.000, identity relation
- `author_like_foreshortened`: 348 decoded / 348 truth-matched, BER 0.000, identity relation
- `small_rotated_fragment`: 64 decoded / 64 truth-matched, BER 0.000, identity relation
