### PR TITLE
docs: facade-first READMEs + self-contained detector crates; version/deprecated sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,16 +46,15 @@ Upgrading from an earlier release? See the [Migration Guide](docs/migrations/0.1
   then decode anchors / dots / circles in rectified cells". The heavy
   lifting lives in [`calib-targets-chessboard`] and
   [`projective-grid`][projective-grid-readme].
-- **Single grid pipeline, typed outputs.** The topological pipeline
-  (Shu / Brunton / Fiala 2009) is image-free Delaunay +
-  edge-classification + flood-fill labelling, used for all four target
-  families. `GraphBuildAlgorithm` still exists as a type but the
-  `SeedAndGrow` variant was removed; `Topological` is the sole variant.
+- **Single grid pipeline, typed outputs.** One image-free grid builder —
+  Delaunay triangulation followed by an axis-driven cell test — assembles
+  the lattice for all four target families, then each detector decodes its
+  own anchors / dots / circles in the rectified cells.
 - **Local invariants, not global warps.** Graph construction and
   validation work on local neighbourhoods, so moderate perspective and
   radial distortion degrade gracefully without an explicit distortion
-  model. Boundary extension uses per-candidate local-H over the K
-  nearest labels, tolerating stronger distortion.
+  model. Boundary extension fits a local homography around each candidate
+  corner, tolerating stronger distortion.
 - **Partial boards supported.** PuzzleBoard gives absolute IDs from a
   single visible fragment; ChArUco / marker boards label whatever is
   visible and the facade `detect_*_all` helpers return every connected
@@ -63,9 +62,8 @@ Upgrading from an earlier release? See the [Migration Guide](docs/migrations/0.1
 - **Consistency diagnostics built in.** PuzzleBoard surfaces the
   chosen search / scoring mode, observed edge evidence, and
   soft-decoder margins through its diagnostics channel. The chessboard
-  detector ends in a Stage 9 final-geometry check that drops gross
-  mislabels and isolated false positives before emitting any
-  `Detection`.
+  detector ends in a final-geometry check that drops gross mislabels and
+  isolated false positives before emitting any `Detection`.
 - **Multi-config sweeps.** `detect_*_best` tries three built-in presets
   and keeps the best result — no hand-tuning required for the common
   failure cases.
@@ -100,9 +98,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         Some(det) => {
             println!("detected {} corners", det.corners.len());
             for c in &det.corners {
-                // position: sub-pixel (x, y) in pixels; grid: (i, j) lattice index
+                // position: sub-pixel (x, y) in pixels; grid: (u, v) lattice index
                 println!("  ({:.1}, {:.1}) -> grid ({}, {})",
-                    c.position.x, c.position.y, c.grid.i, c.grid.j);
+                    c.position.x, c.position.y, c.grid.u, c.grid.v);
             }
         }
         None => println!("no board detected"),
@@ -208,8 +206,8 @@ Each detector returns a typed result; its corners share a common vocabulary.
 A chessboard corner (`ChessboardCorner`) carries:
 
 - **`position`** — sub-pixel `(x, y)` in **pixels** (image origin top-left).
-- **`grid`** — integer lattice index `GridCoords { i, j }` (`i` increases
-  right, `j` down), rebased so the top-left visible corner is `(0, 0)`.
+- **`grid`** — integer lattice index `Coord { u, v }` (`u` increases
+  right, `v` down), rebased so the top-left visible corner is `(0, 0)`.
 - **`score`** — corner quality.
 
 ChArUco, PuzzleBoard, and marker corners add an `id` (a globally unique

--- a/book/src/getting-started.md
+++ b/book/src/getting-started.md
@@ -197,7 +197,7 @@ for c in corners:
 ```toml
 # Cargo.toml
 [dependencies]
-calib-targets = "0.4"
+calib-targets = "0.10"
 image = "0.25"
 ```
 

--- a/crates/calib-targets-aruco/README.md
+++ b/crates/calib-targets-aruco/README.md
@@ -22,8 +22,9 @@ calib-targets-aruco = "0.10"
 ## Quickstart
 
 ```rust
-use calib_targets_aruco::{builtins, scan_decode_markers, Matcher, ScanDecodeConfig};
-use calib_targets_core::GrayImageView;
+use calib_targets_aruco::{
+    builtins, scan_decode_markers, GrayImageView, Matcher, ScanDecodeConfig,
+};
 
 let dict = builtins::builtin_dictionary("DICT_4X4_50").expect("dict");
 let matcher = Matcher::new(dict, 1);            // Hamming tolerance

--- a/crates/calib-targets-aruco/README.md
+++ b/crates/calib-targets-aruco/README.md
@@ -16,8 +16,7 @@ Most users go through the facade [`calib-targets`][facade] or the
 
 ```toml
 [dependencies]
-calib-targets-aruco = "0.8"
-calib-targets-core = "0.8"
+calib-targets-aruco = "0.10"
 ```
 
 ## Quickstart

--- a/crates/calib-targets-aruco/src/lib.rs
+++ b/crates/calib-targets-aruco/src/lib.rs
@@ -11,8 +11,9 @@
 //! ## Quickstart
 //!
 //! ```
-//! use calib_targets_aruco::{builtins, scan_decode_markers, Matcher, ScanDecodeConfig};
-//! use calib_targets_core::GrayImageView;
+//! use calib_targets_aruco::{
+//!     builtins, scan_decode_markers, GrayImageView, Matcher, ScanDecodeConfig,
+//! };
 //!
 //! let dict = builtins::builtin_dictionary("DICT_4X4_50").expect("dict");
 //! let matcher = Matcher::new(dict, 1);
@@ -42,3 +43,8 @@ pub use scan::{
     decode_marker_in_cell, sample_cell, scan_decode_markers, scan_decode_markers_in_cells,
     ArucoScanConfig, CellSamples, MarkerCell, MarkerDetection, ScanDecodeConfig,
 };
+
+// Re-export the core image-view type this crate's scan API names, so depending
+// on calib-targets-aruco alone is sufficient (no direct calib-targets-core dep
+// required to name the input view).
+pub use calib_targets_core::GrayImageView;

--- a/crates/calib-targets-charuco/README.md
+++ b/crates/calib-targets-charuco/README.md
@@ -23,19 +23,52 @@ and [alignment & refinement chapter][book-alignment].
 
 ```toml
 [dependencies]
-calib-targets-charuco = "0.8"
-calib-targets-core = "0.8"
-calib-targets-aruco = "0.8"
+calib-targets-charuco = "0.10"
 ```
 
 ## Quickstart
 
+Most users should reach for the facade crate [`calib-targets`][facade]: it runs
+ChESS corner detection for you and takes an `image::GrayImage` straight in.
+
+```toml
+[dependencies]
+calib-targets = "0.10"
+image = "0.25"
+```
+
 ```rust,no_run
-use calib_targets_aruco::builtins;
+use calib_targets::aruco::builtins;
+use calib_targets::charuco::{CharucoBoardSpec, CharucoParams, MarkerLayout};
+use calib_targets::detect;
+use image::ImageReader;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let img = ImageReader::open("board.png")?.decode()?.to_luma8();
+
+    let board = CharucoBoardSpec::new(5, 7, 1.0, 0.70, builtins::DICT_4X4_50)
+        .with_marker_layout(MarkerLayout::OpenCvCharuco);
+    let params = CharucoParams::for_board(&board);
+
+    let result = detect::detect_charuco(&img, &params)?;
+    println!("detected {} corners", result.corners.len());
+    Ok(())
+}
+```
+
+### Using this crate directly
+
+Depend on `calib-targets-charuco` alone when you already have ChESS corners and
+want the detector without the image-loading layer. Every type the API needs —
+the marker `Dictionary`, the `GrayImageView`, and the `ChessCorner` input — is
+re-exported here, so no direct `calib-targets-aruco` / `calib-targets-core`
+dependency is required:
+
+```rust,no_run
 use calib_targets_charuco::{
-    CharucoBoardSpec, CharucoDetector, CharucoParams, MarkerLayout,
+    builtins, CharucoBoardSpec, CharucoDetector, CharucoParams, ChessCorner,
+    GrayImageView, MarkerLayout,
 };
-use calib_targets_core::{Corner, GrayImageView};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let board = CharucoBoardSpec::new(5, 7, 1.0, 0.70, builtins::DICT_4X4_50)
@@ -44,16 +77,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let pixels = vec![0u8; 32 * 32];
     let view = GrayImageView { width: 32, height: 32, data: &pixels };
-    let corners: Vec<Corner> = Vec::new();
+    let corners: Vec<ChessCorner> = Vec::new();
 
     let _ = detector.detect(&view, &corners)?;
     Ok(())
 }
 ```
-
-Use [`calib_targets::detect::detect_charuco`] for an `image::GrayImage`-
-in, result-out helper; it runs corner detection, calls this detector, and
-returns the same `CharucoDetectionResult`.
 
 ## Inputs
 
@@ -123,7 +152,7 @@ Defaults from `for_board(&spec)` work for most targets.
 | Grid validation | `grid_smoothness_threshold_rel`, `corner_validation_threshold_rel` | Smoothness / local-H residuals on refined corners. Loosen under lens distortion. |
 | Per-cell decode | `scan.marker_size_rel`, `scan.inset_frac`, `scan.multi_threshold` | Marker cell sampling for the soft-bit score matrix. |
 | Alignment accept | `min_marker_inliers`, `min_secondary_marker_inliers` | Downstream inlier floors (the board matcher is its own gate, so these stay low). |
-| Board-level matcher | `bit_likelihood_slope` (κ), `per_bit_floor`, `alignment_min_margin` | Soft-bit gate. Defaults (κ=36, margin=0.05) are tuned conservatively across the internal regression sets. |
+| Board-level matcher | `bit_likelihood_slope` (κ), `per_bit_floor`, `alignment_min_margin` | Soft-bit gate. Defaults (κ=36, margin=0.05) are chosen conservatively to favour precision over recall. |
 
 ## Tuning difficult cases
 

--- a/crates/calib-targets-charuco/src/lib.rs
+++ b/crates/calib-targets-charuco/src/lib.rs
@@ -10,10 +10,10 @@
 //! ## Quickstart
 //!
 //! ```no_run
-//! use calib_targets_aruco::builtins;
-//! use calib_targets_charuco::{CharucoBoardSpec, CharucoDetector, CharucoParams, MarkerLayout};
-//! use calib_targets_chessboard::ChessCorner;
-//! use calib_targets_core::GrayImageView;
+//! use calib_targets_charuco::{
+//!     builtins, CharucoBoardSpec, CharucoDetector, CharucoParams, ChessCorner,
+//!     GrayImageView, MarkerLayout,
+//! };
 //!
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let board = CharucoBoardSpec::new(5, 7, 1.0, 0.7, builtins::DICT_4X4_50)
@@ -68,4 +68,10 @@ pub use link_check::{
     LinkViolationKind, MarkerCornerLink,
 };
 
-pub use calib_targets_core::{GridAlignment, GridTransform};
+// A consumer of this crate alone must be able to name every foreign type our
+// public API requires — the marker dictionary, the image view, and the corner
+// input — without depending on calib-targets-aruco / -core / -chessboard
+// directly.
+pub use calib_targets_aruco::{builtins, Dictionary};
+pub use calib_targets_chessboard::ChessCorner;
+pub use calib_targets_core::{GrayImageView, GridAlignment, GridTransform};

--- a/crates/calib-targets-chessboard/README.md
+++ b/crates/calib-targets-chessboard/README.md
@@ -33,7 +33,7 @@ fn detect_one(corners: &[ChessCorner]) {
         println!("labelled {} corners", d.corners.len());
         for c in &d.corners {
             // c.grid: (i, j) — always present; c.input_index: input-slice index.
-            let _ = (c.grid.i, c.grid.j, c.position, c.input_index, c.score);
+            let _ = (c.grid.u, c.grid.v, c.position, c.input_index, c.score);
         }
     }
 }
@@ -68,7 +68,7 @@ bounding box and sorted by `(j, i)`) plus a stable
 | Field | Meaning |
 |---|---|
 | `position: Point2<f32>` | Sub-pixel image position. |
