### PR TITLE
release: 0.11.2 — chess-corners 1.2 migration, drop direct chess-corners-core dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,20 @@ see [Older releases](#older-releases) at the bottom for the index.
 
 ## Unreleased
 
-## 0.11.1
+## 0.11.2
+
+Dependency-cleanup patch: no public API or behaviour changes.
+
+### Changed
+
+- **Migrated to `chess-corners` 1.2 and dropped the direct
+  `chess-corners-core` dependency.** The ChArUco local corner re-detection
+  and the FFI config lowering previously hand-composed low-level
+  `chess-corners-core` primitives (patch response + origin-offset image view
+  + refiner plumbing); they now drive the facade's single-scale ROI entry
+  point (`Detector::detect_u8_roi`, new in `chess-corners` 1.2). One fewer
+  direct dependency, one strategy-lowering site upstream, identical
+  detection results (full regression suites pass unchanged).
 
 Metadata-only patch: no code or behaviour changes.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,9 +325,9 @@ dependencies = [
 
 [[package]]
 name = "box-image-pyramid"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58db2aca6700a9bcf47012920fc7050090bac3c0f89a36fd757359e81b0d325f"
+checksum = "f60e7b0ed84477c5d16709138f4a8d69c8c94f8ef010f4568f4b2b66909236ad"
 dependencies = [
  "rayon",
 ]
@@ -381,7 +381,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "calib-targets"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "assert_cmd",
  "calib-targets-aruco",
@@ -409,7 +409,7 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-aruco"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "calib-targets-chessboard",
  "calib-targets-core",
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-bench"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "calib-targets",
  "calib-targets-chessboard",
@@ -443,14 +443,13 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-charuco"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "calib-targets",
  "calib-targets-aruco",
  "calib-targets-chessboard",
  "calib-targets-core",
  "chess-corners",
- "chess-corners-core",
  "criterion",
  "env_logger",
  "image",
@@ -466,7 +465,7 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-chessboard"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "approx",
  "calib-targets",
@@ -487,7 +486,7 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-core"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "chess-corners",
  "nalgebra",
@@ -504,7 +503,6 @@ dependencies = [
  "calib-targets",
  "cbindgen",
  "chess-corners",
- "chess-corners-core",
  "flate2",
  "image",
  "serde",
@@ -515,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-marker"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "calib-targets-chessboard",
  "calib-targets-core",
@@ -531,7 +529,7 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-print"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "calib-targets-aruco",
  "calib-targets-charuco",
@@ -547,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-puzzleboard"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "calib-targets",
  "calib-targets-chessboard",
@@ -569,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-py"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "calib-targets",
  "chess-corners",
@@ -583,7 +581,7 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-studio"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "axum",
  "calib-targets",
@@ -602,7 +600,7 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-wasm"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "calib-targets",
  "calib-targets-aruco",
@@ -678,9 +676,9 @@ dependencies = [
 
 [[package]]
 name = "chess-corners"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a93909d10ae8867ffb0872e0337c55af9e374a21af655ad3c5f124dffca0b0"
+checksum = "ff45579842c7af9ea2c8ba5f783741d0ecbffd7ecd324013dae736d175015fb4"
 dependencies = [
  "box-image-pyramid",
  "chess-corners-core",
@@ -693,9 +691,9 @@ dependencies = [
 
 [[package]]
 name = "chess-corners-core"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c509f18ee5552b3b1e09a736eaa6ed0e6b5d693d8328dab5762fed03cfec620"
+checksum = "fed54c772847709e809dbd0a41cdef908d7f724825807f3f2b4f37f16630ef96"
 dependencies = [
  "log",
  "rayon",
@@ -2158,7 +2156,7 @@ dependencies = [
 
 [[package]]
 name = "projective-grid"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "criterion",
  "delaunator",
@@ -2186,7 +2184,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.11.1"
+version = "0.11.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/VitalyVorobyev/calib-targets-rs"
@@ -64,15 +64,7 @@ approx = "0.5"
 assert_cmd = "2"
 axum = "0.8"
 cbindgen = "0.29"
-chess-corners = "1.1"
-# The low-level ChESS contract (`ChessParams`, `RefinerKind`, `ImageView`,
-# `Roi`, `Refiner`, `chess_response_u8_patch`,
-# `detect_corners_from_response_with_refiner`) moved out of the removed
-# `chess_corners::low_level` module and onto the `chess-corners-core` crate
-# root in 1.0, so the crates that drive the response/detect stages by hand
-# (charuco corner refit, puzzleboard + charuco redetect params, the FFI
-# config lowering) now depend on it directly.
-chess-corners-core = "1.1"
+chess-corners = "1.2"
 clap = "4.5"
 criterion = { version = "0.5", default-features = false, features = ["cargo_bench_support", "html_reports"] }
 delaunator = "1.0"

--- a/crates/calib-targets-charuco/Cargo.toml
+++ b/crates/calib-targets-charuco/Cargo.toml
@@ -44,7 +44,6 @@ calib-targets-core.workspace = true
 calib-targets-chessboard.workspace = true
 calib-targets-aruco.workspace = true
 chess-corners = { workspace = true, features = ["rayon"] }
-chess-corners-core.workspace = true
 nalgebra.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true

--- a/crates/calib-targets-charuco/src/detector/corner_refit.rs
+++ b/crates/calib-targets-charuco/src/detector/corner_refit.rs
@@ -48,10 +48,7 @@ use calib_targets_aruco::MarkerDetection;
 use calib_targets_core::{
     estimate_homography_rect_to_img, GrayImageView, LabeledCorner, TargetDetection, TargetKind,
 };
-use chess_corners_core::{
-    chess_response_u8_patch, detect_corners_from_response_with_refiner, ChessParams, ImageView,
-    Refiner, Roi,
-};
+use chess_corners::{Detector, Roi};
 use nalgebra::Point2;
 
 // ---------------------------------------------------------------------------
@@ -60,8 +57,8 @@ use nalgebra::Point2;
 
 /// Configuration for the corner validation stage.
 ///
-/// Groups the three tuning parameters so that `validate_and_fix_corners` stays
-/// within the argument-count limit.
+/// Groups the validation thresholds and the re-detection engine so that
+/// `validate_and_fix_corners` stays within the argument-count limit.
 pub(crate) struct CornerValidationConfig<'a> {
     /// Side length of one board square in pixels (used to scale thresholds).
     pub px_per_square: f32,
@@ -69,8 +66,11 @@ pub(crate) struct CornerValidationConfig<'a> {
     /// expressed as a fraction of `px_per_square`.  Set to `f32::INFINITY`
     /// to disable validation entirely.
     pub threshold_rel: f32,
-    /// ChESS detector parameters used for local re-detection.
-    pub chess_params: &'a ChessParams,
+    /// Re-detection engine for suspected false corners. Built once per detect
+    /// call from [`CharucoParams::corner_redetect_params`](crate::CharucoParams)
+    /// and threaded as `&mut` so its internal scratch buffers are reused across
+    /// corners and both validation stages.
+    pub detector: &'a mut Detector,
 }
 
 // ---------------------------------------------------------------------------
@@ -158,8 +158,10 @@ fn collect_board_to_image_correspondences(
 
 /// Run a local ChESS detection in a window centred on `seed`.
 ///
-/// Uses `chess_response_u8_patch` on the full image restricted to a patch of
-/// half-width `roi_half_px`, then runs NMS + subpixel refinement.
+/// Drives the facade's single-scale ROI detector
+/// ([`Detector::detect_u8_roi`]) over a window of half-width `roi_half_px`
+/// around `seed`, clamped to the image bounds. The detector reports corners
+/// already in the full-image pixel frame.
 ///
 /// Returns the image-space position of the strongest corner found within
 /// `roi_half_px` of the seed, or `None` if no corner is found.
@@ -167,7 +169,7 @@ pub(crate) fn redetect_corner_in_roi(
     image: &GrayImageView<'_>,
     seed: Point2<f32>,
     roi_half_px: i32,
-    chess_params: &ChessParams,
+    detector: &mut Detector,
 ) -> Option<Point2<f32>> {
     // Compute ROI in integer image coords, clamped to image bounds.
     let x0 = ((seed.x as i32) - roi_half_px).max(0) as usize;
@@ -179,56 +181,33 @@ pub(crate) fn redetect_corner_in_roi(
         return None;
     }
 
-    // Compute ChESS response only inside the ROI.
-    let patch_resp = chess_response_u8_patch(
-        image.data,
-        image.width,
-        image.height,
-        chess_params,
-        Roi::new(x0, y0, x1, y1)?,
-    );
+    let roi = Roi::new(x0, y0, x1, y1)?;
+    // The ROI path is single-scale and reports positions in the full-image
+    // frame. Its only error modes are a dimension mismatch or an unsupported
+    // (ML) refiner, neither of which the internal redetect config can hit, so
+    // treat any error as "no corner found".
+    let corners = detector
+        .detect_u8_roi(image.data, image.width as u32, image.height as u32, roi)
+        .ok()?;
 
-    if patch_resp.width() == 0 || patch_resp.height() == 0 {
-        return None;
-    }
-
-    // Build an ImageView with origin = (x0, y0) so the refiner reads the
-    // correct global pixels even though the response map has local coords.
-    let refine_view = ImageView::with_origin(
-        image.width,
-        image.height,
-        image.data,
-        [x0 as i32, y0 as i32],
-    )?;
-
-    let mut refiner = Refiner::from_kind(chess_params.refiner.clone());
-    let raw_corners = detect_corners_from_response_with_refiner(
-        &patch_resp,
-        chess_params,
-        Some(refine_view),
-        &mut refiner,
-    );
-
-    // Shift patch-local coordinates back to global image coordinates and pick
-    // the strongest corner that is within roi_half_px of the seed.
+    // Pick the strongest corner within roi_half_px of the seed.
     let seed_x = seed.x;
     let seed_y = seed.y;
     let max_dist2 = (roi_half_px as f32) * (roi_half_px as f32);
 
-    raw_corners
+    corners
         .into_iter()
-        .map(|c| {
-            let gx = c.x + x0 as f32;
-            let gy = c.y + y0 as f32;
-            (c.strength, gx, gy)
-        })
-        .filter(|&(_s, gx, gy)| {
-            let dx = gx - seed_x;
-            let dy = gy - seed_y;
+        .filter(|c| {
+            let dx = c.x - seed_x;
+            let dy = c.y - seed_y;
             dx * dx + dy * dy <= max_dist2
         })
-        .max_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal))
-        .map(|(_s, gx, gy)| Point2::new(gx, gy))
+        .max_by(|a, b| {
+            a.response
+                .partial_cmp(&b.response)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        })
+        .map(|c| Point2::new(c.x, c.y))
 }
 
 // ---------------------------------------------------------------------------
@@ -259,7 +238,7 @@ pub(crate) fn validate_and_fix_corners(
     markers: &[MarkerDetection],
     alignment: &CharucoAlignment,
     image: &GrayImageView<'_>,
-    cfg: &CornerValidationConfig<'_>,
+    cfg: CornerValidationConfig<'_>,
 ) -> TargetDetection {
     // Fast path: validation disabled or no markers to consult.
     if cfg.threshold_rel.is_infinite() || markers.is_empty() {
@@ -315,7 +294,7 @@ pub(crate) fn validate_and_fix_corners(
         }
 
         // Corner is a candidate false positive — attempt local re-detection.
-        match redetect_corner_in_roi(image, seed, roi_half_px, cfg.chess_params) {
+        match redetect_corner_in_roi(image, seed, roi_half_px, cfg.detector) {
             Some(new_pos) => {
                 // Replace the false position with the re-detected one.
                 let mut fixed = corner;

--- a/crates/calib-targets-charuco/src/detector/grid_smoothness.rs
+++ b/crates/calib-targets-charuco/src/detector/grid_smoothness.rs
@@ -10,7 +10,7 @@
 
 use super::corner_refit::redetect_corner_in_roi;
 use calib_targets_core::{square_predict_grid_position, Coord, CornerMap, GrayImageView};
-use chess_corners_core::ChessParams;
+use chess_corners::Detector;
 use log::debug;
 use nalgebra::Point2;
 
@@ -29,7 +29,7 @@ pub(crate) fn smooth_grid_corners(
     image: &GrayImageView<'_>,
     px_per_square: f32,
     threshold_rel: f32,
-    chess_params: &ChessParams,
+    detector: &mut Detector,
 ) {
     if threshold_rel.is_infinite() || corner_map.len() < 3 {
         return;
@@ -68,7 +68,7 @@ pub(crate) fn smooth_grid_corners(
     }
 
     for (gc, predicted) in flagged {
-        match redetect_corner_in_roi(image, predicted, roi_half_px, chess_params) {
+        match redetect_corner_in_roi(image, predicted, roi_half_px, detector) {
             Some(new_pos) => {
                 debug!(
                     "grid smoothness: re-detected corner ({},{}) at ({:.1},{:.1}) -> ({:.1},{:.1})",
@@ -120,9 +120,10 @@ mod tests {
             width: 1,
             height: 1,
         };
-        let params = ChessParams::default();
+        let mut detector = Detector::new(crate::detector::params::default_redetect_params())
+            .expect("valid redetect config");
 
-        smooth_grid_corners(&mut map, &dummy_image, spacing, 0.05, &params);
+        smooth_grid_corners(&mut map, &dummy_image, spacing, 0.05, &mut detector);
 
         // All 9 corners should remain.
         assert_eq!(map.len(), 9);
@@ -143,9 +144,10 @@ mod tests {
             width: 1,
             height: 1,
         };
-        let params = ChessParams::default();
+        let mut detector = Detector::new(crate::detector::params::default_redetect_params())
+            .expect("valid redetect config");
 
-        smooth_grid_corners(&mut map, &dummy_image, spacing, 0.05, &params);
+        smooth_grid_corners(&mut map, &dummy_image, spacing, 0.05, &mut detector);
 
         // All corners should remain unchanged.
         assert_eq!(map.len(), 9);
@@ -175,9 +177,10 @@ mod tests {
             width: 1,
             height: 1,
         };
-        let params = ChessParams::default();
+        let mut detector = Detector::new(crate::detector::params::default_redetect_params())
+            .expect("valid redetect config");
 
-        smooth_grid_corners(&mut map, &dummy_image, spacing, 0.05, &params);
+        smooth_grid_corners(&mut map, &dummy_image, spacing, 0.05, &mut detector);
 
         // No corners should be removed.
         assert_eq!(map.len(), orig_len);
@@ -196,9 +199,10 @@ mod tests {
             width: 1,
             height: 1,
         };
-        let params = ChessParams::default();
+        let mut detector = Detector::new(crate::detector::params::default_redetect_params())
+            .expect("valid redetect config");
 
-        smooth_grid_corners(&mut map, &dummy_image, spacing, 0.05, &params);
+        smooth_grid_corners(&mut map, &dummy_image, spacing, 0.05, &mut detector);
 
         // Middle should be snapped to predicted position, not removed.
         assert_eq!(map.len(), 3);
@@ -220,9 +224,10 @@ mod tests {
             width: 1,
             height: 1,
         };
-        let params = ChessParams::default();
+        let mut detector = Detector::new(crate::detector::params::default_redetect_params())
+            .expect("valid redetect config");
 
-        smooth_grid_corners(&mut map, &dummy_image, spacing, 0.05, &params);
+        smooth_grid_corners(&mut map, &dummy_image, spacing, 0.05, &mut detector);
 
         // Both corners should remain (no pairs to predict from).
         assert_eq!(map.len(), 2);

--- a/crates/calib-targets-charuco/src/detector/params.rs
+++ b/crates/calib-targets-charuco/src/detector/params.rs
@@ -2,8 +2,7 @@ use crate::board::CharucoBoardSpec;
 use calib_targets_aruco::ScanDecodeConfig;
 use calib_targets_chessboard::{ChessboardAdvancedTuning, ChessboardParams};
 use calib_targets_core::{default_chess_config, DetectorConfig};
-use chess_corners::SaddlePointConfig;
-use chess_corners_core::{ChessParams as ChessCornerParams, RefinerKind};
+use chess_corners::{ChessRefiner, SaddlePointConfig};
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 
@@ -57,18 +56,18 @@ pub struct CharucoParams {
     /// Minimal number of marker inliers needed to accept the alignment.
     #[serde(default = "default_min_marker_inliers")]
     pub min_marker_inliers: usize,
-    /// ChESS detector parameters used for local corner re-detection.
+    /// ChESS detector configuration used for local corner re-detection.
     ///
-    /// When validation identifies a false corner, these parameters control
-    /// the ChESS response computation and subpixel refinement in a small
-    /// patch centred on the marker-predicted seed position.
+    /// When validation identifies a false corner, this config drives a
+    /// single-scale ROI detection ([`chess_corners::Detector::detect_u8_roi`])
+    /// in a small window centred on the marker-predicted seed position.
     ///
     /// Internal (`pub(crate)`): the field carries the upstream `chess_corners`
-    /// parameter type and is `#[serde(skip)]`, so JSON / binding consumers
+    /// [`DetectorConfig`] and is `#[serde(skip)]`, so JSON / binding consumers
     /// could never set it — it is reconstructed from defaults on every
     /// deserialisation and is not part of the public configuration surface.
     #[serde(skip)]
-    pub(crate) corner_redetect_params: ChessCornerParams,
+    pub(crate) corner_redetect_params: DetectorConfig,
     /// Opt-in, **unstable** board-level-matcher and corner-validation tuning
     /// knobs. Leave unset (`None`) unless a specific input fails and you have
     /// evidence for the change; `None` behaves exactly like
@@ -213,36 +212,23 @@ fn default_cell_weight_border_threshold() -> f32 {
     0.5
 }
 
-/// Build the ChESS parameters used for local re-detection inside a small ROI.
+/// Build the ChESS config used for local re-detection inside a small ROI.
 ///
 /// Lower threshold and looser cluster requirement compared to the global scan,
 /// because we already know approximately where the true corner should be.
-pub(crate) fn default_redetect_params() -> ChessCornerParams {
-    let mut params = ChessCornerParams::default();
-    // `threshold = 0.0` is the paper contract ("keep every strictly-positive
-    // response"), which is what this ROI re-detection has always actually run
-    // at. Under chess-corners 0.11 this line read `threshold_rel = 0.05`, but
-    // that never took effect: 0.11 resolved the cutoff as
-    // `threshold_abs.unwrap_or(threshold_rel * max_response)` and
-    // `ChessParams::default()` set `threshold_abs = Some(0.0)`, so the
-    // absolute floor always won and the relative value was dead. 1.0 collapsed
-    // the pair into a single absolute `threshold`, so writing `0.0` here
-    // preserves the behaviour exactly rather than resurrecting a knob that was
-    // never live.
-    params.threshold = 0.0;
-    params.nms_radius = 2;
-    params.min_cluster_size = 1;
-    params.refiner = RefinerKind::SaddlePoint(SaddlePointConfig::default());
-    params
-}
-
-/// Convert a `ChessCornerParams` into the upstream
-/// `chess_corners_core::ChessParams`.
-///
-/// Since `ChessCornerParams` is now a re-export of
-/// `chess_corners_core::ChessParams`, this is an identity-like operation.
-pub(crate) fn to_chess_params(params: &ChessCornerParams) -> chess_corners_core::ChessParams {
-    params.clone()
+/// `threshold = 0.0` keeps every strictly-positive response. Orientation is
+/// skipped ([`without_orientation`](DetectorConfig::without_orientation)): the
+/// re-detection consumes only the refined corner position, so the per-corner
+/// axis fit would be wasted work — preserving the old hand-rolled path's cost.
+pub(crate) fn default_redetect_params() -> DetectorConfig {
+    DetectorConfig::chess()
+        .with_threshold(0.0)
+        .with_detection(|d| {
+            d.nms_radius = 2;
+            d.min_cluster_size = 1;
+        })
+        .with_chess(|c| c.refiner = ChessRefiner::SaddlePoint(SaddlePointConfig::default()))
+        .without_orientation()
 }
 
 impl CharucoParams {
@@ -372,29 +358,23 @@ mod tests {
 
     #[test]
     fn default_redetect_params_uses_saddle_point_refiner() {
-        let params = default_redetect_params();
+        let cfg = default_redetect_params();
         // Absolute floor of 0.0 — the paper contract, and what this path has
         // always effectively run at. See the note in `default_redetect_params`.
-        assert_eq!(params.threshold, 0.0);
-        assert_eq!(params.nms_radius, 2);
-        assert_eq!(params.min_cluster_size, 1);
+        assert_eq!(cfg.threshold, 0.0);
+        assert_eq!(cfg.detection.nms_radius, 2);
+        assert_eq!(cfg.detection.min_cluster_size, 1);
+        // Orientation is skipped: the re-detection uses only the refined
+        // position, so the per-corner axis fit would be wasted cost.
+        assert!(cfg.orientation_method.is_none());
+        let chess_corners::DetectionStrategy::Chess(chess) = cfg.strategy else {
+            panic!("expected the ChESS strategy, got {:?}", cfg.strategy);
+        };
         assert!(
-            matches!(params.refiner, RefinerKind::SaddlePoint(_)),
+            matches!(chess.refiner, ChessRefiner::SaddlePoint(_)),
             "expected SaddlePoint refiner, got {:?}",
-            params.refiner,
+            chess.refiner,
         );
-    }
-
-    #[test]
-    fn to_chess_params_is_identity() {
-        // Since ChessCornerParams IS chess_corners_core::ChessParams, to_chess_params
-        // should round-trip perfectly.
-        let mut params = ChessCornerParams::default();
-        params.threshold = 0.3;
-        params.nms_radius = 4;
-        let converted = to_chess_params(&params);
-        assert!((converted.threshold - 0.3).abs() < 1e-6);
-        assert_eq!(converted.nms_radius, 4);
     }
 
     #[test]

--- a/crates/calib-targets-charuco/src/detector/pipeline.rs
+++ b/crates/calib-targets-charuco/src/detector/pipeline.rs
@@ -6,7 +6,6 @@ use super::corner_refit::{validate_and_fix_corners, CornerValidationConfig};
 use super::grid_smoothness::smooth_grid_corners;
 use super::marker_sampling::{build_corner_map, build_marker_cells};
 use super::merge::merge_charuco_results;
-use super::params::to_chess_params;
 use super::{CharucoDetectError, CharucoDetection, CharucoParams};
 use crate::alignment::CharucoAlignment;
 use crate::board::{CharucoBoard, CharucoBoardError};
@@ -14,6 +13,7 @@ use calib_targets_aruco::MarkerDetection;
 use calib_targets_chessboard::ChessCorner;
 use calib_targets_chessboard::{ChessboardDetection, ChessboardDetector as ChessDetector};
 use calib_targets_core::{GrayImageView, LabeledCorner, TargetDetection, TargetKind};
+use chess_corners::Detector;
 use log::{debug, warn};
 
 /// Adapt a [`ChessboardDetection`] into the generic [`TargetDetection`]
@@ -351,6 +351,12 @@ impl CharucoDetector {
         // the effective tuning once for the whole component loop.
         let min_secondary_marker_inliers =
             self.params.effective_tuning().min_secondary_marker_inliers;
+        // Build the local corner re-detection engine once per detect call and
+        // reuse it across every component and both validation stages, so its
+        // internal scratch buffers are allocated a single time. The config is
+        // an internal constant (`default_redetect_params`) and always valid.
+        let mut redetector = Detector::new(self.params.corner_redetect_params)
+            .expect("internal corner-redetect config is always valid");
         let mut results: Vec<(CharucoDetection, RawMarkerCounts)> = Vec::new();
         for (i, chessboard) in components.iter().enumerate() {
             let min_inliers = if i == 0 {
@@ -359,7 +365,7 @@ impl CharucoDetector {
                 min_secondary_marker_inliers
             };
 
-            match self.detect_component(image, chessboard, min_inliers, i, sink) {
+            match self.detect_component(image, chessboard, min_inliers, i, &mut redetector, sink) {
                 Ok((result, raw_counts)) => {
                     debug!(
                         "component {i}: {} corners, {} markers",
@@ -403,6 +409,7 @@ impl CharucoDetector {
         chessboard: &ChessboardDetection,
         min_marker_inliers: usize,
         component_index: usize,
+        redetector: &mut Detector,
         sink: &mut S,
     ) -> Result<(CharucoDetection, RawMarkerCounts), CharucoDetectError> {
         // Adapt the typed chessboard result into the generic
@@ -415,13 +422,12 @@ impl CharucoDetector {
         let chessboard = chessboard_detection_to_target(chessboard);
         let inliers: Vec<usize> = (0..chessboard.corners.len()).collect();
         let mut corner_map = build_corner_map(&chessboard.corners, &inliers);
-        let corner_redetect_params = to_chess_params(&self.params.corner_redetect_params);
         smooth_grid_corners(
             &mut corner_map,
             image,
             self.params.px_per_square,
             tuning.grid_smoothness_threshold_rel,
-            &corner_redetect_params,
+            redetector,
         );
         let cells = build_marker_cells(&corner_map);
         debug!(
@@ -509,10 +515,10 @@ impl CharucoDetector {
             &markers,
             &alignment,
             image,
-            &CornerValidationConfig {
+            CornerValidationConfig {
                 px_per_square: self.params.px_per_square,
                 threshold_rel: tuning.corner_validation_threshold_rel,
-                chess_params: &corner_redetect_params,
+                detector: redetector,
             },
         );
         debug!(

--- a/crates/calib-targets-charuco/tests/rust_api_smoke.rs
+++ b/crates/calib-targets-charuco/tests/rust_api_smoke.rs
@@ -43,7 +43,7 @@ edition = "2021"
 # our stated MSRV would get. Without it the resolver picks the newest cached
 # version of every transitive dep, and a dep that raises its own rust-version
 # breaks this test for reasons unrelated to our API.
-rust-version = "1.88"
+rust-version = "1.91"
 resolver = "3"
 
 [dependencies]

--- a/crates/calib-targets-ffi/Cargo.toml
+++ b/crates/calib-targets-ffi/Cargo.toml
@@ -41,7 +41,6 @@ generate-header = ["dep:cbindgen"]
 calib-targets = { workspace = true, features = ["image", "diagnostics"] }
 cbindgen = { workspace = true, optional = true }
 chess-corners.workspace = true
-chess-corners-core.workspace = true
 flate2.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/calib-targets-ffi/src/convert.rs
+++ b/crates/calib-targets-ffi/src/convert.rs
@@ -10,7 +10,7 @@
 
 use crate::error::{FfiError, FfiResult};
 use crate::types::{
-    ct_charuco_board_spec_t, ct_charuco_detector_params_t, ct_chess_config_t, ct_chess_params_t,
+    ct_charuco_board_spec_t, ct_charuco_detector_params_t, ct_chess_config_t,
     ct_chessboard_advanced_t, ct_chessboard_corner_t, ct_chessboard_params_t,
     ct_circle_match_params_t, ct_circle_polarity_t, ct_circle_score_params_t, ct_dictionary_id_t,
     ct_grid_alignment_t, ct_grid_coords_t, ct_grid_transform_t, ct_labeled_corner_t,
@@ -58,14 +58,13 @@ use chess_corners::{
     CenterOfMassConfig, ChessRefiner, ChessRing, ForstnerConfig, MultiscaleConfig,
     SaddlePointConfig, UpscaleConfig,
 };
-use chess_corners_core::{ChessParams, RefinerKind};
 
 // ─── Shared ChESS config ────────────────────────────────────────────────────
 
 pub(crate) fn convert_refiner_kind(
     value: crate::types::ct_refiner_kind_t,
     cfg: &crate::types::ct_refiner_config_t,
-) -> FfiResult<RefinerKind> {
+) -> FfiResult<ChessRefiner> {
     match value {
         CT_REFINER_KIND_CENTER_OF_MASS => {
             if cfg.center_of_mass.radius < 0 {
@@ -75,7 +74,7 @@ pub(crate) fn convert_refiner_kind(
             }
             let mut out = CenterOfMassConfig::default();
             out.radius = cfg.center_of_mass.radius;
-            Ok(RefinerKind::CenterOfMass(out))
+            Ok(ChessRefiner::CenterOfMass(out))
         }
         CT_REFINER_KIND_FORSTNER => {
             if cfg.forstner.radius < 0 {
@@ -94,7 +93,7 @@ pub(crate) fn convert_refiner_kind(
             )?;
             out.max_offset =
                 require_nonnegative(cfg.forstner.max_offset, "refiner.forstner.max_offset")?;
-            Ok(RefinerKind::Forstner(out))
+            Ok(ChessRefiner::Forstner(out))
         }
         CT_REFINER_KIND_SADDLE_POINT => {
             if cfg.saddle_point.radius < 0 {
@@ -116,24 +115,12 @@ pub(crate) fn convert_refiner_kind(
                 cfg.saddle_point.min_abs_det,
                 "refiner.saddle_point.min_abs_det",
             )?;
-            Ok(RefinerKind::SaddlePoint(out))
+            Ok(ChessRefiner::SaddlePoint(out))
         }
         other => Err(FfiError::config_error(format!(
             "refiner.kind must be a valid ct_refiner_kind_t constant, got {other}"
         ))),
     }
-}
-
-pub(crate) fn convert_chess_params(params: &ct_chess_params_t) -> FfiResult<ChessParams> {
-    // `ChessParams` (`chess_corners_core::ChessParams`) is `#[non_exhaustive]`,
-    // so we must start from `default()` and patch individual fields.
-    let mut out = ChessParams::default();
-    out.use_radius10 = flag_to_bool(params.use_radius10, "chess.params.use_radius10")?;
-    out.threshold = require_nonnegative(params.threshold, "chess.params.threshold")?;
-    out.nms_radius = params.nms_radius;
-    out.min_cluster_size = params.min_cluster_size;
-    out.refiner = convert_refiner_kind(params.refiner.kind, &params.refiner)?;
-    Ok(out)
 }
 
 /// Validate the C pyramid shape and lower it to the `(levels, min_size)` pair
@@ -176,27 +163,28 @@ fn convert_upscale_config(config: &ct_upscale_config_t) -> FfiResult<UpscaleConf
 }
 
 pub(crate) fn convert_chess_config(config: &ct_chess_config_t) -> FfiResult<DetectorConfig> {
-    let params = convert_chess_params(&config.params)?;
+    // Lower the flat C `ct_chess_params_t` directly onto the strategy-typed
+    // `DetectorConfig`. The flat shape (`use_radius10`, `threshold`,
+    // `nms_radius`, `min_cluster_size`, `refiner`) is split across the ChESS
+    // strategy, the shared `DetectionParams`, and the top-level threshold.
+    let params = &config.params;
+    let use_radius10 = flag_to_bool(params.use_radius10, "chess.params.use_radius10")?;
+    let threshold = require_nonnegative(params.threshold, "chess.params.threshold")?;
+    let nms_radius = params.nms_radius;
+    let min_cluster_size = params.min_cluster_size;
+    let refiner = convert_refiner_kind(params.refiner.kind, &params.refiner)?;
+    let ring = if use_radius10 {
+        ChessRing::Broad
+    } else {
+        ChessRing::Canonical
+    };
+
     let (pyramid_levels, pyramid_min_size) = convert_pyramid_params(&config.multiscale.pyramid)?;
     let merge_radius = require_nonnegative(
         config.multiscale.merge_radius,
         "chess.multiscale.merge_radius",
     )?;
     let upscale = convert_upscale_config(&config.upscale)?;
-
-    // Map the low-level `ChessParams` onto the strategy-typed
-    // `DetectorConfig`. The flat C shape (`use_radius10`, `nms_radius`,
-    // `min_cluster_size`, `refiner`, `threshold`) is split across the ChESS
-    // strategy, the shared `DetectionParams`, and the top-level threshold.
-    let threshold = params.threshold;
-    let ring = if params.use_radius10 {
-        ChessRing::Broad
-    } else {
-        ChessRing::Canonical
-    };
-    let refiner = refiner_kind_to_chess_refiner(params.refiner);
-    let nms_radius = params.nms_radius;
-    let min_cluster_size = params.min_cluster_size;
 
     // A 1-level pyramid is a no-op; collapse it to `SingleScale` so the
     // detector skips the pyramid path entirely.
@@ -215,8 +203,7 @@ pub(crate) fn convert_chess_config(config: &ct_chess_config_t) -> FfiResult<Dete
         .with_multiscale(multiscale)
         .with_upscale(upscale)
         .with_merge_radius(merge_radius)
-        // `nms_radius` / `min_cluster_size` moved off the per-strategy config
-        // and onto the shared `DetectionParams` in chess-corners 1.0.
+        // `nms_radius` / `min_cluster_size` live on the shared `DetectionParams`.
         .with_detection(|d| {
             d.nms_radius = nms_radius;
             d.min_cluster_size = min_cluster_size;
@@ -225,22 +212,6 @@ pub(crate) fn convert_chess_config(config: &ct_chess_config_t) -> FfiResult<Dete
             c.ring = ring;
             c.refiner = refiner;
         }))
-}
-
-/// Translate a low-level [`RefinerKind`] back into the facade-level
-/// [`ChessRefiner`] enum used by [`DetectorConfig`]. ChESS callers only
-/// surface the three image-patch refiners (the Radon-peak refiner is for
-/// the Radon strategy); fall back to the default `CenterOfMass` for any
-/// future / Radon-specific variant.
-fn refiner_kind_to_chess_refiner(kind: RefinerKind) -> ChessRefiner {
-    match kind {
-        RefinerKind::CenterOfMass(cfg) => ChessRefiner::CenterOfMass(cfg),
-        RefinerKind::Forstner(cfg) => ChessRefiner::Forstner(cfg),
-        RefinerKind::SaddlePoint(cfg) => ChessRefiner::SaddlePoint(cfg),
-        // RefinerKind is `#[non_exhaustive]`; Radon-only / future variants
-        // fall through to the library default for the ChESS strategy.
-        _ => ChessRefiner::default(),
-    }
 }
 
 // ─── Optional wrappers ──────────────────────────────────────────────────────

--- a/crates/calib-targets/tests/rust_api_smoke.rs
+++ b/crates/calib-targets/tests/rust_api_smoke.rs
@@ -29,7 +29,7 @@ edition = "2021"
 # our stated MSRV would get. Without it the resolver picks the newest cached
 # version of every transitive dep, and a dep that raises its own rust-version
 # breaks this test for reasons unrelated to our API.
-rust-version = "1.88"
+rust-version = "1.91"
 resolver = "3"
 
 [dependencies]


### PR DESCRIPTION
## Summary

- **Migrate to `chess-corners` 1.2** and drop the direct `chess-corners-core` dependency workspace-wide.
- ChArUco local corner re-detection (`corner_refit` / `grid_smoothness` / `pipeline`) now drives the facade's new single-scale ROI entry point (`Detector::detect_u8_roi`) instead of hand-composing core primitives (`chess_response_u8_patch` + `ImageView::with_origin` + `Refiner` + `detect_corners_from_response_with_refiner`). The re-detect engine is built once per detect call and reused across components and both validation stages; orientation fitting is skipped since only positions are consumed.
- FFI chess-config lowering converts the flat C params directly onto the strategy-typed `DetectorConfig`, dropping the intermediate `RefinerKind` round-trip. **C ABI unchanged** (generated-header check clean).
- Isolated downstream smoke tests drop their temporary `[patch.crates-io]` blocks (chess-corners 1.2.0 is published) and align the generated crates' `rust-version` with the actual 1.91 MSRV (stale 1.88 predated #82).
- Version bump 0.11.1 → 0.11.2 + changelog. No public API or behaviour changes.

## Test plan

- Full release-gate sequence green: `fmt`, `clippy -D warnings`, `test --workspace` (471), `test --workspace --all-features` (475), `cargo doc` (zero warnings), `cargo deny check`, FFI header `--check`, Python typing stubs `--check` + pytest (58), `scripts/build-wasm.sh`, `mdbook build book`.
- Regression suites pass unchanged against the published chess-corners 1.2.0 (crates.io, not the path patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C9HUquMworJPdzP5UoiLss