### PR TITLE
fix: correct MSRV to 1.91 + drop unused fixed dep (0.11.1)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -232,5 +232,5 @@ generated data stay out of Git. Stage files individually; never `git add -A` in
 a directory that may contain them. Details in
 [`docs/development/conventions.md`](../docs/development/conventions.md#local-only-artifacts--never-commit).
 
-**MSRV:** workspace sets `rust-version = "1.88"`. Toolchain pinned to `stable`
+**MSRV:** workspace sets `rust-version = "1.91"`. Toolchain pinned to `stable`
 in `rust-toolchain.toml`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,34 @@ jobs:
         # in the root Cargo.toml.
         run: cargo test --workspace --all-targets
 
+  msrv:
+    # Verify the declared MSRV (`rust-version` in the root Cargo.toml) actually
+    # builds. Cargo never cross-checks `rust-version` against dependencies'
+    # own floors, so the declaration rots silently when an upstream bumps
+    # theirs — exactly how 1.88 went stale once chess-corners 1.1 moved to
+    # 1.91. `cargo check --workspace` mirrors what a consumer building on the
+    # MSRV toolchain compiles. Keep the version here in sync with
+    # `rust-version` in Cargo.toml.
+    runs-on: ubuntu-latest
+    env:
+      # rust-toolchain.toml pins `stable`; RUSTUP_TOOLCHAIN outranks it.
+      RUSTUP_TOOLCHAIN: "1.91"
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.91"
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+
+      - name: check (MSRV)
+        run: cargo check --workspace
+
   wasm:
     runs-on: ubuntu-latest
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,11 +64,18 @@ Guidelines:
 - Prefer feature flags over adding many tiny crates when the boundary is not clear.
 
 ## MSRV (minimum supported Rust version)
-MSRV is currently **unspecified**.
-- If you set one, add it to:
-  - workspace `Cargo.toml`: `rust-version = "..."` (and/or per-crate)
-  - `rust-toolchain.toml` to pin toolchain in CI/dev
-- Until MSRV is defined, prefer stable Rust features and avoid nightly-only APIs.
+MSRV is **1.91**, declared as `rust-version = "1.91"` in the workspace
+`Cargo.toml` and enforced by the `msrv` CI job (which builds the whole
+workspace with 1.91 on every PR).
+- `rust-toolchain.toml` deliberately stays on `stable`, NOT the MSRV: CI's
+  fmt/clippy legs run on stable, so local development must lint with the same
+  compiler or local clippy silently misses lints CI enforces. The MSRV job —
+  not the dev toolchain — is what guards against using post-MSRV APIs.
+- When raising the MSRV, update in lockstep: `rust-version` in `Cargo.toml`,
+  the `msrv` job's toolchain in `.github/workflows/ci.yml`, the README badge,
+  `book/src/intro.md`, and this section. Cargo does not cross-check
+  `rust-version` against dependencies' floors, so bump ours whenever a
+  dependency (e.g. `chess-corners`) raises its own.
 
 ## How to make changes
 - Keep diffs small and focused.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ see [Older releases](#older-releases) at the bottom for the index.
 
 ## Unreleased
 
+## 0.11.1
+
+Metadata-only patch: no code or behaviour changes.
+
+### Fixed
+
+- **MSRV corrected to 1.91.** The declared `rust-version = "1.88"` had gone
+  stale: `chess-corners` 1.1 requires rustc 1.91, so 0.11.0 could not actually
+  be built on 1.88–1.90 despite its metadata claiming otherwise (Cargo does
+  not cross-check `rust-version` against dependencies). The workspace now
+  declares 1.91 — the same floor as `chess-corners` — and CI gained an `msrv`
+  job that builds with 1.91 on every PR so the claim cannot rot silently
+  again.
+- **Dropped the unused `fixed` dependency.** `kiddo`'s default features pull
+  in fixed-point axis support that no crate here uses (all k-d trees are
+  `f32`); the workspace now depends on `kiddo` with
+  `default-features = false, features = ["tracing"]`. This also removes the
+  one transitive that would otherwise have forced the MSRV to 1.93.
+
 ## 0.11.0
 
 This release is dominated by the migration to **`chess-corners` 1.0**, an

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,7 +381,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "calib-targets"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "assert_cmd",
  "calib-targets-aruco",
@@ -409,7 +409,7 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-aruco"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "calib-targets-chessboard",
  "calib-targets-core",
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-bench"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "calib-targets",
  "calib-targets-chessboard",
@@ -443,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-charuco"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "calib-targets",
  "calib-targets-aruco",
@@ -466,7 +466,7 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-chessboard"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "approx",
  "calib-targets",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-core"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "chess-corners",
  "nalgebra",
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-marker"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "calib-targets-chessboard",
  "calib-targets-core",
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-print"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "calib-targets-aruco",
  "calib-targets-charuco",
@@ -547,7 +547,7 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-puzzleboard"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "calib-targets",
  "calib-targets-chessboard",
@@ -569,7 +569,7 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-py"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "calib-targets",
  "chess-corners",
@@ -583,7 +583,7 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-studio"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "axum",
  "calib-targets",
@@ -602,7 +602,7 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-wasm"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "calib-targets",
  "calib-targets-aruco",
@@ -1064,19 +1064,6 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
-name = "fixed"
-version = "1.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9af2cbf772fa6d1c11358f92ef554cb6b386201210bcf0e91fb7fba8a907fb40"
-dependencies = [
- "az",
- "bytemuck",
- "half",
- "num-traits",
- "typenum",
-]
 
 [[package]]
 name = "flate2"
@@ -1583,7 +1570,6 @@ dependencies = [
  "az",
  "cmov",
  "divrem",
- "fixed",
  "generator",
  "num-traits",
  "ordered-float",
@@ -2172,7 +2158,7 @@ dependencies = [
 
 [[package]]
 name = "projective-grid"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "criterion",
  "delaunator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,13 +32,13 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/VitalyVorobyev/calib-targets-rs"
 homepage = "https://vitalyvorobyev.github.io/calib-targets-rs/"
 documentation = "https://vitalyvorobyev.github.io/calib-targets-rs/api"
-rust-version = "1.88"
+rust-version = "1.91"
 
 [workspace.lints.clippy]
 # Re-introducing `#[allow(clippy::too_many_arguments)]` to silence the
@@ -105,7 +105,7 @@ image = { version = "0.25", default-features = false, features = [
     "tiff",
     "webp",
 ] }
-kiddo = "5"
+kiddo = { version = "5", default-features = false, features = ["tracing"] }
 log = "0.4"
 nalgebra = "0.35"
 numpy = "0.29"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![CI](https://github.com/VitalyVorobyev/calib-targets-rs/actions/workflows/ci.yml/badge.svg)](https://github.com/VitalyVorobyev/calib-targets-rs/actions/workflows/ci.yml)
 [![Security audit](https://github.com/VitalyVorobyev/calib-targets-rs/actions/workflows/audit.yml/badge.svg)](https://github.com/VitalyVorobyev/calib-targets-rs/actions/workflows/audit.yml)
 [![Docs](https://github.com/VitalyVorobyev/calib-targets-rs/actions/workflows/docs.yml/badge.svg)](https://vitalyvorobyev.github.io/calib-targets-rs/)
-[![MSRV](https://img.shields.io/badge/MSRV-1.88-blue.svg)](https://blog.rust-lang.org/2025/06/26/Rust-1.88.0/)
+[![MSRV](https://img.shields.io/badge/MSRV-1.91-blue.svg)](https://blog.rust-lang.org/2025/10/30/Rust-1.91.0/)
 
 **Calibration-target detection in Rust.** Detects chessboards, ChArUco,
 PuzzleBoard, and checkerboard marker boards from grayscale images.

--- a/book/src/intro.md
+++ b/book/src/intro.md
@@ -68,4 +68,4 @@ dataclasses with `to_dict()`/`from_dict(...)` helpers for JSON interoperability.
 For marker boards, `target_position` is populated only when
 `params.board.cell_size` is set and alignment succeeds.
 
-MSRV: Rust 1.88 (stable).
+MSRV: Rust 1.91 (stable).


### PR DESCRIPTION
Metadata-only patch release prep — no code or behaviour changes.

## What

- **MSRV 1.88 → 1.91.** The declared `rust-version = "1.88"` was stale: `chess-corners` 1.1 requires rustc 1.91, so 0.11.0 cannot actually build on 1.88–1.90 despite its metadata. Cargo never cross-checks `rust-version` against dependencies' floors and CI only built `stable`, so nothing ever surfaced it. Verified empirically: 1.88 hard-fails (chess-corners/box-image-pyramid need 1.91, nalgebra/wide 1.89), 1.91 compiles the full workspace clean.
- **Drop `fixed` from the dependency tree.** kiddo's default features enable fixed-point k-d tree axes nobody here uses (all trees are f32): now `kiddo = { default-features = false, features = ["tracing"] }`. This also removes the one transitive (`fixed` 1.31, rust-version 1.93) that would otherwise dictate a 1.93 floor.
- **New `msrv` CI job** — builds the workspace with 1.91 on every PR (`RUSTUP_TOOLCHAIN` outranks the repo's `rust-toolchain.toml` stable pin), so the declaration can never rot silently again.
- **Workspace bumped to 0.11.1** so the published crates carry the corrected metadata; badge, book intro, and CLAUDE.md updated to match.

## Verification

fmt / clippy `-D warnings` / `cargo test --workspace` (70 suites, 0 failures) / doc zero-warnings / `cargo deny check` / `cargo +1.91.0 check --workspace` all green locally.

Release plan after merge: tag `v0.11.1` (crates.io + PyPI + FFI archives). No `wasm-v0.11.1` — nothing npm-relevant changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBC4RmExzVTLTs4qAjSB3E