-| `grid: GridCoords` | The `(i, j)` grid label. Non-optional — a chessboard corner is always labelled. |
+| `grid: Coord` | The `(u, v)` grid label (`u` right, `v` down). Non-optional — a chessboard corner is always labelled. |
 | `input_index: usize` | Index back into the caller's input `&[ChessCorner]` slice — used by ChArUco / marker-board alignment. |
 | `score: f32` | Corner score. |
 

--- a/crates/calib-targets-core/README.md
+++ b/crates/calib-targets-core/README.md
@@ -14,7 +14,7 @@ writing a new detector or consuming detection results without the facade.
 
 ```toml
 [dependencies]
-calib-targets-core = "0.8"
+calib-targets-core = "0.10"
 nalgebra = "0.34"
 ```
 
@@ -26,7 +26,7 @@ nalgebra = "0.34"
 | [`LabeledCorner`] | A detected corner with grid label: `position`, `grid: Option<(i, j)>`, `id`, `target_position`, `score`. The common detector output. |
 | [`TargetDetection`] | `{ kind: TargetKind, corners: Vec<LabeledCorner> }`. Uniform wrapper across all detector types. |
 | [`TargetKind`] | `Chessboard`, `ChArUco`, `PuzzleBoard`, `CheckerboardMarker`. Non-exhaustive. |
