### PR TITLE
feat(projective-grid): stable-tier neighbour-midpoint predictor (predict_grid_position)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ expected. Detection behaviour on the public benchmark is byte-identical.
 
 ### Added
 
+- **`projective_grid::predict_grid_position` / `PredictedPosition`** — the
+  neighbour-midpoint position predictor is back on the stable tier, as one
+  lattice-generic function (`lattice::predict`). It averages the midpoints of
+  the available opposite neighbour pairs (2 axis families on square, 3 on hex
+  axial) from a `HashMap<Coord, Point2<F>>`, returning `None` on the labelled
+  frontier — interpolation only, never extrapolation. This restores the
+  capability of the removed 0.9 `square_predict_grid_position` /
+  `hex_predict_grid_position` helpers (same midpoint-pair math, so downstream
+  smoothness gates keep their numerical behaviour) for consumers that run
+  local, homography-free outlier checks or seed searches for missed lattice
+  points; `n_axis_pairs` reports how constrained each prediction is.
 - **`Evidence::Oriented1`** — single-supplied-axis input is now a first-class
   evidence kind for `projective_grid::detect_grid`; the second axis is
   recovered from neighbour-chord geometry.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -399,7 +399,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "calib-targets"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "assert_cmd",
  "calib-targets-aruco",
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-aruco"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "calib-targets-chessboard",
  "calib-targets-core",
@@ -442,7 +442,7 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-bench"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "calib-targets",
  "calib-targets-chessboard",
@@ -461,7 +461,7 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-charuco"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "calib-targets",
  "calib-targets-aruco",
@@ -483,7 +483,7 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-chessboard"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "approx",
  "calib-targets",
@@ -504,7 +504,7 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-core"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "chess-corners",
  "log",
@@ -534,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-marker"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "calib-targets-chessboard",
  "calib-targets-core",
@@ -551,7 +551,7 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-print"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "calib-targets-aruco",
  "calib-targets-charuco",
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-puzzleboard"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "calib-targets",
  "calib-targets-chessboard",
@@ -589,7 +589,7 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-py"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "calib-targets",
  "chess-corners",
@@ -603,7 +603,7 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-studio"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "axum",
  "calib-targets",
@@ -622,7 +622,7 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-wasm"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "calib-targets-aruco",
  "calib-targets-charuco",
@@ -2396,7 +2396,7 @@ dependencies = [
 
 [[package]]
 name = "projective-grid"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "criterion",
  "delaunator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/VitalyVorobyev/calib-targets-rs"

--- a/crates/projective-grid/src/lattice/mod.rs
+++ b/crates/projective-grid/src/lattice/mod.rs
@@ -16,9 +16,11 @@
 use nalgebra::{Point2, Vector2};
 
 pub mod hex;
+pub mod predict;
 pub mod square;
 
 pub use hex::Hex;
+pub use predict::{predict_grid_position, PredictedPosition};
 pub use square::Square;
 
 /// How the topological pipeline turns Delaunay triangles into lattice cells.

--- a/crates/projective-grid/src/lattice/predict.rs
+++ b/crates/projective-grid/src/lattice/predict.rs
@@ -1,0 +1,236 @@
+//! Neighbour-midpoint position prediction on a labelled lattice.
+//!
+//! Given a map of already-labelled lattice coordinates to image positions,
+//! [`predict_grid_position`] predicts where a coordinate *should* sit by
+//! averaging the midpoints of its opposite neighbour pairs, one pair per
+//! lattice axis family (2 on square, 3 on hex axial). The prediction is
+//! purely local and homography-free, so it tolerates lens distortion that a
+//! single global projective fit cannot model.
+//!
+//! Because it only ever *interpolates* between opposite neighbours, the
+//! prediction is available exactly where it is reliable: a coordinate on the
+//! outer frontier of the labelled set (no complete opposite pair) yields
+//! `None` rather than an extrapolated guess. Typical uses are smoothness
+//! checks (compare a detected position against its neighbour-midpoint
+//! prediction to flag outliers) and seeding a local search for a lattice
+//! point that the feature detector missed.
+
+use std::collections::HashMap;
+
+use nalgebra::Point2;
+
+use crate::float::{lit, Float};
+
+use super::{Coord, LatticeKind};
+
+/// A neighbour-midpoint position prediction from [`predict_grid_position`].
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[non_exhaustive]
+pub struct PredictedPosition<F: Float> {
+    /// Predicted image position: the average of the available opposite-pair
+    /// midpoints.
+    pub position: Point2<F>,
+    /// Number of complete opposite neighbour pairs the prediction averages
+    /// (1..= the family's axis count). More pairs constrain the prediction
+    /// more tightly.
+    pub n_axis_pairs: usize,
+}
+
+/// Predict a lattice coordinate's image position from its labelled
+/// neighbours.
+///
+/// For each axis family of `kind`, if both opposite neighbours of `at` are
+/// present in `labelled`, their midpoint predicts `at`; the returned position
+/// averages the available midpoints. Returns `None` when no complete
+/// opposite pair exists — this function interpolates only, it never
+/// extrapolates outward from the labelled set.
+///
+/// On a square lattice the pairs are `(±1, 0)` and `(0, ±1)`; on a hex axial
+/// lattice they are `(±1, 0)`, `(0, ±1)`, and `±(1, -1)`.
+///
+/// ```
+/// use nalgebra::Point2;
+/// use projective_grid::{predict_grid_position, Coord, LatticeKind};
+/// use std::collections::HashMap;
+///
+/// let mut labelled: HashMap<Coord, Point2<f32>> = HashMap::new();
+/// labelled.insert(Coord::new(-1, 0), Point2::new(10.0, 50.0));
+/// labelled.insert(Coord::new(1, 0), Point2::new(90.0, 50.0));
+///
+/// let pred = predict_grid_position(&labelled, Coord::new(0, 0), LatticeKind::Square).unwrap();
+/// assert_eq!(pred.position, Point2::new(50.0, 50.0));
+/// assert_eq!(pred.n_axis_pairs, 1);
+///
+/// // A frontier coordinate with no opposite pair is not predicted.
+/// assert!(predict_grid_position(&labelled, Coord::new(2, 0), LatticeKind::Square).is_none());
+/// ```
+pub fn predict_grid_position<F: Float>(
+    labelled: &HashMap<Coord, Point2<F>>,
+    at: Coord,
+    kind: LatticeKind,
+) -> Option<PredictedPosition<F>> {
+    let half: F = lit(0.5);
+    let mut sum_x = F::zero();
+    let mut sum_y = F::zero();
+    let mut n_axis_pairs = 0usize;
+
+    for &off in kind.neighbour_offsets() {
+        // Each opposite pair {off, -off} appears twice in the neighbour set;
+        // keep the lexicographically-positive representative.
+        if off.u < 0 || (off.u == 0 && off.v < 0) {
+            continue;
+        }
+        let fwd = Coord::new(at.u + off.u, at.v + off.v);
+        let bwd = Coord::new(at.u - off.u, at.v - off.v);
+        if let (Some(pf), Some(pb)) = (labelled.get(&fwd), labelled.get(&bwd)) {
+            sum_x += half * (pf.x + pb.x);
+            sum_y += half * (pf.y + pb.y);
+            n_axis_pairs += 1;
+        }
+    }
+
+    if n_axis_pairs == 0 {
+        return None;
+    }
+    let n: F = lit(n_axis_pairs as f32);
+    Some(PredictedPosition {
+        position: Point2::new(sum_x / n, sum_y / n),
+        n_axis_pairs,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nalgebra::Matrix3;
+
+    fn assert_close(actual: Point2<f64>, expected: Point2<f64>) {
+        let err = (actual - expected).norm();
+        assert!(
+            err < 1e-9,
+            "expected {expected:?}, got {actual:?} (err {err:e})"
+        );
+    }
+
+    fn square_grid(n: i32, spacing: f64) -> HashMap<Coord, Point2<f64>> {
+        let mut map = HashMap::new();
+        for v in 0..n {
+            for u in 0..n {
+                map.insert(
+                    Coord::new(u, v),
+                    Point2::new(u as f64 * spacing, v as f64 * spacing),
+                );
+            }
+        }
+        map
+    }
+
+    fn hex_grid(radius: i32, spacing: f64) -> HashMap<Coord, Point2<f64>> {
+        let sqrt3 = 3.0f64.sqrt();
+        let mut map = HashMap::new();
+        for q in -radius..=radius {
+            for r in -radius..=radius {
+                if (q + r).abs() > radius {
+                    continue;
+                }
+                let x = spacing * (q as f64 + r as f64 * 0.5);
+                let y = spacing * (r as f64 * sqrt3 / 2.0);
+                map.insert(Coord::new(q, r), Point2::new(x, y));
+            }
+        }
+        map
+    }
+
+    fn warp(map: &mut HashMap<Coord, Point2<f64>>, h: &Matrix3<f64>) {
+        for p in map.values_mut() {
+            let w = h * nalgebra::Vector3::new(p.x, p.y, 1.0);
+            *p = Point2::new(w.x / w.z, w.y / w.z);
+        }
+    }
+
+    #[test]
+    fn square_interior_predicts_exactly() {
+        let grid = square_grid(5, 40.0);
+        let pred = predict_grid_position(&grid, Coord::new(2, 2), LatticeKind::Square).unwrap();
+        assert_close(pred.position, Point2::new(80.0, 80.0));
+        assert_eq!(pred.n_axis_pairs, 2);
+    }
+
+    #[test]
+    fn square_missing_cell_is_predicted_from_neighbours() {
+        let mut grid = square_grid(5, 40.0);
+        grid.remove(&Coord::new(2, 2));
+        let pred = predict_grid_position(&grid, Coord::new(2, 2), LatticeKind::Square).unwrap();
+        assert_close(pred.position, Point2::new(80.0, 80.0));
+        assert_eq!(pred.n_axis_pairs, 2);
+    }
+
+    #[test]
+    fn square_edge_uses_single_pair() {
+        let grid = square_grid(5, 40.0);
+        // (2, 0): vertical pair needs (2, -1) which does not exist.
+        let pred = predict_grid_position(&grid, Coord::new(2, 0), LatticeKind::Square).unwrap();
+        assert_eq!(pred.n_axis_pairs, 1);
+        assert_close(pred.position, Point2::new(80.0, 0.0));
+    }
+
+    #[test]
+    fn square_corner_has_no_pair() {
+        let grid = square_grid(5, 40.0);
+        assert!(predict_grid_position(&grid, Coord::new(0, 0), LatticeKind::Square).is_none());
+        assert!(predict_grid_position(&grid, Coord::new(-1, 2), LatticeKind::Square).is_none());
+    }
+
+    #[test]
+    fn hex_interior_averages_three_pairs() {
+        let grid = hex_grid(3, 60.0);
+        let pred = predict_grid_position(&grid, Coord::new(0, 0), LatticeKind::Hex).unwrap();
+        assert_eq!(pred.n_axis_pairs, 3);
+        assert_close(pred.position, Point2::new(0.0, 0.0));
+    }
+
+    #[test]
+    fn hex_frontier_yields_none() {
+        let grid = hex_grid(2, 60.0);
+        // (3, 0) is outside the radius-2 disc with no bracketing neighbours.
+        assert!(predict_grid_position(&grid, Coord::new(3, 0), LatticeKind::Hex).is_none());
+    }
+
+    #[test]
+    fn perspective_warp_keeps_prediction_close() {
+        // Midpoint interpolation is exact for affine maps and first-order
+        // accurate under projective warps; a mild perspective term must keep
+        // the residual well under a pixel at 40 px pitch.
+        let h = Matrix3::new(
+            0.9, 0.05, 12.0, //
+            -0.04, 1.1, -7.0, //
+            2e-4, 1e-4, 1.0,
+        );
+        for (kind, mut grid) in [
+            (LatticeKind::Square, square_grid(7, 40.0)),
+            (LatticeKind::Hex, hex_grid(3, 40.0)),
+        ] {
+            warp(&mut grid, &h);
+            for (&at, &truth) in &grid {
+                let Some(pred) = predict_grid_position(&grid, at, kind) else {
+                    continue;
+                };
+                let err = (pred.position - truth).norm();
+                assert!(
+                    err < 0.5,
+                    "{kind:?} at {at:?}: prediction off by {err:.3} px"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn displaced_point_does_not_poison_its_own_prediction() {
+        // The prediction at `at` never reads `labelled[at]`, so a displaced
+        // detection is still compared against a clean neighbour consensus.
+        let mut grid = square_grid(5, 40.0);
+        grid.insert(Coord::new(2, 2), Point2::new(95.0, 71.0));
+        let pred = predict_grid_position(&grid, Coord::new(2, 2), LatticeKind::Square).unwrap();
+        assert_close(pred.position, Point2::new(80.0, 80.0));
+    }
+}

--- a/crates/projective-grid/src/lib.rs
+++ b/crates/projective-grid/src/lib.rs
@@ -152,8 +152,9 @@ pub use crate::error::{EvidenceKind, GridError, GridTask};
 pub use crate::feature::{CoordinateHypothesis, LocalAxis, OrientedFeature, PointFeature};
 pub use crate::float::Float;
 pub use crate::lattice::{
-    Coord, GridDimensions, GridTransform, Hex, Lattice, LatticeKind, Square, D4_TRANSFORMS,
-    D6_TRANSFORMS, HEX_AXIAL_OFFSETS, SQUARE_CARDINAL_OFFSETS,
+    predict_grid_position, Coord, GridDimensions, GridTransform, Hex, Lattice, LatticeKind,
+    PredictedPosition, Square, D4_TRANSFORMS, D6_TRANSFORMS, HEX_AXIAL_OFFSETS,
+    SQUARE_CARDINAL_OFFSETS,
 };
 pub use crate::orient::{
     synthesize_oriented2, synthesize_oriented2_from_oriented1, synthesize_oriented3,


### PR DESCRIPTION
## What

Adds `projective_grid::predict_grid_position` + `PredictedPosition` (new `lattice::predict` module, re-exported at the root) and bumps the workspace version 0.10.0 → 0.10.1.

```rust
pub fn predict_grid_position<F: Float>(
    labelled: &HashMap<Coord, Point2<F>>,
    at: Coord,
    kind: LatticeKind,
) -> Option<PredictedPosition<F>>  // { position, n_axis_pairs }
```

Opposite-pair midpoint averaging, one pair per axis family (2 on square, 3 on hex axial). Interpolation only — frontier coordinates with no complete opposite pair return `None`. Float-generic (f32/f64), stable tier (not `shared::*`).

## Why

projective-grid 0.10 removed the 0.9 `square_predict_grid_position` / `hex_predict_grid_position` helpers with no public successor (the equivalent engine math in `shared::grow::predict` is `pub(crate)` and engine-shaped). Downstream, ringgrid's geometric-verify local test and completion seeding consumed the deleted hex helper; re-implementing lattice-prediction math the crate conceptually owns would duplicate it. This restores the capability as one lattice-generic function — the same midpoint-pair math as 0.9, so ringgrid's hex regression baselines keep their numerical behaviour, and the square arm serves upcoming square-lattice ring targets.

## Notes for the release

- The delta vs the published projective-grid 0.10.0 is purely additive → 0.10.1 is correct semver **for projective-grid**.
- The workspace `Unreleased` changelog section still carries breaking changes for the `calib-targets-*` crates (e.g. `GridCoords` removal ripples) that are already inside the published projective-grid 0.10.0 but not yet released for the other crates. If tagging `v0.10.1` publishes the whole crate list, those crates get breaking changes under a patch bump — you may prefer rolling them to 0.11.0 separately. ringgrid only needs **projective-grid** ≥ 0.10.1 on crates.io.

## Testing

- 8 new unit tests (exact interior/edge/corner predictions on square + hex, missing-cell seeding, perspective-warp residual < 0.5 px at 40 px pitch, displaced-point independence) + 1 doctest.
- `cargo test -p projective-grid` (147 lib + doc), `cargo clippy -p projective-grid --all-targets -- -D warnings`, `cargo fmt --check`, `cargo build --workspace` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)