-| [`GridCoords`] | Integer `(i, j)` grid index, with `i` right, `j` down. Labels are always rebased so that the bounding-box minimum sits at `(0, 0)`. |
+| [`Coord`] | Integer lattice index `{ u, v }` (`u` right = grid column `i`, `v` down = grid row `j`). Labels are always rebased so that the bounding-box minimum sits at `(0, 0)`. |
 | [`GridAlignment`] / [`GridTransform`] | Dihedral-group D4 (8 transforms) aligning a detected grid to a board-fixed coordinate system. |
 
 ## Utilities
@@ -61,13 +61,13 @@ nalgebra = "0.34"
 ## Quickstart
 
 ```rust
-use calib_targets_core::{GridCoords, LabeledCorner, TargetDetection, TargetKind};
+use calib_targets_core::{Coord, LabeledCorner, TargetDetection, TargetKind};
 use nalgebra::Point2;
 
 // Public types are `#[non_exhaustive]`: build them with the named
 // constructor plus `with_*` setters, not a struct literal.
 let corner = LabeledCorner::new(Point2::new(10.0, 20.0), 1.0)
-    .with_grid(GridCoords::from((0, 0)));
+    .with_grid(Coord::new(0, 0));
 
 let detection = TargetDetection::new(TargetKind::Chessboard, vec![corner]);
 

--- a/crates/calib-targets-marker/README.md
+++ b/crates/calib-targets-marker/README.md
@@ -74,7 +74,7 @@ use calib_targets_marker::{
     MarkerBoardParams, MarkerBoardSpec, MarkerCircleSpec,
 };
 
-fn main() {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let spec = MarkerBoardSpec::new(
         6,
         8,
@@ -85,13 +85,14 @@ fn main() {
         ],
     )
     .with_cell_size(1.0);
-    let detector = MarkerBoardDetector::new(MarkerBoardParams::new(spec));
+    let detector = MarkerBoardDetector::new(MarkerBoardParams::new(spec))?;
 
     let pixels = vec![0u8; 32 * 32];
     let view = GrayImageView { width: 32, height: 32, data: &pixels };
     let corners: Vec<ChessCorner> = Vec::new();
 
     let _ = detector.detect_from_image_and_corners(&view, &corners);
+    Ok(())
 }
 ```
 

--- a/crates/calib-targets-marker/README.md
+++ b/crates/calib-targets-marker/README.md
@@ -19,38 +19,80 @@ Algorithm details: [book chapter][book-chapter].
 
 ```toml
 [dependencies]
-calib-targets-marker = "0.8"
-calib-targets-core = "0.8"
+calib-targets-marker = "0.10"
 ```
 
 ## Quickstart
 
-```rust
-use calib_targets_core::{Corner, GrayImageView};
-use calib_targets_marker::{
-    CellCoords, CirclePolarity, MarkerBoardDetector, MarkerBoardSpec, MarkerBoardParams,
-    MarkerCircleSpec,
+Most users should reach for the facade crate [`calib-targets`][facade]: it runs
+ChESS corner detection for you and takes an `image::GrayImage` straight in.
+
+```toml
+[dependencies]
+calib-targets = "0.10"
+image = "0.25"
+```
+
+```rust,no_run
+use calib_targets::detect;
+use calib_targets::marker::{
+    CellCoords, CirclePolarity, MarkerBoardParams, MarkerBoardSpec, MarkerCircleSpec,
 };
 
-let layout = MarkerBoardSpec::new(
-    6,
-    8,
-    [
-        MarkerCircleSpec::new(CellCoords { i: 2, j: 2 }, CirclePolarity::White),
-        MarkerCircleSpec::new(CellCoords { i: 3, j: 2 }, CirclePolarity::Black),
-        MarkerCircleSpec::new(CellCoords { i: 2, j: 3 }, CirclePolarity::White),
-    ],
-)
-.with_cell_size(1.0);
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let img = image::open("marker_board.png")?.to_luma8();
 
-let params = MarkerBoardParams::new(layout);
-let detector = MarkerBoardDetector::new(params);
+    let spec = MarkerBoardSpec::new(
+        6,
+        8,
+        [
+            MarkerCircleSpec::new(CellCoords { i: 2, j: 2 }, CirclePolarity::White),
+            MarkerCircleSpec::new(CellCoords { i: 3, j: 2 }, CirclePolarity::Black),
+            MarkerCircleSpec::new(CellCoords { i: 2, j: 3 }, CirclePolarity::White),
+        ],
+    )
+    .with_cell_size(1.0);
+    let params = MarkerBoardParams::new(spec);
 
-let pixels = vec![0u8; 32 * 32];
-let view = GrayImageView { width: 32, height: 32, data: &pixels };
-let corners: Vec<Corner> = Vec::new();
+    if let Some(result) = detect::detect_marker_board(&img, &params) {
+        println!("detected {} corners", result.corners.len());
+    }
+    Ok(())
+}
+```
 
-let _ = detector.detect_from_image_and_corners(&view, &corners);
+### Using this crate directly
+
+Depend on `calib-targets-marker` alone when you already have ChESS corners. The
+corner input (`ChessCorner`) and image view (`GrayImageView`) are re-exported
+here, so no direct `calib-targets-chessboard` / `calib-targets-core` dependency
+is required:
+
+```rust,no_run
+use calib_targets_marker::{
+    CellCoords, ChessCorner, CirclePolarity, GrayImageView, MarkerBoardDetector,
+    MarkerBoardParams, MarkerBoardSpec, MarkerCircleSpec,
+};
+
+fn main() {
+    let spec = MarkerBoardSpec::new(
+        6,
+        8,
+        [
+            MarkerCircleSpec::new(CellCoords { i: 2, j: 2 }, CirclePolarity::White),
+            MarkerCircleSpec::new(CellCoords { i: 3, j: 2 }, CirclePolarity::Black),
+            MarkerCircleSpec::new(CellCoords { i: 2, j: 3 }, CirclePolarity::White),
+        ],
+    )
+    .with_cell_size(1.0);
+    let detector = MarkerBoardDetector::new(MarkerBoardParams::new(spec));
+
+    let pixels = vec![0u8; 32 * 32];
+    let view = GrayImageView { width: 32, height: 32, data: &pixels };
+    let corners: Vec<ChessCorner> = Vec::new();
+
+    let _ = detector.detect_from_image_and_corners(&view, &corners);
+}
 ```
 
 ## Inputs

--- a/crates/calib-targets-marker/src/lib.rs
+++ b/crates/calib-targets-marker/src/lib.rs
@@ -62,3 +62,10 @@ pub use types::{
     CircleMatch, CircleMatchParams, MarkerBoardCorner, MarkerBoardDetectionResult,
     MarkerBoardParams, MarkerBoardSpec, MarkerCircleSpec,
 };
+
+// Re-export the foreign types this crate's public API requires — the corner
+// input, the image view, and the alignment result — so depending on
+// calib-targets-marker alone is sufficient (no direct calib-targets-chessboard
+// / -core dependency needed).
+pub use calib_targets_chessboard::ChessCorner;
+pub use calib_targets_core::{GrayImageView, GridAlignment, GridTransform};

--- a/crates/calib-targets-print/README.md
+++ b/crates/calib-targets-print/README.md
@@ -14,7 +14,7 @@ Canonical user guide: [printable-targets book chapter][book-chapter].
 
 ```toml
 [dependencies]
-calib-targets-print = "0.8"
+calib-targets-print = "0.10"
 ```
 
 ## Quickstart
@@ -143,13 +143,8 @@ producers:
   text are intentionally absent — confirm with the producer whether
   they need the chrome or clear side and add downstream.
 
-The hand-rolled writer lives in [`render_dxf.rs`][writer-src] and is
-covered by a checked-in golden snapshot
-([`tests/golden/charuco_3x3_dict4x4_50.dxf`][golden]) plus unit tests
-for the Y-flip, polarity filter, and entity counts.
-
-[writer-src]: https://github.com/VitalyVorobyev/calib-targets-rs/blob/main/crates/calib-targets-print/src/render_dxf.rs
-[golden]: https://github.com/VitalyVorobyev/calib-targets-rs/blob/main/crates/calib-targets-print/tests/golden/charuco_3x3_dict4x4_50.dxf
+The DXF output is deterministic and covered by a golden-snapshot
+regression test.
 
 ## Limitations
 

--- a/crates/calib-targets-puzzleboard/README.md
+++ b/crates/calib-targets-puzzleboard/README.md
@@ -23,8 +23,7 @@ Algorithm details and bit-layout spec: [book chapter][book-chapter].
 
 ```toml
 [dependencies]
-calib-targets-puzzleboard = "0.8"
-calib-targets-core = "0.8"
+calib-targets-puzzleboard = "0.10"
 ```
 
 ## Quickstart (facade)
@@ -103,9 +102,9 @@ defaults or `sweep_for_board(spec)` for a multi-config preset.
 - [`PuzzleBoardScoringMode::SoftLogLikelihood`] (default) — per-bit
   log-likelihood with a best-vs-runner-up margin gate. Recommended for
   real data and multi-view consistency checks.
-- [`PuzzleBoardScoringMode::HardWeighted`] — legacy hard match-count
-  ranking with a confidence-weighted tie-break. Kept for diagnostics and
-  backward-compatibility.
+- [`PuzzleBoardScoringMode::HardWeighted`] — hard match-count ranking with
+  a confidence-weighted tie-break. Simpler and faster than the soft scorer
+  and used as a sweep fallback, but less robust on noisy data.
 
 ```rust,no_run
 # use calib_targets::{detect, puzzleboard::{PuzzleBoardParams, PuzzleBoardScoringMode, PuzzleBoardSearchMode, PuzzleBoardSpec}};

--- a/crates/calib-targets-puzzleboard/src/lib.rs
+++ b/crates/calib-targets-puzzleboard/src/lib.rs
@@ -64,4 +64,8 @@ pub use diagnostics::{
 pub use io::{PuzzleBoardDetectConfig, PuzzleBoardDetectReport, PuzzleBoardIoError};
 pub use params::PuzzleBoardParams;
 
-pub use calib_targets_core::{GridAlignment, GridTransform, GRID_TRANSFORMS_D4};
+// Re-export the foreign types this crate's public API requires — the corner
+// input and the image view — so depending on calib-targets-puzzleboard alone is
+// sufficient (no direct calib-targets-chessboard / -core dependency needed).
+pub use calib_targets_chessboard::ChessCorner;
+pub use calib_targets_core::{GrayImageView, GridAlignment, GridTransform, GRID_TRANSFORMS_D4};

--- a/crates/calib-targets-wasm/README.md
+++ b/crates/calib-targets-wasm/README.md
@@ -169,7 +169,7 @@ edges and soft-mode runner-up scoring evidence are returned by
 ```typescript
 {
   position: { x: number, y: number },          // sub-pixel image location
-  grid:     { i: number, j: number } | null,   // integer grid label, rebased to (0,0)
+  grid:     { u: number, v: number } | null,   // integer grid label, rebased to (0,0)
   id:       number | null,                     // ChArUco / PuzzleBoard ID
   target_position: { x: number, y: number } | null,  // mm on the printed board
   score:    number,


### PR DESCRIPTION
## Summary

A documentation sweep across the crate READMEs (plus the root README and the
book getting-started page), answering the architectural question it surfaced:
**do consumers really need `calib-targets-core` / `-aruco` directly to use
ChArUco, marker, or PuzzleBoard?** The answer is now uniformly **no**.

## Self-containment (the headline)

`detect(…)` on charuco/marker/puzzleboard takes `&GrayImageView` (core) +
`&[ChessCorner]` (chessboard), and results expose `GridAlignment` (core) — none
of which the detector crates re-exported. So using a detector crate directly
forced direct deps on internal crates. ChArUco additionally needed the ArUco
`Dictionary` / `builtins`.

Each detector crate now **re-exports the foreign types its own public API
names** (additive, non-breaking), so depending on the one crate is sufficient.
Marker and PuzzleBoard had the same gap as ChArUco — and the marker README's
`use calib_targets_core::{Corner, …}` did not even compile (`core::Corner`
doesn't exist; the type is `chessboard::ChessCorner`).

## READMEs

- **Facade-first** everywhere: one `calib-targets` dep gives
  `calib_targets::{detect, charuco|marker|puzzleboard, aruco::builtins}`. Each
  detector README adds a self-contained "using this crate directly" block.
- **Versions** → `0.10` (the real workspace version); were `0.8` / `0.9` /
  `0.4`. Changelog history left intact.
- **Deprecated references** (would not compile if copy-pasted): `GridCoords` →
  `Coord` (fields `.u`/`.v`, not `.i`/`.j`); `core::Corner` →
  `chessboard::ChessCorner`; WASM `grid` JSON shape `{i,j}` → `{u,v}`.
- **Internal / too-detailed trims**: root README's "Stage 9", the removed
  `SeedAndGrow`-variant history, and `local-H` jargon; charuco's "internal
  regression sets" line (private-dataset policy); puzzleboard's "legacy"
  scoring-mode editorializing; print's source-file / unit-test pointers.

## Not changed
- Changelog `0.8`/`0.9` mentions (correct history) and the FFI `Cargo.toml`
  comment.
- The npm `pkg/package.json` `0.7.2` is a generated wasm-pack artifact (version
  stamped at build time) — flagged, not hand-edited.

## Test plan
- `cargo fmt --all --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps` (zero warnings) ✓
- `cargo test --workspace` ✓ (0 failures; the charuco/puzzleboard rustdoc
  quickstarts compile against the new re-exports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dd7sgzbAA3SzujnatMWrvu
